### PR TITLE
Fix lint rule crash when variable is used as routename

### DIFF
--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -22,7 +22,13 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!ember.isRoute(node) || !node.arguments[0]) return;
+        if (
+          !ember.isRoute(node) ||
+          !node.arguments[0] ||
+          (node.arguments[0] && node.arguments[0].type === 'Identifier')
+        ) {
+          return;
+        }
 
         const routeName = node.arguments[0].value;
         const hasAnyUppercaseLetter = Boolean(routeName.match('[A-Z]'));

--- a/tests/lib/rules/no-capital-letters-in-routes.js
+++ b/tests/lib/rules/no-capital-letters-in-routes.js
@@ -17,6 +17,12 @@ eslintTester.run('no-capital-letters-in-routes', rule, {
   valid: [
     'this.route("sign-in");',
     'this.route("news", { path: "/:news_id" });',
+    {
+      code: `
+        const routeName="about";
+        this.route(routeName);`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    }
   ],
 
   invalid: [{


### PR DESCRIPTION
Resolves #163

I'm not very familiar with eslint-plugins. If there's a way to resolve the value of a node type "Identifier", I'm happy to change this PR. Couldn't see how or if that's possible.