### PR TITLE
Failing test case for init() order

### DIFF
--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -109,6 +109,7 @@ eslintTester.run('order-in-controllers', rule, {
       code: `
         export default Controller.extend({
           foo: service(),
+          someProp: null,
           init() {
             this._super(...arguments);
           },


### PR DESCRIPTION
When I try to upgrade eslint-plugin-ember from 4.6.1 to 4.6.2 I have an eslint error about invalid `init` order.

For example with the following controller contents:
```js
import Controller from '@ember/controller';

export default Controller.extend({
  someProp: null,

  init() {
    this._super(...arguments);
  }
});
```
I get the following error:
```
6:3  error  The inherited "init" property should be above the "someProp" property on line 4  ember/order-in-controllers
```

Is it a regression?