### PR TITLE
feat: use dynamic error message for 'no-invalid-debug-function-arguments' rule.

### DIFF
--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -7,7 +7,10 @@ const emberUtils = require('../utils/ember');
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = "Usage of Ember's `assert` / `warn` / `deprecate` function has its arguments passed in the wrong order. `String description` should come before `Boolean condition`.";
+function getErrorMessage(debugFunction) {
+  return `Usage of Ember's \`${debugFunction}\` function has its arguments passed in the wrong order. \`String description\` should come before \`Boolean condition\`.`;
+}
+
 const DEBUG_FUNCTIONS = ['assert', 'deprecate', 'warn'];
 
 module.exports = {
@@ -20,7 +23,7 @@ module.exports = {
     fixable: null
   },
 
-  ERROR_MESSAGE,
+  getErrorMessage,
   DEBUG_FUNCTIONS,
 
   create(context) {
@@ -29,7 +32,7 @@ module.exports = {
         if (isDebugFunctionWithReversedArgs(node)) {
           context.report({
             node,
-            message: ERROR_MESSAGE
+            message: getErrorMessage(getDebugFunction(node))
           });
         }
       }
@@ -47,8 +50,11 @@ function isDebugFunctionWithReversedArgs(node) {
 }
 
 function isDebugFunction(node) {
-  // Example: Detects `Ember.assert()` or `assert()`.
-  return DEBUG_FUNCTIONS.some(debugFunction => emberUtils.isModule(node, debugFunction));
+  return getDebugFunction(node) !== undefined;
+}
+
+function getDebugFunction(node) {
+  return DEBUG_FUNCTIONS.find(debugFunction => emberUtils.isModule(node, debugFunction));
 }
 
 function isString(node) {

--- a/tests/lib/rules/no-invalid-debug-function-arguments.js
+++ b/tests/lib/rules/no-invalid-debug-function-arguments.js
@@ -5,7 +5,7 @@
 const rule = require('../../../lib/rules/no-invalid-debug-function-arguments');
 const RuleTester = require('eslint').RuleTester;
 
-const { DEBUG_FUNCTIONS, ERROR_MESSAGE } = rule;
+const { DEBUG_FUNCTIONS, getErrorMessage } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -67,31 +67,31 @@ const VALID_USAGES = [
 const INVALID_USAGES = flatten(DEBUG_FUNCTIONS.map(debugFunction => [
   {
     code: `${debugFunction}(true, 'My description.');`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `Ember.${debugFunction}(true, 'My description.');`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `${debugFunction}(true, 'My description.', { id: 'some-id' });`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `Ember.${debugFunction}(true, 'My description.', { id: 'some-id' });`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `${debugFunction}(true, \`My \${123} description.\`);`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `const CONDITION = true; ${debugFunction}(CONDITION, 'My description.');`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `const CONDITION = true; ${debugFunction}(CONDITION, \`My \${123} description.\`);`,
-    errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   }
 ]));
 


### PR DESCRIPTION
Error message (before):
```
Usage of Ember's `assert` / `warn` / `deprecate` function has its arguments passed in the wrong order. `String description` should come before `Boolean condition`."
```
Error message (after):
```
Usage of Ember's `assert` function has its arguments passed in the wrong order. `String description` should come before `Boolean condition`."
```

Requested by @Turbo87: https://github.com/ember-cli/eslint-plugin-ember/pull/364#issuecomment-450449647