### PR TITLE
Enforce component lifecycle hook order

### DIFF
--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -12,7 +12,17 @@ ember/order-in-components: [2, {
     'single-line-function',
     'multi-line-function',
     'observer',
-    'lifecycle-hook',
+    'init',
+    'didReceiveAttrs',
+    'willRender',
+    'didInsertElement',
+    'didRender',
+    'didUpdateAttrs',
+    'willUpdate',
+    'didUpdate',
+    'willDestroyElement',
+    'willClearRender',
+    'didDestroyElement',
     'actions',
     ['method', 'empty-method'],
   ]
@@ -27,7 +37,17 @@ order: [
   'property',
   ['single-line-function', 'multi-line-function'],
   'observer',
-  'lifecycle-hook',
+  'init',
+  'didReceiveAttrs',
+  'willRender',
+  'didInsertElement',
+  'didRender',
+  'didUpdateAttrs',
+  'willUpdate',
+  'didUpdate',
+  'willDestroyElement',
+  'willClearRender',
+  'didDestroyElement',
   'actions',
   ['method', 'empty-method'],
 ]
@@ -44,7 +64,7 @@ You should write code grouped and ordered in this way:
 3. Single line computed properties
 4. Multiline computed properties
 5. Observers
-6. Lifecycle Hooks
+6. Lifecycle Hooks (in execution order)
 7. Actions
 8. Custom / private methods
 
@@ -69,7 +89,7 @@ export default Component.extend({
   }),
 
   // 5. Observers
-  onVahicleChange: observer('vehicle', function() {
+  onVehicleChange: observer('vehicle', function() {
     // observer logic
   }),
 
@@ -80,6 +100,10 @@ export default Component.extend({
 
   didInsertElement() {
     // custom didInsertElement logic
+  },
+  
+  willDestroyElement() {
+    // custom willDestroyElement logic
   },
 
   // 7. All actions

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -12,9 +12,19 @@ const ORDER = [
   'single-line-function',
   'multi-line-function',
   'observer',
-  'lifecycle-hook',
+  'init',
+  'didReceiveAttrs',
+  'willRender',
+  'didInsertElement',
+  'didRender',
+  'didUpdateAttrs',
+  'willUpdate',
+  'didUpdate',
+  'willDestroyElement',
+  'willClearRender',
+  'didDestroyElement',
   'actions',
-  ['method', 'empty-method'],
+  ['method', 'empty-method']
 ];
 
 //------------------------------------------------------------------------------
@@ -28,12 +38,30 @@ module.exports = {
       category: 'Organizing',
       recommended: true
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null // or "code" or "whitespace"
   },
 
   create(context) {
     const options = context.options[0] || {};
-    const order = options.order ? addBackwardsPosition(options.order, 'empty-method', 'method') : ORDER;
+    let order = options.order ? addBackwardsPosition(options.order, 'empty-method', 'method') : ORDER;
+    order = order.slice(0);
+    const indexOfLifecycleHook = order.indexOf('lifecycle-hook');
+
+    if (indexOfLifecycleHook !== -1) {
+      order.splice(indexOfLifecycleHook, 1, [
+        'init',
+        'didReceiveAttrs',
+        'willRender',
+        'didInsertElement',
+        'didRender',
+        'didUpdateAttrs',
+        'willUpdate',
+        'didUpdate',
+        'willDestroyElement',
+        'willClearRender',
+        'didDestroyElement'
+      ]);
+    }
 
     const filePath = context.getFilename();
 
@@ -42,7 +70,7 @@ module.exports = {
         if (!ember.isEmberComponent(node, filePath)) return;
 
         reportUnorderedProperties(node, context, 'component', order);
-      },
+      }
     };
   }
 };

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -10,29 +10,40 @@ module.exports = {
 };
 
 const NAMES = {
-  service: 'service injection',
+  actions: 'actions hash',
+  activate: 'lifecycle hook',
+  afterModel: 'lifecycle hook',
+  attribute: 'attribute',
+  beforeModel: 'lifecycle hook',
+  deactivate: 'lifecycle hook',
+  didDestroyElement: 'lifecycle hook',
+  didInsertElement: 'lifecycle hook',
+  didReceiveAttrs: 'lifecycle hook',
+  didRender: 'lifecycle hook',
+  didUpdate: 'lifecycle hook',
+  didUpdateAttrs: 'lifecycle hook',
+  'empty-method': 'empty method',
+  init: 'lifecycle hook',
+  'lifecycle-hook': 'lifecycle hook',
+  method: 'method',
+  model: '"model" hook',
+  observer: 'observer',
   property: 'property',
   'single-line-function': 'single-line function',
   'multi-line-function': 'multi-line function',
-  observer: 'observer',
-  beforeModel: 'lifecycle hook',
-  model: '"model" hook',
-  afterModel: 'lifecycle hook',
-  serialize: 'lifecycle hook',
+  'query-params': 'property',
   redirect: 'lifecycle hook',
-  activate: 'lifecycle hook',
-  setupController: 'lifecycle hook',
+  relationship: 'relationship',
   renderTemplate: 'lifecycle hook',
   resetController: 'lifecycle hook',
-  deactivate: 'lifecycle hook',
-  'lifecycle-hook': 'lifecycle hook',
-  actions: 'actions hash',
-  method: 'method',
-  'empty-method': 'empty method',
+  serialize: 'lifecycle hook',
+  service: 'service injection',
+  setupController: 'lifecycle hook',
   unknown: 'unknown property type',
-  attribute: 'attribute',
-  relationship: 'relationship',
-  'query-params': 'property'
+  willClearRender: 'lifecycle hook',
+  willDestroyElement: 'lifecycle hook',
+  willRender: 'lifecycle hook',
+  willUpdate: 'lifecycle hook'
 };
 
 function determinePropertyType(node, parentType) {
@@ -42,7 +53,7 @@ function determinePropertyType(node, parentType) {
 
   if (parentType === 'component') {
     if (ember.isComponentLifecycleHook(node)) {
-      return 'lifecycle-hook';
+      return node.key.name;
     }
   }
 

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -14,7 +14,7 @@ eslintTester.run('order-in-components', rule, {
   valid: [
     {
       code: 'export default Component.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -27,7 +27,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -38,7 +38,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -47,7 +47,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend(TestMixin, {
@@ -56,7 +56,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend(TestMixin, TestMixin2, {
@@ -65,7 +65,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -78,7 +78,7 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: computed("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `
@@ -94,7 +94,7 @@ eslintTester.run('order-in-components', rule, {
           })
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -104,7 +104,7 @@ eslintTester.run('order-in-components', rule, {
 
         ghi: alias("def")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -119,7 +119,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -134,7 +134,7 @@ eslintTester.run('order-in-components', rule, {
         customFunction() {
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -158,7 +158,7 @@ eslintTester.run('order-in-components', rule, {
 
         customFunc() {
         }});`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -187,7 +187,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -199,7 +199,7 @@ eslintTester.run('order-in-components', rule, {
         tSomeAction: task(function* (url) {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -213,7 +213,7 @@ eslintTester.run('order-in-components', rule, {
         tSomeAction: task(function* (url) {
         }).restartable()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -228,7 +228,7 @@ eslintTester.run('order-in-components', rule, {
         _anotherPrivateFnc() {
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -241,7 +241,7 @@ eslintTester.run('order-in-components', rule, {
         typeOfDate: null,
         action: K
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -251,7 +251,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -261,7 +261,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -272,7 +272,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -292,9 +292,9 @@ eslintTester.run('order-in-components', rule, {
           'property',
           'multi-line-function',
           'single-line-function',
-          'actions',
-        ],
-      }],
+          'actions'
+        ]
+      }]
     },
     {
       code: `export default Component.extend({
@@ -314,9 +314,9 @@ eslintTester.run('order-in-components', rule, {
         order: [
           'property',
           ['single-line-function', 'multi-line-function'],
-          'actions',
-        ],
-      }],
+          'actions'
+        ]
+      }]
     },
     {
       code: `export default Component.extend({
@@ -327,7 +327,7 @@ eslintTester.run('order-in-components', rule, {
 
         ghi: alias("def")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -335,7 +335,7 @@ eslintTester.run('order-in-components', rule, {
         name: "Jon Snow",
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -344,7 +344,7 @@ eslintTester.run('order-in-components', rule, {
 
         someComputedValue: computed.reads('count'),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -353,7 +353,7 @@ eslintTester.run('order-in-components', rule, {
         bar: computed(function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       code: `export default Component.extend({
@@ -380,9 +380,9 @@ eslintTester.run('order-in-components', rule, {
           'empty-method',
           'single-line-function',
           'multi-line-function',
-          'method',
-        ],
-      }],
+          'method'
+        ]
+      }]
     }
   ],
   invalid: [
@@ -400,14 +400,14 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "role" property should be above the actions hash on line 2',
-        line: 4,
+        line: 4
       }, {
         message: 'The "vehicle" single-line function should be above the actions hash on line 2',
-        line: 6,
+        line: 6
       }, {
         message: 'The "levelOfHappiness" multi-line function should be above the actions hash on line 2',
-        line: 8,
-      }],
+        line: 8
+      }]
     },
     {
       code: `export default Component.extend({
@@ -423,8 +423,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "role" property should be above the "vehicle" single-line function on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend({
@@ -440,11 +440,11 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 5,
+        line: 5
       }, {
         message: 'The "role" property should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 7,
-      }],
+        line: 7
+      }]
     },
     {
       code: `export default Component.extend(TestMixin, {
@@ -460,11 +460,11 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 5,
+        line: 5
       }, {
         message: 'The "role" property should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 7,
-      }],
+        line: 7
+      }]
     },
     {
       code: `export default Component.extend(TestMixin, TestMixin2, {
@@ -480,11 +480,11 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 5,
+        line: 5
       }, {
         message: 'The "role" property should be above the "levelOfHappiness" multi-line function on line 2',
-        line: 7,
-      }],
+        line: 7
+      }]
     },
     {
       code: `export default Component.extend({
@@ -494,8 +494,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "i18n" service injection should be above the "abc" property on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       code: `export default Component.extend({
@@ -505,8 +505,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "i18n" service injection should be above the "vehicle" single-line function on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       code: `
@@ -519,8 +519,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "i18n" service injection should be above the "vehicle" single-line function on line 4',
-        line: 5,
-      }],
+        line: 5
+      }]
     },
     {
       code: `export default Component.extend({
@@ -531,8 +531,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "vehicle" single-line function should be above the "levelOfHappiness" observer on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend({
@@ -544,8 +544,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "aaa" multi-line function should be above the "levelOfHappiness" observer on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend({
@@ -557,8 +557,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "levelOfHappiness" observer should be above the "init" lifecycle hook on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend({
@@ -569,8 +569,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "init" lifecycle hook should be above the actions hash on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       code: `export default Component.extend({
@@ -582,8 +582,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The actions hash should be above the "customFunc" method on line 2',
-        line: 5,
-      }],
+        line: 5
+      }]
     },
     {
       code: `export default Component.extend({
@@ -594,8 +594,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The actions hash should be above the "tAction" method on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend(TestMixin, TestMixin2, {
@@ -613,11 +613,11 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 4',
-        line: 7,
+        line: 7
       }, {
         message: 'The "role" property should be above the "foo" single-line function on line 2',
-        line: 9,
-      }],
+        line: 9
+      }]
     },
     {
       code: `let foo = 'foo';
@@ -629,8 +629,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The property should be above the actions hash on line 4',
-        line: 5,
-      }],
+        line: 5
+      }]
     },
     {
       filename: 'example-app/components/some-component/component.js',
@@ -641,8 +641,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "role" property should be above the actions hash on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       filename: 'example-app/components/some-component.js',
@@ -653,8 +653,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "role" property should be above the actions hash on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       filename: 'example-app/twisted-path/some-component.js',
@@ -665,8 +665,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "role" property should be above the actions hash on line 2',
-        line: 3,
-      }],
+        line: 3
+      }]
     },
     {
       code: `export default Component.extend({
@@ -677,8 +677,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "template" property should be above the actions hash on line 3',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
     {
       code: `export default Component.extend({
@@ -690,8 +690,8 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "tabindex" property should be above the "someComputedValue" single-line function on line 3',
-        line: 5,
-      }],
+        line: 5
+      }]
     },
     {
       code: `export default Component.extend({
@@ -702,8 +702,31 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "name" property should be above the "foo" multi-line function on line 2',
-        line: 4,
-      }],
+        line: 4
+      }]
     },
-  ],
+    {
+      code: `export default Component.extend({
+        actions: {},
+        didReceiveAttrs() {},
+        willDestroyElement() {},
+        didInsertElement() {},
+        init() {},
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "didReceiveAttrs" lifecycle hook should be above the actions hash on line 2',
+        line: 3
+      }, {
+        message: 'The "willDestroyElement" lifecycle hook should be above the actions hash on line 2',
+        line: 4
+      }, {
+        message: 'The "didInsertElement" lifecycle hook should be above the actions hash on line 2',
+        line: 5
+      }, {
+        message: 'The "init" lifecycle hook should be above the actions hash on line 2',
+        line: 6
+      }]
+    }
+  ]
 });


### PR DESCRIPTION
As a followup to my previous route hook order PR (https://github.com/ember-cli/eslint-plugin-ember/pull/124) I wanted to get one started for components, and models will be next after this :smile: 

I’m enforcing that component hooks be called, more or less, in execution order. There is some weirdness to consider with certain hooks executed on both initial render and rerender, but I believe this order makes sense.