### PR TITLE
Allow recognition of controller injection

### DIFF
--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -7,6 +7,7 @@
 ```
 ember/order-in-controllers: [2, {
   order: [
+    'controller',
     'service',
     'query-params',
     'inherited-property',
@@ -24,7 +25,7 @@ If you want some of properties to be treated equally in order you can group them
 
 ```
 order: [
-  ['service', 'query-params'],
+  ['controller', 'service', 'query-params'],
   'inherited-property',
   'property',
   ['single-line-function', 'multi-line-function']
@@ -37,54 +38,58 @@ You can find full list of properties that you can use to configure this rule [he
 
 You should write code grouped and ordered in this way:
 
-1. Services
-2. Query params
-3. Default controller's properties
-4. Custom properties
-5. Single line computed properties
-6. Multi line computed properties
-7. Observers
-8. Actions
-9. Custom / private methods
+1. Controller injections
+2. Service injections
+3. Query params
+4. Default controller's properties
+5. Custom properties
+6. Single line computed properties
+7. Multi line computed properties
+8. Observers
+9. Actions
+10. Custom / private methods
 
 
 ```javascript
-const { Controller, computed, inject: { service }, get } = Ember;
+const { Controller, computed, inject: { controller, service }, get } = Ember;
 
 export default Controller.extend({
-  // 1. Services
+  // 1. Controller injections
+  application: controller(),
+
+  // 2. Service injections
   currentUser: service(),
 
-  // 2. Query params
+  // 3. Query params
   queryParams: ['view'],
 
-  // 3. Default controller's properties
+  // 4. Default controller's properties
   concatenatedProperties: ['concatenatedProperty'],
-  
-  // 4. Custom properties
+
+  // 5. Custom properties
   attitude: 10,
 
-  // 5. Single line Computed Property
+  // 6. Single line Computed Property
   health: alias('model.health'),
 
-  // 6. Multiline Computed Property
+  // 7. Multiline Computed Property
   levelOfHappiness: computed('attitude', 'health', function() {
     return get(this, 'attitude') * get(this, 'health') * Math.random();
   }),
 
-  // 7. Observers
+  // 8. Observers
   onVahicleChange: observer('vehicle', function() {
     // observer logic
   }),
 
-  // 8. All actions
+  // 9. All actions
   actions: {
     sneakyAction() {
       return this._secretMethod();
     },
   },
 
-  // 9. Custom / private methods
+  // 10. Custom / private methods
   _secretMethod() {
     // custom secret method logic
   },

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -7,6 +7,7 @@ const reportUnorderedProperties = propOrder.reportUnorderedProperties;
 const addBackwardsPosition = propOrder.addBackwardsPosition;
 
 const ORDER = [
+  'controller',
   'service',
   'query-params',
   'inherited-property',

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -21,6 +21,7 @@ module.exports = {
   getEmberImportAliasName,
 
   isInjectedServiceProp,
+  isInjectedControllerProp,
   isObserverProp,
   isObjectProp,
   isArrayProp,
@@ -151,6 +152,9 @@ function isEmberMixin(node, filePath) {
 
 function isInjectedServiceProp(node) {
   return isPropOfType(node, 'service') || isPropOfType(node, 'inject');
+}
+function isInjectedControllerProp(node) {
+  return isPropOfType(node, 'controller');
 }
 
 function isObserverProp(node) {

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -52,6 +52,10 @@ function determinePropertyType(node, parentType) {
     return 'service';
   }
 
+  if (ember.isInjectedControllerProp(node.value)) {
+    return 'controller';
+  }
+
   if (parentType === 'component') {
     if (ember.isComponentLifecycleHook(node)) {
       return node.key.name;

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -15,6 +15,7 @@ const NAMES = {
   afterModel: 'lifecycle hook',
   attribute: 'attribute',
   beforeModel: 'lifecycle hook',
+  controller: 'controller injection',
   deactivate: 'lifecycle hook',
   didDestroyElement: 'lifecycle hook',
   didInsertElement: 'lifecycle hook',

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -18,6 +18,7 @@ eslintTester.run('order-in-controllers', rule, {
     },
     {
       code: `export default Controller.extend({
+        application: controller(),
         currentUser: service(),
         queryParams: [],
         customProp: "test",
@@ -88,6 +89,19 @@ eslintTester.run('order-in-controllers', rule, {
         order: [
           'query-params',
           'service',
+        ],
+      }],
+    },
+    {
+      code: `export default Controller.extend({
+        queryParams: [],
+        application: controller(),
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'query-params',
+          'controller',
         ],
       }],
     },
@@ -208,6 +222,17 @@ eslintTester.run('order-in-controllers', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
+        line: 3,
+      }],
+    },
+    {
+      code: `export default Controller.extend({
+        currentUser: service(),
+        application: controller()
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "application" controller injection should be above the "currentUser" service injection on line 2',
         line: 3,
       }],
     },

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -229,11 +229,23 @@ describe('isInjectedServiceProp', () => {
     node = parse('service()');
     expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
 
-    node = parse('Ember.service()');
+    node = parse('Ember.inject.service()');
     expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
 
     node = parse('inject()');
     expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+  });
+});
+
+describe('isInjectedControllerProp', () => {
+  let node;
+
+  it('should check if it\'s an injected controller prop', () => {
+    node = parse('controller()');
+    expect(emberUtils.isInjectedControllerProp(node)).toBeTruthy();
+
+    node = parse('Ember.inject.controller()');
+    expect(emberUtils.isInjectedControllerProp(node)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
This is useful to dictate the position of controller injections in `order-in-controllers`, similar to `service`.

This does not yet add the `controller` property to the default order of the `order-in-controllers` rule.
I'm not sure what the convention should be, I guess before `service` injections?