### PR TITLE
Add use-nested-qunit-syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | Disallow importing of "-test.js" in a test file and exporting from a test file. |
+|  | [use-nested-qunit-syntax](./docs/rules/use-nested-qunit-syntax.md) | Enforce use of module in tests |
 
 
 ### Stylistic Issues

--- a/docs/rules/use-nested-qunit-syntax.md
+++ b/docs/rules/use-nested-qunit-syntax.md
@@ -1,0 +1,33 @@
+# Affirms that nested QUnit syntax is being used (use-nested-qunit-syntax)
+
+The latest version of QUnit supports nested module syntax i.e. test() is invoked from a callback passed to module()
+
+## Rule Details
+
+This rule aims to enforce the new QUnit nested syntax.
+
+Examples of **incorrect** code for this rule:
+
+```js
+module('foo-bar');
+
+test('my foo-bar-test', function () {...})
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { module, test } from 'qunit';
+
+module('foo-bar', function () {
+  test('my foo-bar test', function (assert) {...})
+});
+```
+
+## When Not To Use It
+
+If you are not using >=ember-qunit@3.0.0
+
+## Further Reading
+
+https://github.com/emberjs/ember-qunit

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ module.exports = {
     'routes-segments-snake-case': require('./rules/routes-segments-snake-case'),
     'use-brace-expansion': require('./rules/use-brace-expansion'),
     'use-ember-get-and-set': require('./rules/use-ember-get-and-set'),
+    'use-nested-qunit-syntax': require('./rules/use-nested-qunit-syntax')
   },
   configs: {
     base: require('./config/base'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -37,5 +37,6 @@ module.exports = {
   "ember/require-super-in-init": "error",
   "ember/routes-segments-snake-case": "error",
   "ember/use-brace-expansion": "error",
-  "ember/use-ember-get-and-set": "off"
+  "ember/use-ember-get-and-set": "off",
+  "ember/use-nested-qunit-syntax": "off"
 }

--- a/lib/rules/use-nested-qunit-syntax.js
+++ b/lib/rules/use-nested-qunit-syntax.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const path = require('path');
+
+const messages = {
+  ONLY_USE_MODULE:
+    'Only module can be invoked from test files; imported from qunit',
+  TESTS_SHOULD_BE_NESTED:
+    "Test should be nested within module('test-name', function () { // tests go here })",
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforce use of module in tests',
+      category: 'Testing',
+      recommended: false,
+    },
+    fixable: null,
+    messages,
+  },
+
+  create(context) {
+    const filename = context.getFilename();
+    const isFileInTest =
+      /-test.js$/.test(filename) && filename.split(path.sep).includes('tests');
+
+    let moduleIsImportedFromQunit = false;
+    let qunitImportIdentifier;
+
+    if (!isFileInTest) {
+      return {};
+    }
+
+    return {
+      'ImportDeclaration[source.value = "qunit"]': function (node) {
+        node.specifiers.forEach((specifier) => {
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            qunitImportIdentifier = specifier.local.name;
+          } else if (specifier.local.name === 'module') {
+            moduleIsImportedFromQunit = true;
+          }
+        });
+      },
+
+      'Program > ExpressionStatement > CallExpression': function (node) {
+        if (node.callee.name === 'module' && moduleIsImportedFromQunit) {
+          return;
+        }
+
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.property.name === 'module' &&
+          qunitImportIdentifier === node.callee.object.name
+        ) {
+          return;
+        }
+
+        if (node.callee.name === 'test') {
+          context.report(node.callee, messages.TESTS_SHOULD_BE_NESTED);
+        } else {
+          context.report(node.callee, messages.ONLY_USE_MODULE);
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/use-nested-qunit-syntax.js
+++ b/tests/lib/rules/use-nested-qunit-syntax.js
@@ -1,0 +1,122 @@
+const path = require('path');
+const rule = require('../../../lib/rules/use-nested-qunit-syntax');
+const RuleTester = require('eslint').RuleTester;
+
+const messages = rule.meta.messages;
+const testLocation = path.join('tests', 'unit', 'my-unit-test.js');
+const nonTestLocation = path.join('app', 'components', 'my-component.js');
+
+const eslintTester = new RuleTester({
+  parserOptions: { sourceType: 'module' },
+});
+
+eslintTester.run('use-nested-qunit-syntax', rule, {
+  valid: [
+    {
+      code: `
+        moduleFor('foo-bar');
+      `,
+      filename: nonTestLocation,
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+        module('foo-bar');
+      `,
+      filename: testLocation,
+    },
+    {
+      code: `
+        import { module } from 'qunit';
+        module('foo-bar', function() {
+          setupTest(hooks);
+        });
+      `,
+      filename: testLocation,
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+        import badTestPractice from 'some-confusing-location';
+
+        module('bad test invocations', badTestPractice())
+      `,
+      filename: testLocation
+    },
+    {
+      code: `
+        import QUnit from 'qunit';
+
+        QUnit.module('some-test', function () {});
+      `,
+      filename: testLocation
+    },
+    {
+      code: `
+        import FooUnit from 'qunit';
+
+        FooUnit.module('some-test', function () {});
+      `,
+      filename: testLocation
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        moduleFor('foo-bar');
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.ONLY_USE_MODULE }],
+    },
+    {
+      code: `
+        module('foo-bar');
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.ONLY_USE_MODULE }],
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('some-test');
+
+        test('this is a test', function () {});
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.TESTS_SHOULD_BE_NESTED }]
+    },
+    {
+      code: `
+        QUnit.module('some-test', function () {});
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.ONLY_USE_MODULE }]
+    },
+    {
+      code: `
+        import { module } from 'some-weird-place';
+
+        module('foo-bar', function() {
+          test('sneh', function(assert) {
+            assert.ok(true);
+          })
+        });
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.ONLY_USE_MODULE }]
+    },
+    {
+      code: `
+        import { module } from 'qunit';
+        import fooBar from 'foo-bar';
+
+        fooBar();
+
+        module('foo-bar', function () {});
+      `,
+      filename: testLocation,
+      errors: [{ message: messages.ONLY_USE_MODULE }]
+    }
+  ],
+});


### PR DESCRIPTION
This is the first rule in a series that will support the new qunit nested
syntax as implemented in ember-qunit@3