### PR TITLE
Update avoid-leaking-state-in-ember-objects.md

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -37,7 +37,9 @@ export default Foo.extend({
 export default Foo.extend({
   init() {
     this._super(...arguments);
-    this.items = [];
+    if (!this.items) {
+      this.items = [];
+    }
   },
 
   actions: {


### PR DESCRIPTION
The current suggestion actually changes the behavior. We should only set if there is no value, so this setter acts as a default (in line with current behavior).