### PR TITLE
new-module-imports rule: avoid missing forEach

### DIFF
--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -37,7 +37,7 @@ module.exports = {
         // Filter out non-Ember variable declarations
         if (!node.init || node.init.name !== 'Ember') return;
 
-        const properties = node.id.properties;
+        const properties = node.id.properties || [];
         // Iterate through the destructured properties and report them
         properties.forEach((item) => {
           // Locate nested destructuring


### PR DESCRIPTION
This PR defaults a value in a rule. The value is "`properties` on a `node.id`." If we can't find properties, we probably can't find any nested destructuring either. So, the default is the empty list.

## Pros:

  - this avoids a crash and allows the report to be printed

## Cons:

  - I don't yet have tests for this

## What I tried

`eslint .` failed in my large Ember + coffeescript app.

I opened the Rule and experimented with it: this got me some output before the error:

```js
        const properties = node.id.properties;
        if (!properties) {
          console.log(node.init.name, node);
        }
```

And from there, I fiddled around (image: dog-at-keyboard).
