### PR TITLE
New rule: no-global-jquery

### DIFF
--- a/docs/rules/no-global-jquery.md
+++ b/docs/rules/no-global-jquery.md
@@ -1,0 +1,36 @@
+# No global jQuery (no-global-jquery)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/no-global-jquery.md
+++ b/docs/rules/no-global-jquery.md
@@ -1,36 +1,32 @@
 # No global jQuery (no-global-jquery)
-
-Please describe the origin of the rule here.
-
+Do not use global `$` or `jQuery`.
 
 ## Rule Details
 
-This rule aims to...
+In general, we want application code to reference the version of jQuery that's been directly pinned to the version of Ember used. This helps avoid version conflicts, and ensures that code inside modules isn't reliant on global variables.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-
-// fill me in
-
+export default Component.extend({
+  init() {
+    $('.foo').addClass('bar'); //global usage
+  }
+});
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+import Ember from 'ember';
 
-// fill me in
+const { $ } = Ember;
+export default Component.extend({
+  init() {
+    Ember.$('.foo').addClass('bar') //usage from Ember object
+    // or even better
+    $('.foo').addClass('bar'); // deconstruction from Ember object
+  }
+});
 
 ```
-
-### Options
-
-If there are any options, describe them here. Otherwise, delete this section.
-
-## When Not To Use It
-
-Give a short description of when it would be appropriate to turn off this rule.
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const ember = require('../utils/ember');
+const utils = require('../utils/utils');
+
+const ALIASES = ['$', 'jQuery'];
+const MESSAGE = 'Do not use global `$` or `jQuery`';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'No global jQuery',
+      category: '',
+      recommended: false
+    },
+    fixable: null,  // or "code" or "whitespace"
+    message: MESSAGE,
+  },
+
+  create(context) {
+    let emberImportAliasName;
+    let destructuredAssignment;
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      ImportDeclaration(node) {
+        emberImportAliasName = ember.getEmberImportAliasName(node);
+      },
+
+      VariableDeclarator(node) {
+        if (emberImportAliasName) {
+          destructuredAssignment = utils.collectObjectPatternBindings(node, {
+            [emberImportAliasName]: ['$']
+          }).pop();
+        }
+      },
+
+      CallExpression(node) {
+        if (utils.isGlobalCallExpression(node, destructuredAssignment, ALIASES)) {
+          context.report(node, MESSAGE);
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -13,9 +13,9 @@ const MESSAGE = 'Do not use global `$` or `jQuery`';
 module.exports = {
   meta: {
     docs: {
-      description: 'No global jQuery',
-      category: '',
-      recommended: false
+      description: 'Prevents usage of global jQuery object',
+      category: 'General',
+      recommended: true,
     },
     fixable: null,  // or "code" or "whitespace"
     message: MESSAGE,

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -32,9 +32,14 @@ module.exports = {
 
       VariableDeclarator(node) {
         if (emberImportAliasName) {
-          destructuredAssignment = utils.collectObjectPatternBindings(node, {
-            [emberImportAliasName]: ['$']
-          }).pop();
+          if (utils.isMemberExpression(node.init)) {
+            // assignment of type const $ = Ember.$;
+            destructuredAssignment = node.id.name;
+          } else {
+            destructuredAssignment = utils.collectObjectPatternBindings(node, {
+              [emberImportAliasName]: ['$']
+            }).pop();
+          }
         }
       },
 

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -25,14 +25,6 @@ module.exports = {
     let emberImportAliasName;
     let destructuredAssignment;
 
-    //----------------------------------------------------------------------
-    // Helpers
-    //----------------------------------------------------------------------
-
-    //----------------------------------------------------------------------
-    // Public
-    //----------------------------------------------------------------------
-
     return {
       ImportDeclaration(node) {
         emberImportAliasName = ember.getEmberImportAliasName(node);

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -17,6 +17,7 @@ module.exports = {
   isFunctionExpression,
 
   getModuleProperties,
+  getEmberImportAliasName,
 
   isInjectedServiceProp,
   isObserverProp,
@@ -311,6 +312,18 @@ function isControllerDefaultProp(property) {
 function getModuleProperties(module) {
   const firstObjectExpressionNode = utils.findNodes(module.arguments, 'ObjectExpression')[0];
   return firstObjectExpressionNode ? firstObjectExpressionNode.properties : [];
+}
+
+/**
+ * Get alias name of default ember import.
+ *
+ * @param  {ImportDeclaration} importDeclaration node to parse
+ * @return {String}            import name
+ */
+function getEmberImportAliasName(importDeclaration) {
+  if (!importDeclaration.source) return null;
+  if (importDeclaration.source.raw !== "'ember'") return null;
+  return importDeclaration.specifiers[0].local.name;
 }
 
 function isSingleLineFn(property) {

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -322,7 +322,7 @@ function getModuleProperties(module) {
  */
 function getEmberImportAliasName(importDeclaration) {
   if (!importDeclaration.source) return null;
-  if (importDeclaration.source.raw !== "'ember'") return null;
+  if (importDeclaration.source.value !== 'ember') return null;
   return importDeclaration.specifiers[0].local.name;
 }
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -216,9 +216,9 @@ function isTaggedTemplateExpression(node) {
  */
 function isGlobalCallExpression(node, desctructuredName, aliases) {
   const isDestructured = node && node.callee && node.callee.name === desctructuredName;
-  const isGlobalJquery = node.callee && aliases.indexOf(node.callee.name) > -1;
+  const isGlobalCall = node.callee && aliases.indexOf(node.callee.name) > -1;
 
-  return !isDestructured && isGlobalJquery;
+  return !isDestructured && isGlobalCall;
 }
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -340,6 +340,6 @@ function collectObjectPatternBindings(node, initialObjToBinding) {
 
   const binding = identifiers[bindingIndex];
   return node.id.properties
-    .filter(props => initialObjToBinding[binding].includes(props.key.name))
+    .filter(props => initialObjToBinding[binding].indexOf(props.key.name) > -1)
     .map(props => props.value.name);
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -17,11 +17,13 @@ module.exports = {
   isThisExpression,
   isConditionalExpression,
   isTaggedTemplateExpression,
+  isGlobalCallExpression,
   getSize,
   parseCallee,
   parseArgs,
   findUnorderedProperty,
   getPropertyValue,
+  collectObjectPatternBindings,
 };
 
 /**
@@ -201,6 +203,25 @@ function isTaggedTemplateExpression(node) {
 }
 
 /**
+ * Check if given call is a global call
+ *
+ * This function checks whether given CallExpression node contains global
+ * function call (name is provided in the aliases array). It also gives option to check against
+ * already destructrued name and checking aliases.
+ *
+ * @param  {CallExpression} node The node to check.
+ * @param  {String}         destructuredName The desctructured name.
+ * @param  {Array}          aliases array of aliases of the global function.
+ * @return {Boolean}        Whether function is a global call
+ */
+function isGlobalCallExpression(node, desctructuredName, aliases) {
+  const isDestructured = node && node.callee && node.callee.name === desctructuredName;
+  const isGlobalJquery = node.callee && aliases.indexOf(node.callee.name) > -1;
+
+  return !isDestructured && isGlobalJquery;
+}
+
+/**
  * Get size of expression in lines
  *
  * @param  {Object} node The node to check.
@@ -298,4 +319,27 @@ function getPropertyValue(node, path) {
   }
 
   return property;
+}
+
+/**
+ * Find deconstructed bindings based on the initialObjToBinding hash.
+ *
+ * Extracts the names of destructured properties, even if they are aliased.
+ * `initialObjToBinding` should should have variable names as keys and bindings array as values.
+ * Given `const { $: foo } = Ember` it will return `['foo']`.
+ *
+ * @param  {VariableDeclarator} node node to parse
+ * @param  {Object}             initialObjToBinding relevant bindings
+ * @return {Array}              list of object pattern bindings
+ */
+function collectObjectPatternBindings(node, initialObjToBinding) {
+  const identifiers = Object.keys(initialObjToBinding);
+  const objBindingName = node.init.name;
+  const bindingIndex = identifiers.indexOf(objBindingName);
+  if (bindingIndex === -1) return [];
+
+  const binding = identifiers[bindingIndex];
+  return node.id.properties
+    .filter(props => initialObjToBinding[binding].includes(props.key.name))
+    .map(props => props.value.name);
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "jest-environment-node-debug": "^2.0.0"
   },
   "dependencies": {
     "ember-rfc176-data": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "jest": "^20.0.4",
-    "jest-environment-node-debug": "^2.0.0"
+    "jest": "^20.0.4"
   },
   "dependencies": {
     "ember-rfc176-data": "^0.2.2",

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -73,9 +73,6 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
     },
     {
       code: `
@@ -91,9 +88,6 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
     },
     {
       code: `
@@ -107,9 +101,6 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
     },
     {
       code: `
@@ -125,9 +116,6 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
-      errors: [{
-        message: MESSAGE
-      }]
     }
   ],
 

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -1,0 +1,188 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-global-jquery');
+const RuleTester = require('eslint').RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+};
+const MESSAGE = rule.meta.message;
+
+ruleTester.run('no-global-jquery', rule, {
+  valid: [
+    {
+      code: `
+        export default Ember.Component({
+          valid1() {
+            this.v1 = Ember.$('.v1');
+          },
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Ember.Component({
+          valid2() {
+            this.v2 = this.$();
+          },
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            valid3() {
+              this.v3 = Ember.$('v3');
+            }
+          }
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            valid4() {
+              this.v4 = this.$('v4');
+            }
+          }
+        });`,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $ } = Ember;
+
+        export default Ember.Component({
+          init() {
+            this.el = $('.test');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $ } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            valid() {
+              this.inv1 = $('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $: foo } = Ember;
+
+        export default Ember.Component({
+          init() {
+            this.el = foo('.test');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $: foo } = Ember;
+
+        export default Ember.Component({
+          actions: {
+            valid() {
+              this.inv1 = foo('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.el = $('.test');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            invalid1() {
+              this.inv1 = $('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          init() {
+            this.el = jQuery('.test');
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        export default Ember.Component({
+          actions: {
+            invalid1() {
+              this.inv1 = jQuery('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    }
+  ]
+});

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -116,7 +116,37 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
-    }
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const $ = Ember.$;
+
+        export default Ember.Component({
+          actions: {
+            valid() {
+              this.valid = $('.valid');
+            }
+          }
+        });`,
+      parserOptions,
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const foo = Ember.$;
+
+        export default Ember.Component({
+          actions: {
+            valid() {
+              this.valid = foo('.valid');
+            }
+          }
+        });`,
+      parserOptions,
+    },
   ],
 
   invalid: [
@@ -160,6 +190,42 @@ ruleTester.run('no-global-jquery', rule, {
     },
     {
       code: `
+        export default Ember.Component({
+          actions: {
+            invalid1() {
+              this.inv1 = jQuery('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const foo = Ember.$;
+
+        export default Ember.Component({
+          actions: {
+            invalid1() {
+              this.inv1 = $('.invalid1');
+            }
+          }
+        });`,
+      parserOptions,
+      errors: [{
+        message: MESSAGE
+      }]
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const foo = Ember.$;
+
         export default Ember.Component({
           actions: {
             invalid1() {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -439,3 +439,10 @@ describe('isRelation', () => {
     expect(emberUtils.isRoute(node)).toBeTruthy();
   });
 });
+
+describe('getEmberImportAliasName', () => {
+  it('should get the proper name of default import', () => {
+    const node = babelEslint.parse("import foo from 'ember'").body[0];
+    expect(emberUtils.getEmberImportAliasName(node)).toEqual('foo');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,6 +1471,10 @@ jest-environment-jsdom@^20.0.3:
     jest-util "^20.0.3"
     jsdom "^9.12.0"
 
+jest-environment-node-debug@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node-debug/-/jest-environment-node-debug-2.0.0.tgz#5ef098942fec1b6af5ee4841f4f8a2ff419562f9"
+
 jest-environment-node@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.3.tgz#d488bc4612af2c246e986e8ae7671a099163d403"


### PR DESCRIPTION
Resolves #53.

## Description
This PR introduces rule `no-global-jquery` ported (with some modifications and added tests) from ember-best-practices plugin (see #53).