### PR TITLE
Adding new rule: no-attrs-snapshot

### DIFF
--- a/docs/rules/no-attrs-snapshot.md
+++ b/docs/rules/no-attrs-snapshot.md
@@ -1,11 +1,26 @@
-## Don't use params in `didReceiveAttrs` or `didUpdateAttrs`
+# Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs` (no-attrs-snapshot)
 
-## Rule name: `no-attrs-snapshot`
+Do not use the arguments (attrs) that are passed in `didReceiveAttrs` and `didUpdateAttrs`. Using the arguments (attrs) in these hooks can result in performance degredation in your application.
 
-In 2.0.0, [`didReceiveAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_formatting-component-attributes-with-code-didreceiveattrs-code) and [`didUpdateAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code) hooks were introduced. These hooks are called whenever the arguments to a component referentially change. These hooks receive params, however one should not use them as they force those objects to reify which can be very costly when you have a lot of components on the page. These arguments are also purposely undocumented. If for some reason you need to do a comparison of arguments we suggest that you simply keep a cache on the component.
+```js
 
-- cache the value at the component level
-```javascript
+// Bad
+export default Ember.Component({
+  init() {
+    this._super(...arguments);
+    this.updated = false;
+  },
+  didReceiveAttrs(attrs) {
+    let { newAttrs, oldAttrs } = attrs;
+    if ((newAttrs && oldAttrs) && newAttrs.value !== oldAttrs.value) {
+      this.set('updated', true);
+    } else {
+      this.set('updated', false);
+    }
+  }
+});
+
+// Good
 export default Ember.Component({
   init() {
     this._super(...arguments);
@@ -21,4 +36,63 @@ export default Ember.Component({
     }
   }
 });
+
 ```
+
+## Rule Details
+
+In 2.0.0, `didReceiveAttrs` and `didUpdateAttrs` hooks were introduced. These hooks are called whenever the references of arguments to a component change. These hooks receive arguments, however one should not use them as they force those objects to reify, which can be very costly when you have a lot of components on the page. These arguments are also purposely undocumented. 
+
+If for some reason you need to do a comparison of arguments we suggest that you simply keep a cache on the component.
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+export default Ember.Component({
+  init() {
+    this._super(...arguments);
+    this.updated = false;
+  },
+  didReceiveAttrs(attrs) {
+    let { newAttrs, oldAttrs } = attrs;
+    if ((newAttrs && oldAttrs) && newAttrs.value !== oldAttrs.value) {
+      this.set('updated', true);
+    } else {
+      this.set('updated', false);
+    }
+  }
+});
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+export default Ember.Component({
+  init() {
+    this._super(...arguments);
+    this._valueCache = this.value;
+    this.updated = false;
+  },
+  didReceiveAttrs() {
+    if (this._valueCache !== this.value) {
+      this._valueCache = this.value;
+      this.set('updated', true);
+    } else {
+      this.set('updated', false);
+    }
+  }
+});
+
+```
+
+## When Not To Use It
+
+You can turn this rule of if you aren't worried about the negative performance impacts of using params in these hooks.
+
+## Further Reading
+
+- [`didReceiveAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_formatting-component-attributes-with-code-didreceiveattrs-code)
+- [`didUpdateAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code)

--- a/docs/rules/no-attrs-snapshot.md
+++ b/docs/rules/no-attrs-snapshot.md
@@ -1,0 +1,24 @@
+## Don't use params in `didReceiveAttrs` or `didUpdateAttrs`
+
+## Rule name: `no-attrs-snapshot`
+
+In 2.0.0, [`didReceiveAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_formatting-component-attributes-with-code-didreceiveattrs-code) and [`didUpdateAttrs`](https://guides.emberjs.com/v2.9.0/components/the-component-lifecycle/#toc_resetting-presentation-state-on-attribute-change-with-code-didupdateattrs-code) hooks were introduced. These hooks are called whenever the arguments to a component referentially change. These hooks receive params, however one should not use them as they force those objects to reify which can be very costly when you have a lot of components on the page. These arguments are also purposely undocumented. If for some reason you need to do a comparison of arguments we suggest that you simply keep a cache on the component.
+
+- cache the value at the component level
+```javascript
+export default Ember.Component({
+  init() {
+    this._super(...arguments);
+    this._valueCache = this.value;
+    this.updated = false;
+  },
+  didReceiveAttrs() {
+    if (this._valueCache !== this.value) {
+      this._valueCache = this.value;
+      this.set('updated', true);
+    } else {
+      this.set('updated', false);
+    }
+  }
+});
+```

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -17,15 +17,15 @@ module.exports = {
       recommended: true
     },
     fixable: null, // or "code" or "whitespace"
-    message: message,
+    message
   },
   create(context) {
     const hasAttrsSnapShot = function (node) {
-      let methodName = utils.getPropertyValue(node, 'parent.key.name');
-      let hasParams = node.params.length > 0;
+      const methodName = utils.getPropertyValue(node, 'parent.key.name');
+      const hasParams = node.params.length > 0;
 
       return (methodName === 'didReceiveAttrs' || methodName === 'didUpdateAttrs') && hasParams;
-    }
+    };
 
     const report = function (node) {
       context.report(node, message);

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const utils = require('../utils/utils');
+
+//------------------------------------------------------------------------------
+// General rule -  Disallow use of attrs snapshot in `didReceiveAttrs`
+// and `didUpdateAttrs`.
+//------------------------------------------------------------------------------
+
+const message = 'Do not use the attrs snapshot that is passed in `didReceiveAttrs` and `didUpdateAttrs`. Please see the following guide for more information: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-attrs-snapshot.md';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs`',
+      category: 'Components',
+      recommended: true
+    },
+    fixable: null, // or "code" or "whitespace"
+    message: message,
+  },
+  create(context) {
+    const hasAttrsSnapShot = function (node) {
+      let methodName = utils.getPropertyValue(node, 'parent.key.name');
+      let hasParams = node.params.length > 0;
+
+      return (methodName === 'didReceiveAttrs' || methodName === 'didUpdateAttrs') && hasParams;
+    }
+
+    const report = function (node) {
+      context.report(node, message);
+    };
+
+    return {
+      FunctionExpression(node) {
+        if (hasAttrsSnapShot(node)) {
+          report(node);
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -7,7 +7,7 @@ const utils = require('../utils/utils');
 // and `didUpdateAttrs`.
 //------------------------------------------------------------------------------
 
-const message = 'Do not use the attrs snapshot that is passed in `didReceiveAttrs` and `didUpdateAttrs`. Please see the following guide for more information: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-attrs-snapshot.md';
+const message = 'Do not use the attrs snapshot that is passed in `didReceiveAttrs` and `didUpdateAttrs`. Please see the following guide for more information: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-attrs-snapshot.md';
 
 module.exports = {
   meta: {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -21,6 +21,7 @@ module.exports = {
   parseCallee,
   parseArgs,
   findUnorderedProperty,
+  getPropertyValue,
 };
 
 /**
@@ -269,4 +270,38 @@ function findUnorderedProperty(arr) {
   }
 
   return null;
+}
+
+/**
+ * Gets a property's value either by property path.
+ *
+ * @example
+ * getPropertyValue('name');
+ * getPropertyValue('parent.key.name');
+ *
+ * @param {Object} node
+ * @param {String} path
+ * @returns
+ */
+function getPropertyValue(node, path) {
+  let parts;
+
+  if (typeof path === 'string') {
+    parts = path.split('.');
+  } else {
+    parts = path;
+  }
+
+  if (parts.length === 1) {
+    return node[path];
+  }
+
+  let property = node[parts[0]];
+
+  if (property && parts.length > 1) {
+    parts.shift();
+    return getPropertyValue(property, parts);
+  }
+
+  return property;
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -284,13 +284,7 @@ function findUnorderedProperty(arr) {
  * @returns
  */
 function getPropertyValue(node, path) {
-  let parts;
-
-  if (typeof path === 'string') {
-    parts = path.split('.');
-  } else {
-    parts = path;
-  }
+  let parts = typeof path === 'string' ? path.split('.') : path;
 
   if (parts.length === 1) {
     return node[path];

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -296,7 +296,7 @@ function getPropertyValue(node, path) {
     return node[path];
   }
 
-  let property = node[parts[0]];
+  const property = node[parts[0]];
 
   if (property && parts.length > 1) {
     parts.shift();

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -284,7 +284,7 @@ function findUnorderedProperty(arr) {
  * @returns
  */
 function getPropertyValue(node, path) {
-  let parts = typeof path === 'string' ? path.split('.') : path;
+  const parts = typeof path === 'string' ? path.split('.') : path;
 
   if (parts.length === 1) {
     return node[path];

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -1,0 +1,92 @@
+const rule = require('../../../lib/rules/no-attrs-snapshot');
+const message = rule.meta.message;
+const RuleTester = require('eslint').RuleTester;
+
+const eslintTester = new RuleTester();
+
+eslintTester.run('no-attrs-snapshot', rule, {
+  valid: [
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this._super(...arguments);
+            this._valueCache = this.value;
+            this.updated = false;
+          },
+          didReceiveAttrs() {
+            if (this._valueCache !== this.value) {
+              this._valueCache = this.value;
+              this.set('updated', true);
+            } else {
+              this.set('updated', false);
+            }
+          }
+        });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this._super(...arguments);
+            this._valueCache = this.value;
+            this.updated = false;
+          },
+          didUpdateAttrs() {
+            if (this._valueCache !== this.value) {
+              this._valueCache = this.value;
+              this.set('updated', true);
+            } else {
+              this.set('updated', false);
+            }
+          }
+        });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this._super(...arguments);
+            this.updated = false;
+          },
+          didReceiveAttrs(attrs) {
+            let { newAttrs, oldAttrs } = attrs;
+            if ((newAttrs && oldAttrs) && newAttrs.value !== oldAttrs.value) {
+              this.set('updated', true);
+            } else {
+              this.set('updated', false);
+            }
+          }
+        });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: message
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this._super(...arguments);
+            this.updated = false;
+          },
+          didUpdateAttrs(attrs) {
+            let { newAttrs, oldAttrs } = attrs;
+            if ((newAttrs && oldAttrs) && newAttrs.value !== oldAttrs.value) {
+              this.set('updated', true);
+            } else {
+              this.set('updated', false);
+            }
+          }
+        });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: message
+      }]
+    }
+  ]
+});

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -1,7 +1,7 @@
 const rule = require('../../../lib/rules/no-attrs-snapshot');
-const message = rule.meta.message;
 const RuleTester = require('eslint').RuleTester;
 
+const message = rule.meta.message;
 const eslintTester = new RuleTester();
 
 eslintTester.run('no-attrs-snapshot', rule, {
@@ -64,7 +64,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: message
+        message
       }]
     },
     {
@@ -85,7 +85,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: message
+        message
       }]
     }
   ]

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -188,6 +188,16 @@ describe('parseArgs', () => {
 });
 
 describe('getPropertyValue', () => {
+  const simpleObject = {
+    foo: true,
+    bar: {
+      baz: 1,
+      fizz: {
+        buzz: 'buzz'
+      }
+    }
+  };
+
   const node = babelEslint.parse(`
     export default Ember.Component({
       init() {
@@ -206,17 +216,32 @@ describe('getPropertyValue', () => {
     });
   `).body[0].declaration;
 
-  it('should return null when property value not found', () => {
+  it('should return null when property value not found for simpleObject', () => {
+    const value = utils.getPropertyValue(simpleObject, 'blah');
+    expect(value).toEqual(undefined);
+  });
+
+  it('should return value when using a simple property path for simpleObject', () => {
+    const value = utils.getPropertyValue(simpleObject, 'foo');
+    expect(value).toEqual(true);
+  });
+
+  it('should return value when using a full property path for simpleObject', () => {
+    const buzz = utils.getPropertyValue(simpleObject, 'bar.fizz.buzz');
+    expect(buzz).toEqual('buzz');
+  });
+
+  it('should return null when property value not found for node', () => {
     const value = utils.getPropertyValue(node, 'blah');
     expect(value).toEqual(undefined);
   });
 
-  it('should return value when using a simple property path', () => {
+  it('should return value when using a simple property path for node', () => {
     const type = utils.getPropertyValue(node, 'type');
     expect(type).toEqual('CallExpression');
   });
 
-  it('should return value when using a full property path', () => {
+  it('should return value when using a full property path for node', () => {
     const name = utils.getPropertyValue(node, 'callee.object.name');
     expect(name).toEqual('Ember');
   });

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -186,3 +186,38 @@ describe('parseArgs', () => {
     expect(parsedArgs).toEqual(['asd', 'qwe', 'zxc']);
   });
 });
+
+describe('getPropertyValue', () => {
+  const node = babelEslint.parse(`
+    export default Ember.Component({
+      init() {
+        this._super(...arguments);
+        this._valueCache = this.value;
+        this.updated = false;
+      },
+      didReceiveAttrs() {
+        if (this._valueCache !== this.value) {
+          this._valueCache = this.value;
+          this.set('updated', true);
+        } else {
+          this.set('updated', false);
+        }
+      }
+    });
+  `).body[0].declaration;
+
+  it('should return null when property value not found', () => {
+    const value = utils.getPropertyValue(node, 'blah');
+    expect(value).toEqual(undefined);``
+  });
+
+  it('should return value when using a simple property path', () => {
+    const type = utils.getPropertyValue(node, 'type');
+    expect(type).toEqual('CallExpression');
+  });
+
+  it('should return value when using a full property path', () => {
+    const name = utils.getPropertyValue(node, 'callee.object.name');
+    expect(name).toEqual('Ember');
+  });
+});

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -208,7 +208,7 @@ describe('getPropertyValue', () => {
 
   it('should return null when property value not found', () => {
     const value = utils.getPropertyValue(node, 'blah');
-    expect(value).toEqual(undefined);``
+    expect(value).toEqual(undefined);
   });
 
   it('should return value when using a simple property path', () => {


### PR DESCRIPTION
@michalsnik 

Addresses #51 

This adds the first rule from [eslint-plugin-ember-best-practices](https://github.com/ember-best-practices/eslint-plugin-ember-best-practices). The structure has been adapted to adhere to the existing structure of this repo's rules, with one exception:

The message has been added to the `meta` of the rule. This allows the message to be reused during `invalid` test verifications. 