### PR TITLE
Adds rules for foo: A() and foo: EmberObject.create

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -30,6 +30,28 @@ export default Foo.extend({
     },
   },
 });
+
+// BAD
+export default Foo.extend({
+  items: A(),
+
+  actions: {
+    addItem(item) {
+      this.get('items').pushObject(item);
+    },
+  },
+});
+
+// BAD
+export default Foo.extend({
+  someObj: EmberObject.create({ bar: null }),
+
+  actions: {
+    chamgeProp(val) {
+      this.set('someObj.bar', val);
+    },
+  },
+});
 ```
 
 ```javascript

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -3,6 +3,8 @@
 const ember = require('../utils/ember');
 const utils = require('../utils/utils');
 
+let emberImportAliasName;
+
 const DEFAULT_IGNORED_PROPERTIES = [
   'classNames',
   'classNameBindings',
@@ -14,6 +16,45 @@ const DEFAULT_IGNORED_PROPERTIES = [
   'queryParams',
   'attrs',
 ];
+
+const isEmberObjectCall = function (value) {
+  const callee = value.callee;
+
+  const isEmberObject = (utils.isMemberExpression(callee) &&
+    utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
+    utils.isIdentifier(callee.property) && callee.property.name === 'Object');
+
+  const isEmberObjectCreate = (utils.isMemberExpression(callee) &&
+    utils.isIdentifier(callee.object) && callee.object.name === 'EmberObject' &&
+    utils.isIdentifier(callee.property) && callee.property.name === 'create');
+
+  return callee.name === 'Object' ||
+    callee.name === 'EmberObject' ||
+    isEmberObject ||
+    isEmberObjectCreate;
+};
+
+const isEmberArrayCall = function (value) {
+  const callee = value.callee;
+  return (callee.name === 'A') ||
+    (utils.isMemberExpression(callee) &&
+    utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
+    utils.isIdentifier(callee.property) && callee.property.name === 'A');
+};
+
+const isAllowed = function (property) {
+  const value = property.value;
+
+  return ember.isFunctionExpression(value) ||
+    utils.isLiteral(value) ||
+    utils.isIdentifier(value) ||
+    (utils.isCallExpression(value) && !isEmberArrayCall(value) && !isEmberObjectCall(value)) ||
+    utils.isBinaryExpression(value) ||
+    utils.isTemplateLiteral(value) ||
+    utils.isTaggedTemplateExpression(value) ||
+    utils.isMemberExpression(value) ||
+    utils.isUnaryExpression(value);
+};
 
 //------------------------------------------------------------------------------
 // Ember object rule - Avoid leaking state
@@ -38,47 +79,6 @@ module.exports = {
   DEFAULT_IGNORED_PROPERTIES,
 
   create(context) {
-    let emberImportAliasName;
-
-    const isEmberObjectCall = function (value) {
-      const callee = value.callee;
-
-      const isEmberObject = (utils.isMemberExpression(callee) &&
-        utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
-        utils.isIdentifier(callee.property) && callee.property.name === 'Object');
-
-      const isEmberObjectCreate = (utils.isMemberExpression(callee) &&
-        utils.isIdentifier(callee.object) && callee.object.name === 'EmberObject' &&
-        utils.isIdentifier(callee.property) && callee.property.name === 'create');
-
-      return callee.name === 'Object' ||
-        callee.name === 'EmberObject' ||
-        isEmberObject ||
-        isEmberObjectCreate;
-    };
-
-    const isEmberArrayCall = function (value) {
-      const callee = value.callee;
-      return (callee.name === 'A') ||
-        (utils.isMemberExpression(callee) &&
-        utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
-        utils.isIdentifier(callee.property) && callee.property.name === 'A');
-    };
-
-    const isAllowed = function (property) {
-      const value = property.value;
-
-      return ember.isFunctionExpression(value) ||
-        utils.isLiteral(value) ||
-        utils.isIdentifier(value) ||
-        (utils.isCallExpression(value) && !isEmberArrayCall(value) && !isEmberObjectCall(value)) ||
-        utils.isBinaryExpression(value) ||
-        utils.isTemplateLiteral(value) ||
-        utils.isTaggedTemplateExpression(value) ||
-        utils.isMemberExpression(value) ||
-        utils.isUnaryExpression(value);
-    };
-
     const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
 
     const report = function (node) {

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -15,20 +15,6 @@ const DEFAULT_IGNORED_PROPERTIES = [
   'attrs',
 ];
 
-const isAllowed = function (property) {
-  const value = property.value;
-  return ember.isFunctionExpression(value) ||
-    utils.isLiteral(value) ||
-    utils.isIdentifier(value) ||
-    utils.isCallExpression(value) ||
-    utils.isBinaryExpression(value) ||
-    utils.isTemplateLiteral(value) ||
-    utils.isTaggedTemplateExpression(value) ||
-    utils.isMemberExpression(value) ||
-    utils.isUnaryExpression(value);
-};
-
-
 //------------------------------------------------------------------------------
 // Ember object rule - Avoid leaking state
 // (Don't use arrays or objects as default props)
@@ -52,6 +38,47 @@ module.exports = {
   DEFAULT_IGNORED_PROPERTIES,
 
   create(context) {
+    let emberImportAliasName;
+
+    const isEmberObjectCall = function (value) {
+      const callee = value.callee;
+
+      const isEmberObject = (utils.isMemberExpression(callee) &&
+        utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
+        utils.isIdentifier(callee.property) && callee.property.name === 'Object');
+
+      const isEmberObjectCreate = (utils.isMemberExpression(callee) &&
+        utils.isIdentifier(callee.object) && callee.object.name === 'EmberObject' &&
+        utils.isIdentifier(callee.property) && callee.property.name === 'create');
+
+      return callee.name === 'Object' ||
+        callee.name === 'EmberObject' ||
+        isEmberObject ||
+        isEmberObjectCreate;
+    };
+
+    const isEmberArrayCall = function (value) {
+      const callee = value.callee;
+      return (callee.name === 'A') ||
+        (utils.isMemberExpression(callee) &&
+        utils.isIdentifier(callee.object) && (callee.object.name === 'Ember' || callee.object.name === emberImportAliasName) &&
+        utils.isIdentifier(callee.property) && callee.property.name === 'A');
+    };
+
+    const isAllowed = function (property) {
+      const value = property.value;
+
+      return ember.isFunctionExpression(value) ||
+        utils.isLiteral(value) ||
+        utils.isIdentifier(value) ||
+        (utils.isCallExpression(value) && !isEmberArrayCall(value) && !isEmberObjectCall(value)) ||
+        utils.isBinaryExpression(value) ||
+        utils.isTemplateLiteral(value) ||
+        utils.isTaggedTemplateExpression(value) ||
+        utils.isMemberExpression(value) ||
+        utils.isUnaryExpression(value);
+    };
+
     const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
 
     const report = function (node) {
@@ -60,6 +87,12 @@ module.exports = {
     };
 
     return {
+      ImportDeclaration(node) {
+        if (!emberImportAliasName) {
+          emberImportAliasName = ember.getEmberImportAliasName(node);
+        }
+      },
+
       CallExpression(node) {
         if (!(ember.isEmberObject(node) || ember.isReopenObject(node))) return;
 

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -141,6 +141,24 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
       }],
     },
     {
+      code: 'export default Foo.extend({someProp: A()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
+      code: 'export default Foo.extend({someProp: Ember.A()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
+      code: 'import EmberFoo from "ember"; export default Foo.extend({someProp: EmberFoo.A()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
       code: 'export default Foo.extend({someProp: {}});',
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
@@ -158,7 +176,30 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
-
+    {
+      code: 'export default Foo.extend({someProp: Ember.Object()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
+      code: 'import EmberFoo from "ember"; export default Foo.extend({someProp: EmberFoo.Object()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
+      code: 'export default Foo.extend({someProp: EmberObject.create()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
+    {
+      code: 'export default Foo.extend({someProp: Object()});',
+      errors: [{
+        message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+      }],
+    },
     {
       code: 'export default Foo.extend(SomeMixin, { derp: [] });',
       errors: [{


### PR DESCRIPTION
#300 

Adds warnings for: 
 - someArray: A()
 - someArray: Ember.A()
 - someArray: EmberAlias.A()
 - someProp: Object()
 - someProp: EmberObject.create({...})
 