### PR TITLE
Add failing example of `jquery-ember-run`

### DIFF
--- a/tests/lib/rules/jquery-ember-run.js
+++ b/tests/lib/rules/jquery-ember-run.js
@@ -16,6 +16,10 @@ eslintTester.run('jquery-ember-run', rule, {
       code: 'Ember.$("#something-rendered-by-jquery-plugin").on("click", () => {Ember.run.bind(this, this._handlerActionFromController);});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: "$.ajax({ url: `/foo`, type: 'GET', dataType: 'json' }).then(({ access_token }) => { this.set('jwt', access_token); });",
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
I found that this rules can mistake this usage of `$.ajax` as an invalid usage, when it's perfectly valid.