### PR TITLE
Add solution for service ordering when new module imports used

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -121,7 +121,7 @@ function isEmberRoute(node, filePath) {
 }
 
 function isInjectedServiceProp(node) {
-  return isPropOfType(node, 'service');
+  return isPropOfType(node, 'service') || isPropOfType(node, 'inject');
 }
 
 function isObserverProp(node) {

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -81,6 +81,22 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
+      code: `
+        import { inject } from '@ember/service';
+        export default Component.extend({
+          abc: inject(),
+          def: inject.service(),
+          ghi: service(),
+
+          role: "sloth",
+
+          levelOfHappiness: computed("attitude", "health", () => {
+          })
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
       code: `export default Component.extend({
         role: "sloth",
         abc: [],
@@ -461,6 +477,20 @@ eslintTester.run('order-in-components', rule, {
       errors: [{
         message: 'The "i18n" service injection should be above the "vehicle" single-line function on line 2',
         line: 3,
+      }],
+    },
+    {
+      code: `
+        import { inject } from '@ember/service';
+        export default Component.extend({
+          vehicle: alias("car"),
+          i18n: inject()
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "i18n" service injection should be above the "vehicle" single-line function on line 4',
+        line: 5,
       }],
     },
     {

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -30,6 +30,18 @@ eslintTester.run('order-in-controllers', rule, {
     },
     {
       code: `export default Controller.extend({
+        currentUser: inject(),
+        queryParams: [],
+        customProp: "test",
+        actions: {},
+        _customAction() {},
+        _customAction2: function() {},
+        tSomeTask: task(function* () {})
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: `export default Controller.extend({
         queryParams: [],
         customProp: "test",
         comp: computed("test", function() {}),
@@ -85,6 +97,17 @@ eslintTester.run('order-in-controllers', rule, {
       code: `export default Controller.extend({
         queryParams: [],
         currentUser: service()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
+        line: 3,
+      }],
+    },
+    {
+      code: `export default Controller.extend({
+        queryParams: [],
+        currentUser: inject()
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -35,6 +35,23 @@ eslintTester.run('order-in-routes', rule, {
     },
     {
       code: `export default Route.extend({
+        currentUser: inject(),
+        queryParams: {},
+        customProp: "test",
+        vehicle: alias("car"),
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+        model() {},
+        beforeModel() {},
+        actions: {},
+        _customAction() {},
+        _customAction2: function() {},
+        tSomeTask: task(function* () {})
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: `export default Route.extend({
         levelOfHappiness: computed("attitude", "health", () => {
         }),
         model() {},
@@ -94,6 +111,26 @@ eslintTester.run('order-in-routes', rule, {
       code: `export default Route.extend({
         queryParams: {},
         currentUser: service(),
+        customProp: "test",
+        model() {},
+        beforeModel() {},
+        vehicle: alias("car"),
+        actions: {},
+        _customAction() {}
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "currentUser" service injection should be above the inherited "queryParams" property on line 2',
+        line: 3,
+      }, {
+        message: 'The "vehicle" single-line function should be above the "model" hook on line 5',
+        line: 7,
+      }],
+    },
+    {
+      code: `export default Route.extend({
+        queryParams: {},
+        currentUser: inject(),
         customProp: "test",
         model() {},
         beforeModel() {},

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -216,6 +216,9 @@ describe('isInjectedServiceProp', () => {
 
     node = parse('Ember.service()');
     expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+
+    node = parse('inject()');
+    expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Resolves #95.

## Problem
Property order is not working properly when using new module imports.

## Solution
The current solution is pretty naive, but the work that has to be done is a pretty big change (details outlined in #110) so after discussing with @michalsnik I think it should suffice for now, until we figure out a better, generalised way to approach this.

Food for thought: maybe we shouldn't fix this now, but rather wait for the more generalised approach in #110? WDYT?