### PR TITLE
Adding no-restricted-resolver-tests general rule

### DIFF
--- a/docs/rules/no-restricted-resolver-tests.md
+++ b/docs/rules/no-restricted-resolver-tests.md
@@ -22,7 +22,7 @@ moduleFor('service:session', {
 moduleFor('service:session', {
   needs: ['type:thing']
 });
-moduleFor('arg1', 'arg2', [...,] {});
+moduleFor('service:session', 'arg2', [...,] {});
 
 moduleForComponent('display-page');
 moduleForComponent('display-page', {
@@ -31,7 +31,7 @@ moduleForComponent('display-page', {
 moduleForComponent('display-page', {
   needs: ['type:thing']
 });
-moduleForComponent('thing', 'arg2', [...,] {});
+moduleForComponent('display-page', 'arg2', [...,] {});
 
 moduleForModel('post');
 moduleForModel('post', {
@@ -40,11 +40,38 @@ moduleForModel('post', {
 moduleForModel('post', {
   needs: ['type:thing']
 });
-moduleForModel('thing', 'arg2', [...,] {});
+moduleForModel('post', 'arg2', [...,] {});
 ```
 
 ```js
 // ember-mocha
+
+setupTest('service:session');
+setupTest('service:session', {
+  unit: true
+});
+setupTest('service:session', {
+  needs: ['type:thing']
+});
+moduleFor('arg1', 'arg2', [...,] {});
+
+setupComponentTest('display-page');
+setupComponentTest('display-page', {
+  unit: true
+});
+setupComponentTest('display-page', {
+  needs: ['type:thing']
+});
+setupComponentTest('display-page', 'arg2', [...,] {});
+
+setupModelTest('post');
+setupModelTest('post', {
+  unit: true
+});
+setupModelTest('post', {
+  needs: ['type:thing']
+});
+setupModelTest('post', 'arg2', [...,] {});
 ```
 
 Examples of **correct** code for this rule:
@@ -63,6 +90,23 @@ moduleForComponent('display-page', {
 moduleFor('service:session', {
   integration: true
 });
+```
+
+```js
+// ember-mocha
+
+setupTest('service:session', {
+  integration: true
+});
+
+setupComponentTest('display-page', {
+  integration: true
+});
+
+setupModelTest('post', {
+  integration: true
+});
+
 ```
 
 ## Further Reading

--- a/docs/rules/no-restricted-resolver-tests.md
+++ b/docs/rules/no-restricted-resolver-tests.md
@@ -1,0 +1,70 @@
+# Don't use constructs or configuration that use the restricted resolver in tests. (no-restricted-resolver-tests)
+
+[RFC-0229](https://github.com/emberjs/rfcs/blob/master/text/0229-deprecate-testing-restricted-resolver.md)
+proposed to remove the concept of artificially restricting the resolver used under testing. This rule helps
+identify anti-patterns in tests that we want to migrate off.
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+If `integration: true` is not included in the specified options for the APIs listed below. This specifically includes specifying `unit: true`, `needs: []`, or specifying none of the "test type options" (`unit`, `needs`,or `integration` options) to the following ember-qunit and ember-mocha API's:
+
+```js
+// ember-qunit
+
+moduleFor('service:session');
+moduleFor('service:session', {
+  unit: true
+});
+moduleFor('service:session', {
+  needs: ['type:thing']
+});
+moduleFor('arg1', 'arg2', [...,] {});
+
+moduleForComponent('display-page');
+moduleForComponent('display-page', {
+  unit: true
+});
+moduleForComponent('display-page', {
+  needs: ['type:thing']
+});
+moduleForComponent('thing', 'arg2', [...,] {});
+
+moduleForModel('post');
+moduleForModel('post', {
+  unit: true
+});
+moduleForModel('post', {
+  needs: ['type:thing']
+});
+moduleForModel('thing', 'arg2', [...,] {});
+```
+
+```js
+// ember-mocha
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// ember-qunit
+
+moduleFor('service:session', {
+  integration: true
+});
+
+moduleForComponent('display-page', {
+  integration: true
+});
+
+moduleFor('service:session', {
+  integration: true
+});
+```
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -43,7 +43,7 @@ function hasNeeds(node) {
   );
 }
 
-function hasIntegrationTrueProperty(node) {
+function hasIntegrationTrue(node) {
   return node.properties.some(
     property =>
     property.key.name === 'integration' && property.value.value === true
@@ -112,7 +112,7 @@ module.exports = {
 
         if (
           utils.isObjectExpression(lastArgument) &&
-          !hasIntegrationTrueProperty(lastArgument)
+          !hasIntegrationTrue(lastArgument)
         ) {
           context.report(
             lastArgument,

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -31,21 +31,22 @@ function hasOnlyStringArgument(node) {
 
 function hasUnitTrue(node) {
   return node.properties.some(
-    property => property.key.name === 'unit' && property.value.value === true
+    property =>
+    property.key.name === 'unit' && property.value.value === true
   );
 }
 
 function hasNeeds(node) {
   return node.properties.some(
     property =>
-      property.key.name === 'needs' && property.value.type === 'ArrayExpression'
+    property.key.name === 'needs' && property.value.type === 'ArrayExpression'
   );
 }
 
 function hasIntegrationTrue(node) {
   return node.properties.some(
     property =>
-      property.key.name === 'integration' && property.value.value === true
+    property.key.name === 'integration' && property.value.value === true
   );
 }
 
@@ -67,8 +68,7 @@ function getLastArgument(node) {
 module.exports = {
   meta: {
     docs: {
-      description:
-        'Prevents the use of patterns that use the restricted resolver in tests.',
+      description: 'Prevents the use of patterns that use the restricted resolver in tests.',
       category: 'Best Practices',
       recommended: false,
     },
@@ -91,8 +91,8 @@ module.exports = {
       'setupTest',
       'setupComponentTest',
       'setupModelTest',
-    ].forEach(fn => {
-      visitors[`Identifier[name="${fn}"]`] = function(node) {
+    ].forEach((fn) => {
+      visitors[`Identifier[name="${fn}"]`] = function (node) {
         const lastArgument = getLastArgument(node);
 
         if (hasOnlyStringArgument(node)) {

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -31,22 +31,21 @@ function hasOnlyStringArgument(node) {
 
 function hasUnitTrue(node) {
   return node.properties.some(
-    property =>
-    property.key.name === 'unit' && property.value.value === true
+    property => property.key.name === 'unit' && property.value.value === true
   );
 }
 
 function hasNeeds(node) {
   return node.properties.some(
     property =>
-    property.key.name === 'needs' && property.value.type === 'ArrayExpression'
+      property.key.name === 'needs' && property.value.type === 'ArrayExpression'
   );
 }
 
 function hasIntegrationTrue(node) {
   return node.properties.some(
     property =>
-    property.key.name === 'integration' && property.value.value === true
+      property.key.name === 'integration' && property.value.value === true
   );
 }
 
@@ -68,8 +67,9 @@ function getLastArgument(node) {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevents the use of `unit:true` in ember tests.',
-      category: 'Fill me in',
+      description:
+        'Prevents the use of patterns that use the restricted resolver in tests.',
+      category: 'Best Practices',
       recommended: false,
     },
     fixable: null, // or "code" or "whitespace",
@@ -77,8 +77,8 @@ module.exports = {
       getNoUnitTrueMessage,
       getNoNeedsMessage,
       getSingleStringArgumentMessage,
-      getNoPOJOWithoutIntegrationTrueMessage
-    }
+      getNoPOJOWithoutIntegrationTrueMessage,
+    },
   },
 
   create(context) {
@@ -90,9 +90,9 @@ module.exports = {
       'moduleForModel',
       'setupTest',
       'setupComponentTest',
-      'setupModelTest'
-    ].forEach((fn) => {
-      visitors[`Identifier[name="${fn}"]`] = function (node) {
+      'setupModelTest',
+    ].forEach(fn => {
+      visitors[`Identifier[name="${fn}"]`] = function(node) {
         const lastArgument = getLastArgument(node);
 
         if (hasOnlyStringArgument(node)) {

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const utils = require('../utils/utils');
+
+//------------------------------------------------------------------------------------------------
+// General Rule - Don't use constructs or configuration that use the restricted resolver in tests.
+//------------------------------------------------------------------------------------------------
+
+function getNoUnitTrueMessage(fn) {
+  return `Do not use ${fn} with \`unit: true\``;
+}
+
+function getNoNeedsMessage(fn) {
+  return `Do not use ${fn} with \`needs: [...]\``;
+}
+
+function getSingleStringArgumentMessage(fn) {
+  return `Do not use ${fn} with a single string argument (implies unit: true)`;
+}
+
+function getNoPOJOWithoutIntegrationTrueMessage(fn) {
+  return `Do not use ${fn} whose last parameter is an object unless used in conjunction wtih \`integration: true\``;
+}
+
+function hasOnlyStringArgument(node) {
+  const parentMethodCall = getParentCallExpression(node);
+  const args = parentMethodCall.arguments;
+
+  return args.length === 1 && utils.isLiteral(args[0]);
+}
+
+function hasUnitTrue(node) {
+  return node.properties.some(
+    property =>
+    property.key.name === 'unit' && property.value.value === true
+  );
+}
+
+function hasNeeds(node) {
+  return node.properties.some(
+    property =>
+    property.key.name === 'needs' && property.value.type === 'ArrayExpression'
+  );
+}
+
+function hasIntegrationTrueProperty(node) {
+  return node.properties.some(
+    property =>
+    property.key.name === 'integration' && property.value.value === true
+  );
+}
+
+function getParentCallExpression(node) {
+  return utils.getParent(node, parent => parent.type === 'CallExpression');
+}
+
+function getLastArgument(node) {
+  const parentMethodCall = utils.getParent(
+    node,
+    parent => parent.type === 'CallExpression'
+  );
+  const args = parentMethodCall.arguments;
+  const lastArgument = args[args.length - 1];
+
+  return lastArgument;
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevents the use of `unit:true` in ember tests.',
+      category: 'Fill me in',
+      recommended: false,
+    },
+    fixable: null, // or "code" or "whitespace",
+    messages: {
+      getNoUnitTrueMessage,
+      getNoNeedsMessage,
+      getSingleStringArgumentMessage,
+      getNoPOJOWithoutIntegrationTrueMessage
+    }
+  },
+
+  create(context) {
+    const visitors = {};
+
+    ['moduleFor', 'moduleForComponent', 'moduleForModel'].forEach((fn) => {
+      visitors[`Identifier[name="${fn}"]`] = function (node) {
+        const lastArgument = getLastArgument(node);
+
+        if (hasOnlyStringArgument(node)) {
+          context.report(node, getSingleStringArgumentMessage(fn));
+          return;
+        }
+
+        if (hasUnitTrue(lastArgument)) {
+          context.report(lastArgument, getNoUnitTrueMessage(fn));
+          return;
+        }
+
+        if (hasNeeds(lastArgument)) {
+          context.report(lastArgument, getNoNeedsMessage(fn));
+          return;
+        }
+
+        if (
+          utils.isObjectExpression(lastArgument) &&
+          !hasIntegrationTrueProperty(lastArgument)
+        ) {
+          context.report(
+            lastArgument,
+            getNoPOJOWithoutIntegrationTrueMessage(fn)
+          );
+        }
+      };
+    });
+
+    return visitors;
+  },
+};

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -84,7 +84,14 @@ module.exports = {
   create(context) {
     const visitors = {};
 
-    ['moduleFor', 'moduleForComponent', 'moduleForModel'].forEach((fn) => {
+    [
+      'moduleFor',
+      'moduleForComponent',
+      'moduleForModel',
+      'setupTest',
+      'setupComponentTest',
+      'setupModelTest'
+    ].forEach((fn) => {
       visitors[`Identifier[name="${fn}"]`] = function (node) {
         const lastArgument = getLastArgument(node);
 

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -1,0 +1,189 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-restricted-resolver-tests');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+const messages = rule.meta.messages;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-restricted-resolver-tests', rule, {
+  valid: [
+    {
+      code: `
+              moduleFor('service:session', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
+    {
+      code: `
+              moduleForComponent('display-page', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
+    {
+      code: `
+              moduleForModel('post', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+              moduleFor('service:session');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('moduleFor')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleFor('service:session', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('moduleFor')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleFor('service:session', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('moduleFor')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleFor('service:session', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleFor')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForComponent('display-page');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('moduleForComponent')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForComponent('display-page', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('moduleForComponent')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForComponent('display-page', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('moduleForComponent')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForComponent('display-page', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForComponent')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForModel('post');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('moduleForModel')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForModel('post', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('moduleForModel')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForModel('post', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('moduleForModel')
+        },
+      ],
+    },
+    {
+      code: `
+              moduleForModel('post', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForModel')
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -39,6 +39,30 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
             `,
       parserOptions,
     },
+    {
+      code: `
+              setupTest('service:session', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
+    {
+      code: `
+              setupComponentTest('display-page', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
+    {
+      code: `
+              setupModelTest('post', {
+                integration: true
+              });
+            `,
+      parserOptions,
+    },
   ],
   invalid: [
     {
@@ -182,6 +206,150 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForModel')
+        },
+      ],
+    },
+    {
+      code: `
+              setupTest('service:session');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('setupTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupTest('service:session', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('setupTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupTest('service:session', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('setupTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupTest('service:session', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupComponentTest('display-page');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('setupComponentTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupComponentTest('display-page', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('setupComponentTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupComponentTest('display-page', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('setupComponentTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupComponentTest('display-page', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupComponentTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupModelTest('post');
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getSingleStringArgumentMessage('setupModelTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupModelTest('post', {
+                unit: true
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoUnitTrueMessage('setupModelTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupModelTest('post', {
+                needs: ['type:thing']
+              });
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoNeedsMessage('setupModelTest')
+        },
+      ],
+    },
+    {
+      code: `
+              setupModelTest('post', arg2, {});
+            `,
+      parserOptions,
+      errors: [
+        {
+          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupModelTest')
         },
       ],
     },


### PR DESCRIPTION
[RFC-0229](https://github.com/emberjs/rfcs/blob/master/text/0229-deprecate-testing-restricted-resolver.md) proposed to remove the concept of artificially restricting the resolver used under testing. This rule helps identify anti-patterns in tests that we want to migrate off.

TODO
- [x] Add support for ember-mocha APIs