### PR TITLE
Detect models based on their files' path

### DIFF
--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -18,6 +18,7 @@ module.exports = {
 
   create(context) {
     const message = 'Supply proper attribute type';
+    const filePath = context.getFilename();
 
     const report = function (node) {
       context.report(node, message);
@@ -25,7 +26,7 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!ember.isDSModel(node)) return;
+        if (!ember.isDSModel(node, filePath)) return;
 
         const allProperties = ember.getModuleProperties(node);
         const isDSAttr = allProperties.filter(property => ember.isModule(property.value, 'attr', 'DS'));

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -31,10 +31,11 @@ module.exports = {
   create(context) {
     const options = context.options[0] || {};
     const order = options.order ? addBackwardsPosition(options.order, 'empty-method', 'method') : ORDER;
+    const filePath = context.getFilename();
 
     return {
       CallExpression(node) {
-        if (!ember.isDSModel(node)) return;
+        if (!ember.isDSModel(node, filePath)) return;
 
         reportUnorderedProperties(node, context, 'model', order);
       },

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -92,8 +92,15 @@ function isModule(node, element, module) {
     (isLocalModule(node.callee, element) || isEmberModule(node.callee, element, moduleName));
 }
 
-function isDSModel(node) {
-  return isModule(node, 'Model', 'DS');
+function isDSModel(node, filePath) {
+  const isExtended = isEmberObject(node);
+  let isModuleByPath = false;
+
+  if (filePath && isExtended) {
+    isModuleByPath = isModuleByFilePath(filePath, 'model');
+  }
+
+  return isModule(node, 'Model', 'DS') || isModuleByPath;
 }
 
 function isModuleByFilePath(filePath, module) {

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -88,5 +88,11 @@ eslintTester.run('no-empty-attrs', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message, line: 2 }, { message, line: 3 }, { message, line: 4 }],
     },
+    {
+      filename: 'example-app/models/some-model.js',
+      code: 'export default CustomModel.extend({name: attr()});',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ message, line: 1 }]
+    },
   ],
 });

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -30,10 +30,25 @@ describe('isModule', () => {
 });
 
 describe('isDSModel', () => {
-  const node = parse('DS.Model()');
-
   it('should check if it\'s a DS Model', () => {
+    const node = parse('DS.Model()');
+
     expect(emberUtils.isDSModel(node)).toBeTruthy();
+  });
+
+  it('should check if it\'s a DS Model even if it uses custom name', () => {
+    const node = parse('CustomModel.extend()');
+    const filePath = 'example-app/models/path/to/some-model.js';
+
+    expect(
+      emberUtils.isDSModel(node),
+      'it shouldn\'t detect Model when no file path is provided'
+    ).toBeFalsy();
+
+    expect(
+      emberUtils.isDSModel(node, filePath),
+      'it should detect Model when file path is provided'
+    ).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
This allows models to be detected based on their path, even when they extend another model, the same way #37 did for controllers, components and routes.