### PR TITLE
Fix typo on getNoPOJOWithoutIntegrationTrueMessage

### DIFF
--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -19,7 +19,7 @@ function getSingleStringArgumentMessage(fn) {
 }
 
 function getNoPOJOWithoutIntegrationTrueMessage(fn) {
-  return `Do not use ${fn} whose last parameter is an object unless used in conjunction wtih \`integration: true\``;
+  return `Do not use ${fn} whose last parameter is an object unless used in conjunction with \`integration: true\``;
 }
 
 function hasOnlyStringArgument(node) {


### PR DESCRIPTION
This PR fixes a small typo on `getNoPOJOWithoutIntegrationTrueMessage`