### PR TITLE
Allow member expressions and unary expression for `avoid-leaking-state-in-ember-objects` rule

### DIFF
--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -23,7 +23,9 @@ const isAllowed = function (property) {
     utils.isCallExpression(value) ||
     utils.isBinaryExpression(value) ||
     utils.isTemplateLiteral(value) ||
-    utils.isTaggedTemplateExpression(value);
+    utils.isTaggedTemplateExpression(value) ||
+    utils.isMemberExpression(value) ||
+    utils.isUnaryExpression(value);
 };
 
 

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -94,7 +94,16 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     },
     {
       code: 'export default Foo.extend({ test: `lorem ipsum` });'
-    }
+    },
+    {
+      code: 'export default Foo.extend({ fullName: abc.dgc });'
+    },
+    {
+      code: 'export default Foo.extend({ foo: abc.something() });'
+    },
+    {
+      code: 'export default Foo.extend({ foo: !true });'
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Currently rule is not allowing following case

```js
import abc from 'xyz';
export default foo.extend({ 
 someProp: abc.something;
});
```

```js
import abc from 'xyz';
export default foo.extend({
  someProp: !true;
});
```