### PR TITLE
Update no-empty-attrs' description

### DIFF
--- a/docs/rules/no-empty-attrs.md
+++ b/docs/rules/no-empty-attrs.md
@@ -2,7 +2,7 @@
 
 ### Rule name: `no-empty-attrs`
 
-Ember Data could handle lack of specified types in model description. Nonetheless this could lead to ambiguity. Therefore always supply proper attribute type to ensure the right data transform is used.
+Ember Data handles not specifying a transform in model description. Nonetheless this could lead to ambiguity. This rule ensures that the right transform is specified for every attribute.
 
 ```javascript
 const { Model, attr } = DS;


### PR DESCRIPTION
The argument that is passed to `attr()` is _not_ a type, it is the transform that should be run when (de)serializing that attribute.