### PR TITLE
Fixed #150 issue with 'init' property

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -262,6 +262,7 @@ function isRouteCustomFunction(property) {
 
 function isRouteProperty(name) {
   return [
+    'init',
     'actions',
     'concatenatedProperties',
     'controller',
@@ -282,6 +283,7 @@ function isRouteDefaultProp(property) {
 
 function isControllerProperty(name) {
   return [
+    'init',
     'actions',
     'concatenatedProperties',
     'isDestroyed',

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -91,6 +91,22 @@ eslintTester.run('order-in-controllers', rule, {
         ],
       }],
     },
+    {
+      code: `
+        export default Controller.extend({
+          foo: service(),
+
+          init() {
+            this._super(...arguments);
+          },
+
+          actions: {
+            onKeyPress: function (event) {}
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
   ],
   invalid: [
     {
@@ -222,6 +238,24 @@ eslintTester.run('order-in-controllers', rule, {
         message: 'The "currentUser" service injection should be above the "queryParams" property on line 2',
         line: 3,
       }],
+    },
+    {
+      code: `
+        export default Controller.extend({
+          foo: service(),
+          actions: {
+            onKeyPress: function (event) {}
+          },
+          init() {
+            this._super(...arguments);
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The inherited "init" property should be above the actions hash on line 4',
+        line: 7
+      }]
     },
   ],
 });

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -95,11 +95,9 @@ eslintTester.run('order-in-controllers', rule, {
       code: `
         export default Controller.extend({
           foo: service(),
-
           init() {
             this._super(...arguments);
           },
-
           actions: {
             onKeyPress: function (event) {}
           }
@@ -107,6 +105,29 @@ eslintTester.run('order-in-controllers', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
+    {
+      code: `
+        export default Controller.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+          customFoo() {}
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      code: `
+        export default Controller.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    }
   ],
   invalid: [
     {
@@ -257,5 +278,36 @@ eslintTester.run('order-in-controllers', rule, {
         line: 7
       }]
     },
+    {
+      code: `
+        export default Controller.extend({
+          foo: service(),
+          customFoo() {},
+          init() {
+            this._super(...arguments);
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The inherited "init" property should be above the "customFoo" empty method on line 4',
+        line: 5
+      }]
+    },
+    {
+      code: `
+        export default Controller.extend({
+          init() {
+            this._super(...arguments);
+          },
+          foo: service()
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
+        line: 6
+      }]
+    }
   ],
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -155,12 +155,22 @@ eslintTester.run('order-in-routes', rule, {
       code: `
         export default Route.extend({
           foo: service(),
-
           init() {
             this._super(...arguments);
           },
-
           actions: {}
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      code: `
+        export default Route.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+          customFoo() {}
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
@@ -380,9 +390,7 @@ eslintTester.run('order-in-routes', rule, {
       code: `
         export default Route.extend({
           foo: service(),
-
           actions: {},
-
           init() {
             this._super(...arguments);
           }
@@ -390,8 +398,39 @@ eslintTester.run('order-in-routes', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The inherited "init" property should be above the actions hash on line 5',
-        line: 7
+        message: 'The inherited "init" property should be above the actions hash on line 4',
+        line: 5
+      }]
+    },
+    {
+      code: `
+        export default Route.extend({
+          foo: service(),
+          customFoo() {},
+          init() {
+            this._super(...arguments);
+          },
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The inherited "init" property should be above the "customFoo" empty method on line 4',
+        line: 5
+      }]
+    },
+    {
+      code: `
+        export default Route.extend({
+          init() {
+            this._super(...arguments);
+          },
+          foo: service()
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
+        line: 6
       }]
     },
   ]

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -73,9 +73,9 @@ eslintTester.run('order-in-routes', rule, {
     },
     {
       code: `export default Route.extend({
+        init() {},
         model() {},
         render() {},
-        init() {}
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
@@ -150,7 +150,21 @@ eslintTester.run('order-in-routes', rule, {
           'model'
         ]
       }]
-    }
+    },
+    {
+      code: `
+        export default Route.extend({
+          foo: service(),
+
+          init() {
+            this._super(...arguments);
+          },
+
+          actions: {}
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
   ],
   invalid: [
     {
@@ -361,6 +375,24 @@ eslintTester.run('order-in-routes', rule, {
         message: 'The "test" property should be above the "model" hook on line 2',
         line: 3
       }]
-    }
+    },
+    {
+      code: `
+        export default Route.extend({
+          foo: service(),
+
+          actions: {},
+
+          init() {
+            this._super(...arguments);
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The inherited "init" property should be above the actions hash on line 5',
+        line: 7
+      }]
+    },
   ]
 });


### PR DESCRIPTION
This PR resolves #150 since `inherited-property` is by default at the top of the file (not first but at the top).