### PR TITLE
no-restricted-resolver: Fix crashes

### DIFF
--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -92,7 +92,7 @@ module.exports = {
       'setupComponentTest',
       'setupModelTest',
     ].forEach((fn) => {
-      visitors[`Identifier[name="${fn}"]`] = function (node) {
+      visitors[`CallExpression > Identifier[name="${fn}"]`] = function (node) {
         if (hasOnlyStringArgument(node)) {
           context.report(node, getSingleStringArgumentMessage(fn));
           return;

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -71,6 +71,10 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
             `,
       parserOptions,
     },
+    {
+      code: 'import { setupTest } from \'ember-qunit\';',
+      parserOptions,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
`hasUnitTrue()` assumes that the passed in node is an object expression, but we did not check that it actually is. This PR changes the code logic to ensure it is an object expression before passing it to the `hasUnitTrue()` and `hasNeeds()` functions.

Resolves #337 

/cc @amk221 @gmurphey 