### PR TITLE
minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ All rules from this plugin have to be prefixed with `ember/`
 
 Rules are grouped by category to help you understand their purpose.
 
-All rules below with a check mark :white_check_mark: are enabled by default while using `plugn:ember/base` or `plugin:ember/recommended` configs.
+All rules below with a check mark :white_check_mark: are enabled by default while using `plugin:ember/base` or `plugin:ember/recommended` configs.
 
 The `--fix` option on the command line automatically fixes problems reported by rules which have a wrench :wrench: below.
 


### PR DESCRIPTION
Typo in readme when referencing `plugin:ember/base`