### PR TITLE
Disable and deprecate `avoid-leaking-state-in-components` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | Enforces usage of snake_cased dynamic segments in routes |
 
 
+### Ember Object
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+| :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | Avoids state leakage |
+
+
 ### Stylistic Issues
 
 |    | Rule ID | Description |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The `--fix` option on the command line automatically fixes problems reported by 
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :white_check_mark: | [avoid-leaking-state-in-components](./docs/rules/avoid-leaking-state-in-components.md) | Avoids state leakage |
 | :white_check_mark: | [jquery-ember-run](./docs/rules/jquery-ember-run.md) | Prevents usage of jQuery without Ember Run Loop |
 | :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | Disallow usage of this.attrs in components |
 | :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs` |
@@ -130,6 +129,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 
 | Rule ID | Replaced by |
 |:--------|:------------|
+| [avoid-leaking-state-in-components](./docs/rules/avoid-leaking-state-in-components.md) | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) |
 | [local-modules](./docs/rules/local-modules.md) | [new-module-imports](./docs/rules/new-module-imports.md) |
 
 <!--RULES_TABLE_END-->

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -7,6 +7,7 @@
 module.exports = {
   "ember/alias-model-in-controller": "off",
   "ember/avoid-leaking-state-in-components": "error",
+  "ember/avoid-leaking-state-in-ember-objects": "error",
   "ember/closure-actions": "error",
   "ember/jquery-ember-run": "error",
   "ember/local-modules": "off",

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -6,7 +6,7 @@
  */
 module.exports = {
   "ember/alias-model-in-controller": "off",
-  "ember/avoid-leaking-state-in-components": "error",
+  "ember/avoid-leaking-state-in-components": "off",
   "ember/avoid-leaking-state-in-ember-objects": "error",
   "ember/closure-actions": "error",
   "ember/jquery-ember-run": "error",

--- a/lib/rules/avoid-leaking-state-in-components.js
+++ b/lib/rules/avoid-leaking-state-in-components.js
@@ -12,9 +12,11 @@ module.exports = {
     docs: {
       description: 'Avoids state leakage',
       category: 'Possible Errors',
-      recommended: true
+      recommended: false,
+      replacedBy: ['avoid-leaking-state-in-ember-objects'],
     },
     fixable: null, // or "code" or "whitespace"
+    deprecated: true,
     schema: [{
       type: 'array',
       items: { type: 'string' },

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -2,7 +2,6 @@
 
 exports[`recommended rules 1`] = `
 Array [
-  "avoid-leaking-state-in-components",
   "avoid-leaking-state-in-ember-objects",
   "closure-actions",
   "jquery-ember-run",


### PR DESCRIPTION
related to https://github.com/ember-cli/eslint-plugin-ember/pull/156

/cc @michalsnik @rwjblue 