### PR TITLE
Drop require-folder-tree dependency.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,43 @@
 'use strict';
 
-const resolve = require('path').resolve;
-const requireFolderTree = require('require-folder-tree');
-
-const rules = requireFolderTree(resolve(__dirname, 'rules'));
-const configs = requireFolderTree(resolve(__dirname, 'config'));
-
-/* eslint-disable import/no-dynamic-require */
-const ember = require(resolve(__dirname, 'utils/ember'));
-const utils = require(resolve(__dirname, 'utils/utils'));
-
+/* eslint-disable global-require */
 module.exports = {
-  rules,
-  configs,
+  rules: {
+    'alias-model-in-controller': require('./rules/alias-model-in-controller'),
+    'avoid-leaking-state-in-components': require('./rules/avoid-leaking-state-in-components'),
+    'avoid-leaking-state-in-ember-objects': require('./rules/avoid-leaking-state-in-ember-objects'),
+    'closure-actions': require('./rules/closure-actions'),
+    'jquery-ember-run': require('./rules/jquery-ember-run'),
+    'local-modules': require('./rules/local-modules'),
+    'named-functions-in-promises': require('./rules/named-functions-in-promises'),
+    'new-module-imports': require('./rules/new-module-imports'),
+    'no-attrs-in-components': require('./rules/no-attrs-in-components'),
+    'no-attrs-snapshot': require('./rules/no-attrs-snapshot'),
+    'no-capital-letters-in-routes': require('./rules/no-capital-letters-in-routes'),
+    'no-duplicate-dependent-keys': require('./rules/no-duplicate-dependent-keys'),
+    'no-empty-attrs': require('./rules/no-empty-attrs'),
+    'no-function-prototype-extensions': require('./rules/no-function-prototype-extensions'),
+    'no-global-jquery': require('./rules/no-global-jquery'),
+    'no-jquery': require('./rules/no-jquery'),
+    'no-observers': require('./rules/no-observers'),
+    'no-old-shims': require('./rules/no-old-shims'),
+    'no-on-calls-in-components': require('./rules/no-on-calls-in-components'),
+    'no-side-effects': require('./rules/no-side-effects'),
+    'order-in-components': require('./rules/order-in-components'),
+    'order-in-controllers': require('./rules/order-in-controllers'),
+    'order-in-models': require('./rules/order-in-models'),
+    'order-in-routes': require('./rules/order-in-routes'),
+    'require-super-in-init': require('./rules/require-super-in-init'),
+    'routes-segments-snake-case': require('./rules/routes-segments-snake-case'),
+    'use-brace-expansion': require('./rules/use-brace-expansion'),
+    'use-ember-get-and-set': require('./rules/use-ember-get-and-set'),
+  },
+  configs: {
+    base: require('./config/base'),
+    recommended: require('./config/recommended'),
+  },
   utils: {
-    ember,
-    utils,
+    ember: require('./utils/ember'),
+    utils: require('./utils/utils'),
   },
 };

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "ember-rfc176-data": "^0.2.7",
-    "require-folder-tree": "^1.4.5",
     "snake-case": "^2.1.0"
   },
   "changelog": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,10 +2441,6 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
-lodash@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.8.0.tgz#376eb98bdcd9382a9365c33c4cb8250de1325b91"
-
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3192,12 +3188,6 @@ request@2.81.0, request@^2.79.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-
-require-folder-tree@^1.4.5:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/require-folder-tree/-/require-folder-tree-1.4.5.tgz#dfe553cbab98cc88e1c56a3f2f358f06ef85bcb0"
-  dependencies:
-    lodash "3.8.0"
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`require-folder-tree` is using a _very_ old `lodash` version which is
flagged by an `npm audit` in consuming ember-cli applications as the
following:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution
│
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash
│
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.5
│
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint-plugin-ember [dev]
│
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint-plugin-ember > require-folder-tree > lodash
│
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577
│
└───────────────┴──────────────────────────────────────────────────────────────┘
```

I also personally find the explicitness here to be nicer...