### PR TITLE
assert-arg-order: Fix rule for `Ember.assert()` case

### DIFF
--- a/lib/rules/assert-arg-order.js
+++ b/lib/rules/assert-arg-order.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('../utils/utils');
+const emberUtils = require('../utils/ember');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -43,8 +44,8 @@ function isAssertFunctionWithReversedArgs(node) {
 }
 
 function isAssertFunction(node) {
-  const callee = node.callee;
-  return utils.isCallExpression(node) && utils.isIdentifier(callee) && callee.name === 'assert';
+  // Detect `Ember.assert()` or `assert()`.
+  return emberUtils.isModule(node, 'assert');
 }
 
 function isString(node) {

--- a/tests/lib/rules/assert-arg-order.js
+++ b/tests/lib/rules/assert-arg-order.js
@@ -23,10 +23,22 @@ ruleTester.run('assert-arg-order', rule, {
       code: "myFunction(true, 'My string.');"
     },
     {
+      code: "Ember.myFunction(true, 'My string.');"
+    },
+    {
+      code: "OtherClass.assert(true, 'My string.');"
+    },
+    {
       code: "assert('My description.');"
     },
     {
+      code: "Ember.assert('My description.');"
+    },
+    {
       code: "assert('My description.', true);"
+    },
+    {
+      code: "Ember.assert('My description.', true);"
     },
     {
       code: "const CONDITION = true; assert('My description.', CONDITION);"
@@ -41,6 +53,10 @@ ruleTester.run('assert-arg-order', rule, {
   invalid: [
     {
       code: "assert(true, 'My description.');",
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    },
+    {
+      code: "Ember.assert(true, 'My description.');",
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {


### PR DESCRIPTION
Detect incorrect usages of `Ember.assert()` (in addition to just `assert()`) for rule `assert-arg-order`.