### PR TITLE
Detecting computed properties with MemberExpressions

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -129,8 +129,11 @@ function isObserverProp(node) {
 }
 
 function isComputedProp(node) {
+  const allowedMemberExpNames = ['volatile', 'readOnly', 'property', 'meta'];
   if (utils.isMemberExpression(node.callee) && utils.isCallExpression(node.callee.object)) {
-    return isModule(node.callee.object, 'computed') && utils.isIdentifier(node.callee.property);
+    return isModule(node.callee.object, 'computed') &&
+      utils.isIdentifier(node.callee.property) &&
+      allowedMemberExpNames.includes(node.callee.property.name);
   }
   return isModule(node, 'computed');
 }

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -129,6 +129,9 @@ function isObserverProp(node) {
 }
 
 function isComputedProp(node) {
+  if (utils.isMemberExpression(node.callee) && utils.isCallExpression(node.callee.object)) {
+    return isModule(node.callee.object, 'computed') && utils.isIdentifier(node.callee.property);
+  }
   return isModule(node, 'computed');
 }
 

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -133,7 +133,7 @@ function isComputedProp(node) {
   if (utils.isMemberExpression(node.callee) && utils.isCallExpression(node.callee.object)) {
     return isModule(node.callee.object, 'computed') &&
       utils.isIdentifier(node.callee.property) &&
-      allowedMemberExpNames.includes(node.callee.property.name);
+      allowedMemberExpNames.indexOf(node.callee.property.name) > -1;
   }
   return isModule(node, 'computed');
 }

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -633,5 +633,17 @@ eslintTester.run('order-in-components', rule, {
         line: 5,
       }],
     },
+    {
+      code: `export default Component.extend({
+        foo: computed(function() {
+        }).volatile(),
+        name: "Jon Snow",
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "name" property should be above the "foo" multi-line function on line 2',
+        line: 4,
+      }],
+    },
   ],
 });

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -330,6 +330,15 @@ eslintTester.run('order-in-components', rule, {
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: `export default Component.extend({
+        foo: computed(function() {
+        }).volatile(),
+        bar: computed(function() {
+        })
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    }
   ],
   invalid: [
     {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -229,6 +229,14 @@ describe('isComputedProp', () => {
     node = parse('Ember.computed()');
     expect(emberUtils.isComputedProp(node)).toBeTruthy();
   });
+
+  it('should detect computed props with MemberExpressions', () => {
+    node = parse('computed().volatile()');
+    expect(emberUtils.isComputedProp(node)).toBeTruthy();
+
+    node = parse('Ember.computed().volatile()');
+    expect(emberUtils.isComputedProp(node)).toBeTruthy();
+  });
 });
 
 describe('isObserverProp', () => {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -230,12 +230,25 @@ describe('isComputedProp', () => {
     expect(emberUtils.isComputedProp(node)).toBeTruthy();
   });
 
-  it('should detect computed props with MemberExpressions', () => {
-    node = parse('computed().volatile()');
-    expect(emberUtils.isComputedProp(node)).toBeTruthy();
+  it(
+    'should detect whitelisted computed props with MemberExpressions',
+    () => {
+      ['volatile', 'meta', 'readOnly', 'property'].forEach((prop) => {
+        node = parse(`computed().${prop}()`);
+        expect(emberUtils.isComputedProp(node)).toBeTruthy();
 
-    node = parse('Ember.computed().volatile()');
-    expect(emberUtils.isComputedProp(node)).toBeTruthy();
+        node = parse(`Ember.computed().${prop}()`);
+        expect(emberUtils.isComputedProp(node)).toBeTruthy();
+      })
+    }
+  );
+
+  it('shouldn\'t allow other MemberExpressions', () => {
+    node = parse(`computed().foo()`);
+    expect(emberUtils.isComputedProp(node)).not.toBeTruthy();
+
+    node = parse(`Ember.computed().foo()`);
+    expect(emberUtils.isComputedProp(node)).not.toBeTruthy();
   });
 });
 

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -239,15 +239,15 @@ describe('isComputedProp', () => {
 
         node = parse(`Ember.computed().${prop}()`);
         expect(emberUtils.isComputedProp(node)).toBeTruthy();
-      })
+      });
     }
   );
 
   it('shouldn\'t allow other MemberExpressions', () => {
-    node = parse(`computed().foo()`);
+    node = parse('computed().foo()');
     expect(emberUtils.isComputedProp(node)).not.toBeTruthy();
 
-    node = parse(`Ember.computed().foo()`);
+    node = parse('Ember.computed().foo()');
     expect(emberUtils.isComputedProp(node)).not.toBeTruthy();
   });
 });


### PR DESCRIPTION
Resolves #83 
## Problem:
Linter doesn't recognize following code as a computed property:
```js
foo: computed(function() {}).volatile()
```

## Solution:
The computed property is determined based on whether the node is a `CallExpression` with `Identifier` of type `computed` as callee. However in the above case, we have a `MemberExpression`. The solution involves checking for `MemberExpression` with computed `CallExpression`.