### PR TITLE
Use correct name of observer prototype extension

### DIFF
--- a/docs/rules/no-function-prototype-extensions.md
+++ b/docs/rules/no-function-prototype-extensions.md
@@ -2,13 +2,13 @@
 
 ### Rule name: `no-function-prototype-extensions`
 
-Use computed property syntax, observer syntax or module hooks instead of `.property()`, `.observe()` or `.on()` in Ember modules.
+Use computed property syntax, observer syntax or module hooks instead of `.property()`, `.observes()` or `.on()` in Ember modules.
 
 ```javascript
 export default Component.extend({
     // BAD
     abc: function() { /* custom logic */ }.property('xyz'),
-    def: function() { /* custom logic */ }.observe('xyz'),
+    def: function() { /* custom logic */ }.observes('xyz'),
     ghi: function() { /* custom logic */ }.on('didInsertElement'),
 
     // GOOD

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -19,7 +19,7 @@ module.exports = {
   create(context) {
     const message = 'Don\'t use Ember\'s function prototype extensions';
 
-    const functionPrototypeExtensionNames = ['property', 'observe', 'on'];
+    const functionPrototypeExtensionNames = ['property', 'observes', 'on'];
 
     const isFunctionPrototypeExtension = function (property) {
       return utils.isIdentifier(property) &&

--- a/tests/lib/rules/no-function-prototype-extensions.js
+++ b/tests/lib/rules/no-function-prototype-extensions.js
@@ -82,7 +82,7 @@ eslintTester.run('no-function-prototype-extensions', rule, {
       }],
     },
     {
-      code: 'export default Controller.extend({test: function() {}.observe("abc")});',
+      code: 'export default Controller.extend({test: function() {}.observes("abc")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
         message: 'Don\'t use Ember\'s function prototype extensions',


### PR DESCRIPTION
The prototype extension for creating an observer is `observes()` not `observe()`.