### PR TITLE
Fix init order in controllers and routes

### DIFF
--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -12,6 +12,7 @@ const ORDER = [
   'query-params',
   'inherited-property',
   'property',
+  'init',
   'single-line-function',
   'multi-line-function',
   'observer',

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -10,6 +10,7 @@ const ORDER = [
   'service',
   'inherited-property',
   'property',
+  'init',
   'single-line-function',
   'multi-line-function',
   'beforeModel',

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -208,7 +208,6 @@ function isActionsProp(property) {
 
 function isComponentLifecycleHookName(name) {
   return [
-    'init',
     'didReceiveAttrs',
     'willRender',
     'willInsertElement',

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -267,7 +267,6 @@ function isRouteCustomFunction(property) {
 
 function isRouteProperty(name) {
   return [
-    'init',
     'actions',
     'concatenatedProperties',
     'controller',
@@ -288,7 +287,6 @@ function isRouteDefaultProp(property) {
 
 function isControllerProperty(name) {
   return [
-    'init',
     'actions',
     'concatenatedProperties',
     'isDestroyed',

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -32,16 +32,11 @@ module.exports = {
 
   isRelation,
 
-  isComponentLifecycleHookName,
   isComponentLifecycleHook,
-  isComponentCustomFunction,
 
   isRoute,
-  isRouteCustomFunction,
-  isRouteProperty,
   isRouteDefaultProp,
 
-  isControllerProperty,
   isControllerDefaultProp,
   parseDependentKeys,
   unwrapBraceExpressions,
@@ -233,11 +228,6 @@ function isComponentLifecycleHook(property) {
     isComponentLifecycleHookName(property.key.name);
 }
 
-function isComponentCustomFunction(property) {
-  return isFunctionExpression(property.value) &&
-    !isComponentLifecycleHookName(property.key.name);
-}
-
 function isRoute(node) {
   return utils.isMemberExpression(node.callee) &&
     utils.isThisExpression(node.callee.object) &&
@@ -258,11 +248,6 @@ function isRouteLifecycleHookName(name) {
     'serialize',
     'setupController'
   ].indexOf(name) > -1;
-}
-
-function isRouteCustomFunction(property) {
-  return isFunctionExpression(property.value) &&
-    !isRouteLifecycleHookName(property.key.name);
 }
 
 function isRouteProperty(name) {

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -57,6 +57,10 @@ function determinePropertyType(node, parentType) {
     return 'controller';
   }
 
+  if (node.key.name === 'init') {
+    return 'init';
+  }
+
   if (parentType === 'component') {
     if (ember.isComponentLifecycleHook(node)) {
       return node.key.name;

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -300,7 +300,7 @@ eslintTester.run('order-in-controllers', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The inherited "init" property should be above the actions hash on line 4',
+        message: 'The "init" lifecycle hook should be above the actions hash on line 4',
         line: 7
       }]
     },
@@ -316,7 +316,7 @@ eslintTester.run('order-in-controllers', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The inherited "init" property should be above the "customFoo" empty method on line 4',
+        message: 'The "init" lifecycle hook should be above the "customFoo" empty method on line 4',
         line: 5
       }]
     },
@@ -331,7 +331,7 @@ eslintTester.run('order-in-controllers', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
+        message: 'The "foo" service injection should be above the "init" lifecycle hook on line 3',
         line: 6
       }]
     }

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -109,6 +109,7 @@ eslintTester.run('order-in-controllers', rule, {
       code: `
         export default Controller.extend({
           foo: service(),
+          someProp: null,
           init() {
             this._super(...arguments);
           },

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -334,6 +334,21 @@ eslintTester.run('order-in-controllers', rule, {
         message: 'The "foo" service injection should be above the "init" lifecycle hook on line 3',
         line: 6
       }]
-    }
+    },
+    {
+      code: `
+        export default Controller.extend({
+          init() {
+            this._super(...arguments);
+          },
+          someProp: null
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
+        line: 6
+      }]
+    },
   ],
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -433,5 +433,20 @@ eslintTester.run('order-in-routes', rule, {
         line: 6
       }]
     },
+    {
+      code: `
+        export default Route.extend({
+          init() {
+            this._super(...arguments);
+          },
+          someProp: null
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
+        line: 6
+      }]
+    },
   ]
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -398,7 +398,7 @@ eslintTester.run('order-in-routes', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The inherited "init" property should be above the actions hash on line 4',
+        message: 'The "init" lifecycle hook should be above the actions hash on line 4',
         line: 5
       }]
     },
@@ -414,7 +414,7 @@ eslintTester.run('order-in-routes', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The inherited "init" property should be above the "customFoo" empty method on line 4',
+        message: 'The "init" lifecycle hook should be above the "customFoo" empty method on line 4',
         line: 5
       }]
     },
@@ -429,7 +429,7 @@ eslintTester.run('order-in-routes', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
+        message: 'The "foo" service injection should be above the "init" lifecycle hook on line 3',
         line: 6
       }]
     },


### PR DESCRIPTION
Replaces https://github.com/ember-cli/eslint-plugin-ember/pull/232

Before this change `init` in routes and controllers was treated as an `'inherited-property'`. It prevented us to specify a specific order for `init` for these module types. 