### PR TITLE
named-functions-in-promises example without .bind()

### DIFF
--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -38,6 +38,13 @@ export default Component.extend({
         .then(this._notifyAboutSuccess.bind(this))
         .catch(this._notifyAboutFailure.bind(this));
     },
+    // GOOD if allowSimpleArrowFunction: true
+    updateUser(user) {
+      user.save()
+        .then(() => this._reloadUser())
+        .then(() => this._notifyAboutSuccess())
+        .catch(() => this._notifyAboutFailure());
+    },
   },
   _reloadUser(user) {
     return user.reload();


### PR DESCRIPTION
I like the `() => someFunction()` syntax much better than `someFunction.bind(this)`, but I didn't realize immediately that I could do it that way :)

I discovered https://github.com/ember-cli/eslint-plugin-ember/pull/64 and  https://github.com/ember-cli/eslint-plugin-ember/issues/63#issuecomment-302856559 ✨ 