### PR TITLE
Fix failing tests on windows due to path separators

### DIFF
--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -24,15 +26,15 @@ eslintTester.run('use-ember-get-and-set', rule, {
     'getWithDefault(controller, "test", "default")',
     {
       code: 'this.get("myProperty")',
-      filename: 'app/tests/unit/components/component-test.js',
+      filename: path.join('app', 'tests', 'unit', 'components', 'component-test.js'),
     },
     {
       code: 'this.set("myProperty", "value")',
-      filename: 'app/tests/unit/components/component-test.js',
+      filename: path.join('app', 'tests', 'unit', 'components', 'component-test.js'),
     },
     {
       code: 'this.get("/resources")',
-      filename: 'app/mirage/config.js',
+      filename: path.join('app', 'mirage', 'config.js'),
     },
     {
       code: 'import Ember from "ember"; Ember.get(this, "test")',


### PR DESCRIPTION
Fixes #170 .
Changed the paths in the test for `ember/use-ember-get-and-set` to have platform-dependant separators