### PR TITLE
CI: Use `--runInBand` option of Jest to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: yarn
 
 script:
   - yarn run lint
-  - yarn run test:coverage
+  - yarn run test:coverage --runInBand
 
 before_deploy:
   - yarn global add auto-dist-tag


### PR DESCRIPTION
TravisCI reports incorrect CPU count numbers which cause Jest to be a lot slower than it should be