### PR TITLE
Allow camelCase in route names

### DIFF
--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -5,10 +5,12 @@ const ember = require('../utils/ember');
 // Routing - No capital letters in routes
 //------------------------------------------------------------------------------
 
+const PATTERN = /^[A-Z]{1}/;
+
 module.exports = {
   meta: {
     docs: {
-      description: 'Raise an error when there is a route with uppercased letters in router.js',
+      description: 'Raise an error if a route name begin with an uppercased letter in router.js',
       category: 'Routing',
       recommended: true,
     },
@@ -25,9 +27,8 @@ module.exports = {
         if (!ember.isRoute(node) || !node.arguments[0]) return;
 
         const routeName = node.arguments[0].value;
-        const hasAnyUppercaseLetter = Boolean(routeName.match('[A-Z]'));
 
-        if (hasAnyUppercaseLetter) {
+        if (routeName.test(PATTERN)) {
           report(node);
         }
       },

--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -28,7 +28,7 @@ module.exports = {
 
         const routeName = node.arguments[0].value;
 
-        if (routeName.test(PATTERN)) {
+        if (PATTERN.test(routeName)) {
           report(node);
         }
       },


### PR DESCRIPTION
The purpose of this rule is to avoid invalid route names. Since `myRoute` is a valid name I propose that we update the rule to only catch the invalid `MyRoute`, but not `myRoute`.

*(updated PR description 2017-10-02)*