### PR TITLE
package.json: Limit published files to the `lib` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "6.0.0",
   "description": "Eslint plugin for Ember.js apps",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "directories": {
     "rules": "rules",
     "test": "test"


### PR DESCRIPTION
We should avoid publishing unnecessarily large packages that include the `tests` folder and files like `.editorconfig` for no good reason.