### PR TITLE
throw error on `window.find`

### DIFF
--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -32,5 +32,13 @@ module.exports = {
   "ember/require-super-in-init": "error",
   "ember/routes-segments-snake-case": "error",
   "ember/use-brace-expansion": "error",
-  "ember/use-ember-get-and-set": "off"
+  "ember/use-ember-get-and-set": "off",
+
+  "no-restricted-globals": [
+    "error",
+    {
+      name: "find",
+      message: "You forgot to import `find`, and we are preventing accidental usage of `window.find`."
+    },
+  ]
 }


### PR DESCRIPTION
Solves https://github.com/emberjs/ember-test-helpers/pull/369#issuecomment-392975541 with a linter change rather than a code hack.

The downside of it being here instead of the app .eslintrc blueprint is it doesn't target tests only.

Sister https://github.com/ember-cli/ember-cli/pull/7858