### PR TITLE
use-brace-expansion: Limit lint rule to only trigger for `computed()` but no other macros

### DIFF
--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -27,7 +27,9 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!ember.isComputedProp(node)) return;
+        if (!ember.isComputedProp(node) || utils.isMemberExpression(node.callee)) {
+          return;
+        }
 
         const matchesBraces = x => !!x.match(/[{}]/g);
         const hasBraces = arr => arr.some(matchesBraces);

--- a/tests/lib/rules/use-brace-expansion.js
+++ b/tests/lib/rules/use-brace-expansion.js
@@ -19,6 +19,8 @@ eslintTester.run('use-brace-expansion', rule, {
     { code: '{ test: computed("a.{test,test2}", "c", "b", function() {}) }' },
     { code: '{ test: computed("model.a.{test,test2}", "model.b.{test3,test4}", function() {}) }' },
     { code: '{ test: computed("foo.bar.{name,place}", "foo.qux.[]", "foo.baz.{thing,@each.stuff}", function() {}) }' },
+    { code: '{ test: computed.or("foo.bar.name", "foo.bar.place") }' },
+    { code: '{ test: computed.and("foo.bar.name", "foo.bar.place") }' },
     { code: "{ test: Ember.computed.filterBy('a', 'b', false) }" },
   ],
   invalid: [
@@ -56,6 +58,12 @@ eslintTester.run('use-brace-expansion', rule, {
       code: '{ test: computed("a.{test,test2}", "a.test3", function() {}) }',
       errors: [{
         message: 'Use brace expansion',
+      }],
+    },
+    {
+      code: '{ test: computed("a.test", "a.test2", function() {}).volatile() }',
+      errors: [{
+        message: 'Use brace expansion'
       }],
     },
   ],


### PR DESCRIPTION
Fixes #330.