### PR TITLE
Add `fix` for `use-ember-get-and-set`

### DIFF
--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('../utils/utils');
+const { isIdentifier } = require('../utils/utils');
 
 //------------------------------------------------------------------------------
 // General - use get and set
@@ -18,13 +18,32 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
     const message = 'Use get/set';
 
-    const report = function (node) {
-      context.report(node, message);
-    };
+    function report(node) {
+      context.report({
+        node: node.callee.property,
+        message,
+        fix(fixer) {
+          // this.set('foo', 3);
+          // └┬─┘ └┬┘ └───┬──┘
+          //  │    │      └─────── args
+          //  │    └────────────── method
+          //  └─────────────────── subject
 
-    const avoidedProperties = [
+          const subject = sourceCode.getText(node.callee.object);
+          const method = sourceCode.getText(node.callee.property);
+          const args = node.arguments.map(a => sourceCode.getText(a)).join(', ');
+
+          const fixedSource = `${method}(${subject}, ${args})`;
+
+          return fixer.replaceText(node, fixedSource);
+        }
+      });
+    }
+
+    const avoidedMethods = [
       'get',
       'set',
       'getProperties',
@@ -33,14 +52,13 @@ module.exports = {
     ];
 
     return {
-      MemberExpression(node) {
-        if (
-          utils.isIdentifier(node.property) &&
-          avoidedProperties.indexOf(node.property.name) > -1
-        ) {
-          report(node.property);
+      CallExpression(node) {
+        const method = node.callee.property;
+
+        if (isIdentifier(method) && avoidedMethods.indexOf(method.name) > -1) {
+          report(node);
         }
-      },
+      }
     };
   }
 };

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -8,7 +8,13 @@ const utils = require('../utils/utils');
 
 module.exports = {
   meta: {
-    docs: {}
+    docs: {
+      description: 'Use Ember get/set',
+      category: 'General',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: []
   },
 
   create(context) {

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const { isIdentifier } = require('../utils/utils');
+const utils = require('../utils/utils');
+
+const isIdentifier = utils.isIdentifier;
 
 //------------------------------------------------------------------------------
 // General - use get and set

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -26,84 +26,98 @@ eslintTester.run('use-ember-get-and-set', rule, {
   invalid: [
     {
       code: 'this.get("test")',
+      output: 'get(this, "test")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'controller.get("test")',
+      output: 'get(controller, "test")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'model.get("test")',
+      output: 'get(model, "test")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'this.getWithDefault("test", "default")',
+      output: 'getWithDefault(this, "test", "default")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'controller.getWithDefault("test", "default")',
+      output: 'getWithDefault(controller, "test", "default")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'this.set("test", "value")',
+      output: 'set(this, "test", "value")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'controller.set("test", "value")',
+      output: 'set(controller, "test", "value")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'model.set("test", "value")',
+      output: 'set(model, "test", "value")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'this.getProperties("test", "test2")',
+      output: 'getProperties(this, "test", "test2")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'controller.getProperties("test", "test2")',
+      output: 'getProperties(controller, "test", "test2")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'model.getProperties("test", "test2")',
+      output: 'getProperties(model, "test", "test2")',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'this.setProperties({test: "value"})',
+      output: 'setProperties(this, {test: "value"})',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'controller.setProperties({test: "value"})',
+      output: 'setProperties(controller, {test: "value"})',
       errors: [{
         message: 'Use get/set',
       }],
     },
     {
       code: 'model.setProperties({test: "value"})',
+      output: 'setProperties(model, {test: "value"})',
       errors: [{
         message: 'Use get/set',
       }],

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -27,100 +27,77 @@ eslintTester.run('use-ember-get-and-set', rule, {
     {
       code: 'this.get("test")',
       output: 'get(this, "test")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'controller.get("test")',
       output: 'get(controller, "test")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'model.get("test")',
       output: 'get(model, "test")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
+    },
+    {
+      code: 'this.foo.get("test")',
+      output: 'get(this.foo, "test")',
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'this.getWithDefault("test", "default")',
       output: 'getWithDefault(this, "test", "default")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'controller.getWithDefault("test", "default")',
       output: 'getWithDefault(controller, "test", "default")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'this.set("test", "value")',
       output: 'set(this, "test", "value")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'controller.set("test", "value")',
       output: 'set(controller, "test", "value")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'model.set("test", "value")',
       output: 'set(model, "test", "value")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'this.getProperties("test", "test2")',
       output: 'getProperties(this, "test", "test2")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'controller.getProperties("test", "test2")',
       output: 'getProperties(controller, "test", "test2")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'model.getProperties("test", "test2")',
       output: 'getProperties(model, "test", "test2")',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'this.setProperties({test: "value"})',
       output: 'setProperties(this, {test: "value"})',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'controller.setProperties({test: "value"})',
       output: 'setProperties(controller, {test: "value"})',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'model.setProperties({test: "value"})',
       output: 'setProperties(model, {test: "value"})',
-      errors: [{
-        message: 'Use get/set',
-      }],
+      errors: [{ message: 'Use get/set' }],
     },
   ],
 });


### PR DESCRIPTION
(Based on #54)

This PR:
 * Adds meta information to `use-ember-get-and-set`
 * Adds a `fix` method for `use-ember-get-and-set`
 * Updates the `use-ember-get-and-set` tests to assert `fix` behaves as expected
 * Adds an additional more complex test case to and cleans up the `user-ember-get-and-set` tests to match conventions.

---

This adds a `fix` method to automatically fix the `use-ember-get-and-set` linting error. Effectively, it breaks up an error case into three parts:

```javascript
  this.set('foo', 3);
//└┬─┘ └┬┘ └───┬──┘
// │    │      └─────── args
// │    └────────────── method
// └─────────────────── subject
```

It does this in AST (rather than text) to try and automatically handle more complex cases. It then rewrites that node as source by moving `subject` into the method arguments:
```javascript
set(this, 'foo', 3);
```

Of note, this linting error is now caught via `CallExpression` rather than `MemberExpression` (though the error output should be the same) so we can get access to both the callee and the arguments.

---

**Concern:** ESLint [advises as best practice](http://eslint.org/docs/developer-guide/working-with-rules#applying-fixes) that a `fix` method "[a]void any fixes that could change the runtime behavior of code and cause it to stop working." This is technically not adhered to with this `fix` method as we are moving from calling `.get*`/`.set*` methods on objects to using `get*`/`set*`, which are assumed to already be defined.

It is somewhat common practice to destructure these off `Ember` at the top of your file and in the future (after module unification) these will be directly imported. In the cases where this is not done, this will break the code as `get*`/`set*` will be `undefined`. We could consider trying to detect if these are defined and/or adding the import/destructuring ourselves, but I feel that'd be out of the scope of this rule.