### PR TITLE
Prevent referencing properties in Computed's body that are not dependent keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs` |
 | :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | Raise an error when there is a route with uppercased letters in router.js |
 | :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | Disallow repeating dependent keys |
+| :white_check_mark: | [no-get-untracked-props-in-computed](./docs/rules/no-get-untracked-props-in-computed.md) | Disallow referencing properties in computeds that aren't tracked in it's dependant keys |
 | :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | Warns about unexpected side effects in computed properties |
 | :white_check_mark: | [require-super-in-init](./docs/rules/require-super-in-init.md) | Enforces super calls in init hooks |
 | :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | Enforces usage of snake_cased dynamic segments in routes |

--- a/docs/rules/no-get-untracked-props-in-computed.md
+++ b/docs/rules/no-get-untracked-props-in-computed.md
@@ -1,0 +1,19 @@
+# Do not reference property in Computed's body that is not in dependent keys
+
+## Rule name: `no-get-untracked-props-in-computed`
+
+When using computed properties, you should always put any property you reference inside a computed's body in it's dependent keys.
+
+```js
+export default Component.extend({
+    // BAD
+    abc: computed('propA', function() {
+      return this.get('propA') + this.get('propB');
+    }),
+
+    // GOOD
+    abc: computed('propA', 'propB', function() {
+      return this.get('propA') + this.get('propB');
+    }),
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = {
     'no-attrs-snapshot': require('./rules/no-attrs-snapshot'),
     'no-capital-letters-in-routes': require('./rules/no-capital-letters-in-routes'),
     'no-duplicate-dependent-keys': require('./rules/no-duplicate-dependent-keys'),
+    'no-get-untracked-props-in-computed': require('./rules/no-get-untracked-props-in-computed'),
     'no-empty-attrs': require('./rules/no-empty-attrs'),
     'no-function-prototype-extensions': require('./rules/no-function-prototype-extensions'),
     'no-global-jquery': require('./rules/no-global-jquery'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -19,6 +19,7 @@ module.exports = {
   "ember/no-duplicate-dependent-keys": "error",
   "ember/no-empty-attrs": "off",
   "ember/no-function-prototype-extensions": "error",
+  "ember/no-get-untracked-props-in-computed": "error",
   "ember/no-global-jquery": "error",
   "ember/no-jquery": "off",
   "ember/no-observers": "off",

--- a/lib/rules/no-get-untracked-props-in-computed.js
+++ b/lib/rules/no-get-untracked-props-in-computed.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const {
+  isIdentifier,
+  isStringLiteral,
+  isProperty,
+  isMemberExpression,
+  isThisExpression
+} = require('../utils/utils');
+
+const {
+  parseDependentKeys,
+  isComputedDefinition
+} = require('../utils/ember');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule = {
+  meta: {
+    docs: {
+      description: 'Disallow referencing properties in computeds that aren\'t tracked in it\'s dependant keys',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-get-untracked-props-in-computed.md'
+    },
+    fixable: null,
+  },
+
+  create(context) {
+    let computedContext;
+    let computedScopeLevel = 0;
+    const inComputedScope = () => computedContext && computedScopeLevel === 1;
+    const pushScope = () => computedContext && computedScopeLevel++;
+    const popScope = () => computedContext && computedScopeLevel--;
+
+    return {
+      CallExpression(node) {
+        const ancestors = context.getAncestors();
+        const parent = ancestors[ancestors.length - 1];
+
+        if (isComputedDefinition(node) && isProperty(parent)) {
+          if (computedContext) {
+            return;
+          }
+
+          computedScopeLevel = 0;
+          computedContext = {
+            dependantKeys: parseDependentKeys(node)
+          };
+        }
+
+        if (computedContext && inComputedScope() && isPropertyGetterOnThis(node.callee)) {
+          const getterKeyNode = node.arguments[0];
+
+          // We only look at string literals, no dynamic keys
+          if (!isStringLiteral(getterKeyNode)) {
+            return;
+          }
+
+          const getterKey = getterKeyNode.value;
+
+          if (!isPropertyTracked(computedContext.dependantKeys, getterKey)) {
+            context.report({
+              node,
+              message: `Dependency '${getterKey}' is not tracked in computed's dependant keys`
+            });
+          }
+        }
+      },
+
+      'CallExpression:exit': (node) => {
+        if (isComputedDefinition(node) && computedScopeLevel === 0) {
+          computedContext = null;
+        }
+      },
+
+      FunctionExpression: pushScope,
+      'FunctionExpression:exit': popScope,
+
+      FunctionDeclaration: pushScope,
+      'FunctionDeclaration:exit': popScope,
+    };
+  }
+};
+
+function isPropertyGetterOnThis(callee) {
+  return (
+    isMemberExpression(callee) &&
+    isThisExpression(callee.object) &&
+    isIdentifier(callee.property) &&
+    callee.property.name === 'get'
+  );
+}
+
+function isPropertyTracked(dependantKeys, property) {
+  const explodedDependantKeys = explodeDependantKeys(dependantKeys);
+
+  if (explodedDependantKeys.indexOf(property) > -1) {
+    return true;
+  }
+
+  const chain = explodeProperty(property);
+
+  if (chain.some(subset => explodedDependantKeys.indexOf(subset) > -1)) {
+    return true;
+  }
+
+  return false;
+}
+
+function explodeProperty(property) {
+  return property.split('.').map((node, i, chain) => chain.slice(0, i + 1).join('.'));
+}
+
+function explodeDependantKeys(dependantKeys) {
+  return dependantKeys.reduce((exploded, key) => {
+    // Explode 'propA.propB.[].foo.bar' into 'propA.propA' (take the root key)
+    let nextKeys = key;
+    const split = nextKeys.split(/\.(?:\[\]|@each)/);
+
+    if (split.length > 1) {
+      nextKeys = split[0];
+    }
+
+    return exploded.concat(nextKeys);
+  }, []);
+}
+
+module.exports = Object.assign(rule, {
+  explodeProperty,
+  isPropertyTracked
+});

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -27,6 +27,7 @@ module.exports = {
   isObjectProp,
   isArrayProp,
   isComputedProp,
+  isComputedDefinition,
   isCustomProp,
   isActionsProp,
   isRouteLifecycleHook,
@@ -170,6 +171,31 @@ function isComputedProp(node) {
       allowedMemberExpNames.indexOf(node.callee.property.name) > -1;
   }
   return isModule(node, 'computed');
+}
+
+function isComputedDefinition(node) {
+  if (!utils.isCallExpression(node)) {
+    return false;
+  }
+
+  if (node.arguments.length < 2) {
+    return false;
+  }
+
+  if (utils.isIdentifier(node.callee) && node.callee.name === 'computed') {
+    return true;
+  }
+
+  if (utils.isMemberExpression(node.callee) &&
+      utils.isIdentifier(node.callee.property) &&
+      node.callee.property.name === 'computed' &&
+      utils.isIdentifier(node.callee.object) &&
+      ['Ember', 'Em'].indexOf(node.callee.object.name) > -1
+    ) {
+    return true;
+  }
+
+  return false;
 }
 
 function isArrayProp(node) {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -4,6 +4,8 @@ module.exports = {
   findNodes,
   isIdentifier,
   isLiteral,
+  isStringLiteral,
+  isProperty,
   isUnaryExpression,
   isMemberExpression,
   isCallExpression,
@@ -66,6 +68,26 @@ function isIdentifier(node) {
  */
 function isLiteral(node) {
   return node !== undefined && node.type === 'Literal';
+}
+
+/**
+ * Check whether or node a node is a Literal and of type string.
+ *
+ * @param  {Object}  node The node to check.
+ * @return {Boolean}      Whether or not the node is a string literal.
+ */
+function isStringLiteral(node) {
+  return isLiteral(node) && typeof node.value === 'string';
+}
+
+/**
+ * Check whether or not a node is a Property.
+ *
+ * @param  {Object}  node The node to check.
+ * @return {Boolean}      Whether or not the node is a Property.
+ */
+function isProperty(node) {
+  return node !== undefined && node.type === 'Property';
 }
 
 /**

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -10,6 +10,7 @@ Array [
   "no-attrs-snapshot",
   "no-capital-letters-in-routes",
   "no-duplicate-dependent-keys",
+  "no-get-untracked-props-in-computed",
   "no-function-prototype-extensions",
   "no-global-jquery",
   "no-old-shims",

--- a/tests/lib/rules/no-get-untracked-props-in-computed.js
+++ b/tests/lib/rules/no-get-untracked-props-in-computed.js
@@ -1,0 +1,348 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-get-untracked-props-in-computed');
+
+describe('exports', () => {
+  describe('explodeProperty', () => {
+    it('should correctly explode a dependency', () => {
+      expect(rule.explodeProperty('foo')).toEqual(['foo']);
+      expect(rule.explodeProperty('foo.bar')).toEqual(['foo', 'foo.bar']);
+      expect(rule.explodeProperty('foo.bar')).toEqual(['foo', 'foo.bar']);
+      expect(rule.explodeProperty('foo.bar.baz')).toEqual(['foo', 'foo.bar', 'foo.bar.baz']);
+    });
+  });
+
+  describe('isPropertyTracked', () => {
+    it('should correctly determine if a dependency is tracker', () => {
+      expect(rule.isPropertyTracked(['foo'], 'foo')).toBe(true);
+      expect(rule.isPropertyTracked(['foo', 'bar'], 'foo')).toBe(true);
+      expect(rule.isPropertyTracked(['bar'], 'foo')).toBe(false);
+      expect(rule.isPropertyTracked(['foo'], 'foo.bar')).toBe(true);
+      expect(rule.isPropertyTracked(['foo.bar'], 'foo')).toBe(false);
+      expect(rule.isPropertyTracked(['foo.bar.[]'], 'foo.bar')).toBe(true);
+      expect(rule.isPropertyTracked(['foo.bar.@each.bar'], 'foo.bar')).toBe(true);
+    });
+  });
+});
+
+const RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+ruleTester.run('no-get-untracked-props-in-computed', rule, {
+  valid: [
+    {
+      code: `
+      let obj = {
+        foo: Ember.computed('model.foo', function() {
+          this.get('model.foo');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: Em.computed('model.foo', function() {
+          this.get('model.foo');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', function() {
+          this.get('model.foo');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model', function() {
+          this.get('model.foo');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.{foo,bar}', function() {
+          this.get('model.foo');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA', function() {
+          anotherFn(() => {
+            this.get('propA');
+          });
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA', function() {
+          anotherFn(function() {
+            this.get('propB');
+          });
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA', function() {
+          function myMethod() {
+            this.get('propB');
+          };
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA.[]', function() {
+          this.get('propA');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA.@each.bar', function() {
+          this.get('propA');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('propA', 'propB', function() {
+          this.get('propB');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed(function() {
+          this.get('propB');
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('foo', function() {
+          // Not sure when you would ever do this but lets be sure it doesn't trip up the rule
+          return {
+            foo: computed('bar', () => {
+              this.get('foo');
+            })
+          };
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', {
+          get() {
+            this.get('model.foo');
+          },
+          set() {
+            this.get('model.foo');
+          },
+        })
+      }
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', {
+          get: function() {
+            this.get('model.foo');
+          },
+          set: function() {
+            this.get('model.foo');
+          },
+        })
+      }
+      `,
+      parserOptions,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      let a = {
+        foo: computed('model.foo', function() {
+          this.get('model.bar');
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let a = {
+        foo: computed('model.foo', function() {
+          this.get('model.bar');
+          this.get('model.baz');
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }, {
+        message: 'Dependency \'model.baz\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let a = {
+        foo: computed('model.{foo,bar}', function() {
+          this.get('model.baz');
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.baz\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let a = {
+        foo: computed('model.bar', function() {
+          anotherFn(() => {
+            this.get('model.baz');
+          });
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.baz\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('foo', function() {
+          // Not sure when you would ever do this but lets be sure it doesn't trip up the rule
+          return {
+            foo: computed('bar', () => {
+              this.get('bar');
+            })
+          };
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'bar\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', function() {
+          this.get('model');
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', {
+          get() {
+            this.get('model.foo');
+            this.get('model.bar');
+          },
+          set() {
+            this.get('model.foo');
+            this.get('model.bar');
+          },
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }, {
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+    {
+      code: `
+      let obj = {
+        foo: computed('model.foo', {
+          get: function() {
+            this.get('model.foo');
+            this.get('model.bar');
+          },
+          set: function() {
+            this.get('model.foo');
+            this.get('model.bar');
+          },
+        })
+      }
+      `,
+      parserOptions,
+      errors: [{
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }, {
+        message: 'Dependency \'model.bar\' is not tracked in computed\'s dependant keys',
+      }],
+    },
+  ]
+});

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -288,6 +288,43 @@ describe('isComputedProp', () => {
   });
 });
 
+describe('isComputedDefinition', () => {
+  let node;
+
+  it('should match computed properties with bodies', () => {
+    node = parse('computed(\'foobar\', function() { })');
+    expect(emberUtils.isComputedDefinition(node)).toBeTruthy();
+
+    node = parse('Ember.computed(\'foobar\', function() { })');
+    expect(emberUtils.isComputedDefinition(node)).toBeTruthy();
+
+    node = parse('Em.computed(\'foobar\', function() { })');
+    expect(emberUtils.isComputedDefinition(node)).toBeTruthy();
+  });
+
+  it('should match computeds without dependent keys or function body', () => {
+    node = parse('Ember.computed()');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+
+    node = parse('Ember.computed(() => {})');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+
+    node = parse('Ember.computed(function() { })');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+
+    node = parse('Ember.computed(\'foobar\')');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+  });
+
+  it('shouldn\'t allow macros', () => {
+    node = parse('Ember.computed.match()');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+
+    node = parse('Em.computed.match(\'foo\', /foo/)');
+    expect(emberUtils.isComputedDefinition(node)).not.toBeTruthy();
+  });
+});
+
 describe('isObserverProp', () => {
   let node;
 

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -49,6 +49,26 @@ describe('isLiteral', () => {
   });
 });
 
+describe('isStringLiteral', () => {
+  it('should check if node is identifier', () => {
+    const node = parse('"test"');
+    expect(utils.isStringLiteral(node)).toBeTruthy();
+  });
+
+  it('should be falsy if not string literal', () => {
+    const node = parse('1');
+    expect(utils.isStringLiteral(node)).toBeFalsy();
+  });
+});
+
+describe('isProperty', () => {
+  const node = parse('({ a: 1 })');
+
+  it('should check if node is identifier', () => {
+    expect(utils.isProperty(node.properties[0])).toBeTruthy();
+  });
+});
+
 describe('isUnaryExpression', () => {
   const node = parse('-1');
 


### PR DESCRIPTION
This PR adds a `no-get-untracked-props-in-computed` rule which highlights the following:

```js
export default Component.extend({
    // BAD
    abc: computed('propA', function() {
      return this.get('propA') + this.get('propB');
    }),

    // GOOD
    abc: computed('propA', 'propB', function() {
      return this.get('propA') + this.get('propB');
    }),
});
```

Any thoughts on this rule? The feedback I received was that it was generally a good practice to always reference properties in your computed's body in it's dependent keys but I'd be interested to hear people's thoughts on this.

Notes:
* This is fixable but I think it breaks rule 1 of fixable rules of "Avoid any fixes that could change the runtime behavior of code and cause it to stop working."
* For detecting the computed definition, `isComputedProp` was unsuitable and a new `isComputedDefinition` method was introduced. `isComputedProp` couldn't be extended either because it would be a breaking change since it also matches computed macros `Ember.computed.match` and we explicitly did not want to with `isComputedDefintion`, only a computed with a function body.
* The rule does not match computeds unless they have at least one dependent key because computeds without dependent keys are not dynamic.