### PR TITLE
Update `no-global-jquery` rule to account for new modules import

### DIFF
--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -27,20 +27,46 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        // Capture whether the jquery module is being imported.
-        if (node.source.value === 'jquery') {
-          importAliasName = 'jquery';
-        } else {
-          importAliasName = ember.getEmberImportAliasName(node);
+        const validImportAlias = ['ember', 'jquery'];
+        // Capture whether the 'jquery' or 'ember' module (if an application
+        // is not using the new modules import syntax) is being imported.
+        // Will excluded non-ember or non-jquery imports such as:
+        //    - `import Foo from 'bar';`
+        //    - `import { readOnly } from '@ember/object/computed';`
+        if (validImportAlias.indexOf(node.source.value) !== -1) {
+          const isJqueryImport = node.source.value === 'jquery';
+          if (isJqueryImport) {
+            importAliasName = node.source.value;
+          } else {
+            importAliasName = ember.getEmberImportAliasName(node);
+          }
         }
       },
 
       VariableDeclarator(node) {
-        if (importAliasName) {
-          if (node.init && utils.isMemberExpression(node.init)) {
-            // assignment of type const $ = Ember.$;
-            destructuredAssignment = node.id.name;
+        // If an application is using an older version of Ember, not using
+        // the new modules import syntax, then lets locate a destructured
+        // jQuery assignment.
+        if (importAliasName === 'Ember') {
+          // Let's verify that we are dealing with an Ember MemberExpression
+          // only to test against.
+          if (node.init &&
+              utils.isMemberExpression(node.init) &&
+              isEmberMemberExpression(node.init)) {
+            const isJQueryVariable = node.init.property.name === '$';
+
+            if (isJQueryVariable) {
+              // Assignment of type const $ = Ember.$;
+              destructuredAssignment = node.id.name;
+            }
           } else {
+            // If we are not dealing with an Ember identifier, there is no need
+            // to perform the below checks/run the below code.
+            if (node.init && !isEmberIdentifier(node.init)) return;
+
+            if (!node.id.properties || !isNestedJQueryAssignment(node.id.properties)) return;
+            // Assignment of type const { $: foo } = Ember;
+            // It will grab/return "foo".
             destructuredAssignment = utils.collectObjectPatternBindings(node, {
               [importAliasName]: ['$']
             }).pop();
@@ -58,5 +84,17 @@ module.exports = {
         }
       }
     };
+
+    function isNestedJQueryAssignment(props) {
+      return props.filter(prop => prop.key.name === '$').length !== 0;
+    }
+
+    function isEmberIdentifier(init) {
+      return init.name === 'Ember';
+    }
+
+    function isEmberMemberExpression(init) {
+      return init.object.name === 'Ember';
+    }
   }
 };

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -22,28 +22,37 @@ module.exports = {
   },
 
   create(context) {
-    let emberImportAliasName;
     let destructuredAssignment;
+    let importAliasName;
 
     return {
       ImportDeclaration(node) {
-        emberImportAliasName = ember.getEmberImportAliasName(node);
+        // Capture whether the jquery module is being imported.
+        if (node.source.value === 'jquery') {
+          importAliasName = 'jquery';
+        } else {
+          importAliasName = ember.getEmberImportAliasName(node);
+        }
       },
 
       VariableDeclarator(node) {
-        if (emberImportAliasName) {
+        if (importAliasName) {
           if (node.init && utils.isMemberExpression(node.init)) {
             // assignment of type const $ = Ember.$;
             destructuredAssignment = node.id.name;
           } else {
             destructuredAssignment = utils.collectObjectPatternBindings(node, {
-              [emberImportAliasName]: ['$']
+              [importAliasName]: ['$']
             }).pop();
           }
         }
       },
 
       CallExpression(node) {
+        // In the event in which the jQuery module is being imported
+        // using the new modules import syntax do not report to ESLint
+        if (importAliasName === 'jquery') return;
+
         if (utils.isGlobalCallExpression(node, destructuredAssignment, ALIASES)) {
           context.report(node, MESSAGE);
         }

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -23,6 +23,32 @@ ruleTester.run('no-global-jquery', rule, {
   valid: [
     {
       code: `
+        import $ from 'jquery';
+
+        export default Ember.Component.extend({
+          init() {
+            this.el = $('.test');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import $ from 'jquery';
+
+        const foo = $;
+
+        export default Ember.Component.extend({
+          init() {
+            this.el = foo('.text');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
         import Ember from 'ember';
 
         let something;
@@ -178,7 +204,6 @@ ruleTester.run('no-global-jquery', rule, {
       parserOptions,
     },
   ],
-
   invalid: [
     {
       code: `

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -41,7 +41,82 @@ ruleTester.run('no-global-jquery', rule, {
 
         export default Ember.Component.extend({
           init() {
-            this.el = foo('.text');
+            this.el = foo('.gangnam-style');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+        import Foo from 'bar';
+
+        export default Ember.Component.extend({
+          init() {
+            this.el = Ember.$('.lololol');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $, Component } = Ember;
+        const { eq } = Ember.computed;
+
+        export default Component.extend({
+          init() {
+            this.el = $('.baba-booey');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+        import Foo from 'bar';
+
+        const { $ } = Ember;
+        const { foo } = Foo;
+
+        export default Ember.Component.extend({
+          init() {
+            this.el = $('.to-foo-or-not-to-foo');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+        import Foo from 'bar';
+
+        const { $ } = Ember;
+        const { baz } = Foo.bar;
+
+        export default Ember.Component.extend({
+          init() {
+            this.el = $('.homie-dont-play-that');
+          }
+        });
+      `,
+      parserOptions
+    },
+    {
+      code: `
+        import Ember from 'ember';
+
+        const { $ } = Ember;
+        const wut = 'lolerskates';
+
+        export default Ember.Controller.extend({
+          init() {
+            this.el = $('.whyowhyowhy');
           }
         });
       `,
@@ -60,7 +135,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -75,7 +150,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -128,7 +203,7 @@ ruleTester.run('no-global-jquery', rule, {
             this.el = $('.test');
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -143,7 +218,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -156,7 +231,7 @@ ruleTester.run('no-global-jquery', rule, {
             this.el = foo('.test');
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -171,7 +246,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -186,7 +261,7 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
+      parserOptions
     },
     {
       code: `
@@ -201,8 +276,8 @@ ruleTester.run('no-global-jquery', rule, {
             }
           }
         });`,
-      parserOptions,
-    },
+      parserOptions
+    }
   ],
   invalid: [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,9 +637,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2, debug@^2.4.1:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@2, debug@^2.2.0, debug@^2.4.1, debug@^2.6.3, debug@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
@@ -648,12 +648,6 @@ debug@^2.1.1:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
-
-debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -1213,7 +1207,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1224,7 +1218,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2:
+glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1384,7 +1378,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2519,19 +2513,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.4, readable-stream@^2.1.5:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -2665,15 +2647,9 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.6.1:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@^2.5.4:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -2693,7 +2669,7 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -2888,12 +2864,6 @@ string.prototype.padend@^3.0.0:
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  dependencies:
-    safe-buffer "~5.1.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -3110,15 +3080,9 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12:
+which@^1.2.12, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
This PR updates the `no-global-jquery` rule to not report the `$` module when using the new modules import syntax.