### PR TITLE
[avoid-leaking-state-in-ember-objects] Expose default ignored properties

### DIFF
--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -48,6 +48,8 @@ module.exports = {
     }],
   },
 
+  DEFAULT_IGNORED_PROPERTIES,
+
   create(context) {
     const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
 

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -9,6 +9,22 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
+describe('imports', () => {
+  it('should expose the default ignored properties', () => {
+    expect(rule.DEFAULT_IGNORED_PROPERTIES).toEqual([
+      'classNames',
+      'classNameBindings',
+      'actions',
+      'concatenatedProperties',
+      'mergedProperties',
+      'positionalParams',
+      'attributeBindings',
+      'queryParams',
+      'attrs',
+    ]);
+  });
+});
+
 const eslintTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,


### PR DESCRIPTION
This PR exposes `DEFAULT_IGNORED_PROPERTIES` on the rule `ember/avoid-leaking-state-in-ember-objects` so that users' `.eslintrc.js` files can go from this:

```js
// ...
rules: {
  'ember/avoid-leaking-state-in-ember-objects': ['error', [
    'classNames',
    'classNameBindings',
    'actions',
    'concatenatedProperties',
    'mergedProperties',
    'positionalParams',
    'attributeBindings',
    'queryParams',
    'attrs',
    'shortcuts',
    'include',
  ],
  // ...
},
// ...
```

To this:

```js
const { DEFAULT_IGNORED_PROPERTIES } = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
//...
rules: {
  'ember/avoid-leaking-state-in-ember-objects': ['error', [
    ...DEFAULT_IGNORED_PROPERTIES,
    'shortcuts',
    'include',
  ],
  // ...
},
// ...
```