### PR TITLE
Passing ignored properties should extend default list

### DIFF
--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -49,12 +49,14 @@ module.exports = {
   },
 
   create(context) {
-    const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
+    const ignoredProperties = context.options[0] || [];
 
     const report = function (node) {
       const message = 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties';
       context.report(node, message);
     };
+    
+    ignoredProperties = ignoredProperties.concat(DEFAULT_IGNORED_PROPERTIES);
 
     return {
       CallExpression(node) {

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   create(context) {
-    const ignoredProperties = context.options[0] || [];
+    let ignoredProperties = context.options[0] || [];
 
     const report = function (node) {
       const message = 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties';

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -55,7 +55,7 @@ module.exports = {
       const message = 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties';
       context.report(node, message);
     };
-    
+
     ignoredProperties = ignoredProperties.concat(DEFAULT_IGNORED_PROPERTIES);
 
     return {


### PR DESCRIPTION
This will mimic behavior for avoid-leaking-state-in-components rule