### PR TITLE
Update avoid-leaking-state-in-ember-objects.md

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -7,7 +7,10 @@
 Example configuration:
 
 ```
+const { DEFAULT_IGNORED_PROPERTIES } = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
+
 ember/avoid-leaking-state-in-ember-objects: [1, [
+  ...DEFAULT_IGNORED_PROPERTIES,
   'array',
   'of',
   'ignored',


### PR DESCRIPTION
Add DEFAULT_IGNORED_PROPERTIES when configuring the `avoid-leaking-state-in-ember-objects` in .eslintrc.js