### PR TITLE
CI: Publish tags to npm automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,16 @@ cache: yarn
 script:
   - yarn run lint
   - yarn run test:coverage
+
+before_deploy:
+  - yarn global add auto-dist-tag
+  - auto-dist-tag --write
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: SsaY98/EtrpqOoVyLV7DM43OScnwT9BImfHEVOhPtgak/nVyB3SfAoxufK4dFe9up9P2BTItslc/BbRa4p+Y1GNGFv2wVFD+MbWPIvbb7/xQHSPDgJOguUGt4vL3h6kVpue14u41PO+2rJbfyGY07Uu+rZx63A2X1LDB84l2Hi8wfPmhWXljk96jBFVSSUjyhxm3mA+ysDIdb08wkke60SWXZ3PmReskSEQzzLKohaLq3Hm007kwaEMsAB27zP1QeQ1i5DYidHsBVElFejqqHM/OfFIJsL+94wBTCIWVNaVwIvJLQuw3g4P2/NZe0nfEbMi34QZaxegXFQ+MmFA5mnPuoGo32sU317hseDxJ53vTGqZd+3s/qsJB+fUyrDmYF4DSizI7wpVvvCF7PxMYjug2749ObKx55MI85PyUq+6FL5s06jNBMklNrGz2Q6w0J3oCG+/KbdUtWnv22du4PbGIJk2TY+ujH8c1KMmC6dPVQDew0+e+FhV8eZ1FF++1l1nMJo6fzKRue6hv0YvRlkIjMFDYOj3EYNg6PerFWfi2ud8Ky4GdL/hDPZzjsp5fZo1co5BZK++3THQL4k87faVkDNOLMzt/bKnTWoJiruVufPkuFc+uWAv6w4xxUhlDbm4MGECMxDECVBcXy19DwQlb3Uwzh7vpyPaLn+HG7Zc=
+  on:
+    tags: true
+    repo: ember-cli/eslint-plugin-ember


### PR DESCRIPTION
This removes the need to `npm publish` locally. Instead just use `npm version` to create a new tagged commit and `git push origin master --follow-tags` to push the new commit and tag to the `origin` repository. TravisCI will then build the tag and if the tests pass it will publish the files to to npm repository.

/cc @rwjblue @michalsnik 