### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Enforces aliasing model in controller',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/alias-model-in-controller.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/avoid-leaking-state-in-components.js
+++ b/lib/rules/avoid-leaking-state-in-components.js
@@ -14,6 +14,7 @@ module.exports = {
       category: 'Possible Errors',
       recommended: false,
       replacedBy: ['avoid-leaking-state-in-ember-objects'],
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/avoid-leaking-state-in-components.md'
     },
     fixable: null, // or "code" or "whitespace"
     deprecated: true,

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -39,7 +39,8 @@ module.exports = {
     docs: {
       description: 'Avoids state leakage',
       category: 'Ember Object',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/avoid-leaking-state-in-ember-objects.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: [{

--- a/lib/rules/closure-actions.js
+++ b/lib/rules/closure-actions.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Enforces usage of closure actions',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/closure-actions.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of jQuery without Ember Run Loop',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/jquery-ember-run.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/local-modules.js
+++ b/lib/rules/local-modules.js
@@ -13,6 +13,7 @@ module.exports = {
       category: 'Best Practices',
       recommended: false,
       replacedBy: ['new-module-imports'],
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/local-modules.md'
     },
     deprecated: true,
     fixable: null, // or "code" or "whitespace"

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Enforces usage of named functions in promises',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/named-functions-in-promises.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: ' Use "New Module Imports" from Ember RFC #176',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/new-module-imports.md'
     },
   },
 

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -13,7 +13,8 @@ module.exports = {
     docs: {
       description: 'Disallow usage of this.attrs in components',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-in-components.md'
     },
     fixable: null,
   },

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -14,7 +14,8 @@ module.exports = {
     docs: {
       description: 'Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs`',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-snapshot.md'
     },
     fixable: null, // or "code" or "whitespace"
     message

--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -11,6 +11,7 @@ module.exports = {
       description: 'Raise an error when there is a route with uppercased letters in router.js',
       category: 'Possible Errors',
       recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-capital-letters-in-routes.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: [],

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Disallow repeating dependent keys',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-duplicate-dependent-keys.md'
     },
     fixable: null,
     message: MESSAGE,

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of empty attributes in ember data models',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-empty-attrs.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of Ember\'s `function` prototype extensions',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-function-prototype-extensions.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -16,6 +16,7 @@ module.exports = {
       description: 'Prevents usage of global jQuery object',
       category: 'Best Practices',
       recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-global-jquery.md'
     },
     fixable: null,  // or "code" or "whitespace"
     message: MESSAGE,

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -15,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Disallow any usage of jQuery',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-jquery.md'
     },
     fixable: null, // or "code" or "whitespace"
     message

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of observers',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-observers.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-old-shims.js
+++ b/lib/rules/no-old-shims.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of old shims for modules',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-old-shims.md'
     },
     fixable: 'code',
   },

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of `on` calls in components',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-on-calls-in-components.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -11,7 +11,8 @@ module.exports = {
     docs: {
       description: 'Warns about unexpected side effects in computed properties',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-side-effects.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -37,7 +37,8 @@ module.exports = {
     docs: {
       description: 'Enforces proper order of properties in components',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-components.md'
     },
     fixable: null // or "code" or "whitespace"
   },

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -28,7 +28,8 @@ module.exports = {
     docs: {
       description: 'Enforces proper order of properties in controllers',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-controllers.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -23,7 +23,8 @@ module.exports = {
     docs: {
       description: 'Enforces proper order of properties in models',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-models.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -35,7 +35,8 @@ module.exports = {
     docs: {
       description: 'Enforces proper order of properties in routes',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-routes.md'
     },
     fixable: null // or "code" or "whitespace"
   },

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Enforces super calls in init hooks',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-init.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -13,7 +13,8 @@ module.exports = {
     docs: {
       description: 'Enforces usage of snake_cased dynamic segments in routes',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/routes-segments-snake-case.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -12,7 +12,8 @@ module.exports = {
     docs: {
       description: 'Enforces usage of brace expansion',
       category: 'Stylistic Issues',
-      recommended: true
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-brace-expansion.md'
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -17,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Enforces usage of Ember.get and Ember.set',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-ember-get-and-set.md'
     },
     fixable: 'code',
   },


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.