### PR TITLE
Prevent error when destructured path is not in known globals.

### DIFF
--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -33,14 +33,13 @@ module.exports = {
           } else {
             const key = item.key.name;
             const match = GLOBALS[key];
-            const message = populateMessage({
+            populateMessage({
+              node: item,
               customKey: (key !== item.value.name) ? item.value.name : null,
               key,
               match,
               type: item.type
             });
-            // Report the issue to ESLint
-            context.report(item, message);
           }
         });
       },
@@ -69,10 +68,9 @@ module.exports = {
           const key = fullName.replace(/^Ember\./, '');
           const match = GLOBALS[key];
 
-          if (match) {
-            const message = populateMessage({ fullName, key, match });
-            // report the issue to ESLint
-            context.report(node, message);
+          const reportedError = populateMessage({ node, fullName, key, match });
+
+          if (reportedError) {
             // exit the loop after the first match was found
             break;
           }
@@ -83,18 +81,24 @@ module.exports = {
     function reportNestedProperties(properties, parent) {
       properties.forEach((item) => {
         const match = GLOBALS[`${parent}.${item.key.name}`];
-        const message = populateMessage({
+
+        populateMessage({
+          node: item,
           key: item.key.name,
           match,
           parent,
           type: item.type
         });
-
-        context.report(item, message);
       });
     }
 
     function populateMessage(obj) {
+      // if a given global path does not exist in `globals.json` there is no
+      // JS module import for it, so do not report the error
+      if (!obj.match) {
+        return false;
+      }
+
       // Both the Controller module and Service module each make available the
       // "inject" namespace. In order to make it more readable, so it's more
       // explicit at first glance from which module the "inject" namespace
@@ -122,7 +126,10 @@ module.exports = {
         message = `Use ${replacement} instead of using ${obj.fullName}`;
       }
 
-      return message;
+      // report the issue to ESLint
+      context.report(obj.node, message);
+
+      return true;
     }
   }
 };

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -12,6 +12,14 @@ const RuleTester = require('eslint').RuleTester;
 const eslintTester = new RuleTester();
 eslintTester.run('new-module-imports', rule, {
   valid: [
+    {
+      code: `import Ember from 'ember';
+
+        const { Handlebars: { Utils: { escapeExpression } } } = Ember
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    { code: 'Ember.Handlebars.Utils.escapeExpression("foo");' },
     { code: 'Ember.onerror = function() {};' },
     { code: 'Ember.MODEL_FACTORY_INJECTIONS = true;' },
     { code: 'console.log(Ember.VERSION);' },


### PR DESCRIPTION
Prior to these changes, using destructuring that resulted in a path that was not known to ember-rfc176-data's `globals.json` would throw an error (because we eagerly accessed `match[1]`).

This adds a test for the failure scenario and ensures that only usage of global paths that are listed in `globals.json` are reported as errors by `new-module-imports`.

Fixes #183