### PR TITLE
Don't fail 'no-global-jquery' if module has both jquery and ember imports

### DIFF
--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -24,21 +24,28 @@ module.exports = {
   create(context) {
     let destructuredAssignment;
     let importAliasName;
+    let hasJqueryImport;
+    let hasEmberImport;
 
     return {
       ImportDeclaration(node) {
         const validImportAlias = ['ember', 'jquery'];
-        // Capture whether the 'jquery' or 'ember' module (if an application
+        // Track if the 'jquery' and/or 'ember' module (if an application
         // is not using the new modules import syntax) is being imported.
-        // Will excluded non-ember or non-jquery imports such as:
+        // Will exclude non-ember or non-jquery imports such as:
         //    - `import Foo from 'bar';`
         //    - `import { readOnly } from '@ember/object/computed';`
         if (validImportAlias.indexOf(node.source.value) !== -1) {
           const isJqueryImport = node.source.value === 'jquery';
           if (isJqueryImport) {
+            hasJqueryImport = true;
             importAliasName = node.source.value;
           } else {
-            importAliasName = ember.getEmberImportAliasName(node);
+            const emberImport = ember.getEmberImportAliasName(node);
+            if (emberImport) {
+              hasEmberImport = true;
+              importAliasName = emberImport;
+            }
           }
         }
       },
@@ -47,7 +54,7 @@ module.exports = {
         // If an application is using an older version of Ember, not using
         // the new modules import syntax, then lets locate a destructured
         // jQuery assignment.
-        if (importAliasName === 'Ember') {
+        if (hasEmberImport) {
           // Let's verify that we are dealing with an Ember MemberExpression
           // only to test against.
           if (node.init &&
@@ -77,7 +84,7 @@ module.exports = {
       CallExpression(node) {
         // In the event in which the jQuery module is being imported
         // using the new modules import syntax do not report to ESLint
-        if (importAliasName === 'jquery') return;
+        if (hasJqueryImport) return;
 
         if (utils.isGlobalCallExpression(node, destructuredAssignment, ALIASES)) {
           context.report(node, MESSAGE);

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -277,7 +277,21 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions
-    }
+    },
+    {
+      code: `
+        import $ from 'jquery';
+        import Ember from 'ember';
+        
+        export default Ember.Component({
+          actions: {
+            valid() {
+              this.valid = $('.valid');
+            }
+          }
+        });`,
+      parserOptions
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes https://github.com/ember-cli/eslint-plugin-ember/issues/187#issuecomment-353130981