### PR TITLE
no-invalid-debug-function-arguments: Fix false positives

### DIFF
--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -54,7 +54,10 @@ function isDebugFunction(node) {
 }
 
 function getDebugFunction(node) {
-  return DEBUG_FUNCTIONS.find(debugFunction => emberUtils.isModule(node, debugFunction));
+  return DEBUG_FUNCTIONS.find(debugFunction =>
+    emberUtils.isModule(node, debugFunction) &&
+      (!node.callee.property || node.callee.property.name === debugFunction)
+  );
 }
 
 function isString(node) {

--- a/tests/lib/rules/no-invalid-debug-function-arguments.js
+++ b/tests/lib/rules/no-invalid-debug-function-arguments.js
@@ -56,6 +56,12 @@ const VALID_USAGES_FOR_EACH_DEBUG_FUNCTION = flatten(DEBUG_FUNCTIONS.map(debugFu
   },
   {
     code: `const DESCRIPTION = 'description'; const CONDITION = true; ${debugFunction}(DESCRIPTION, CONDITION);`
+  },
+  {
+    code: `${debugFunction}.unrelatedFunction(true, 'My description.');`
+  },
+  {
+    code: `Ember.${debugFunction}.unrelatedFunction(true, 'My description.');`
   }
 ]));
 


### PR DESCRIPTION
Update rule to ignore unrelated function calls underneath one of the debug functions.

For example, we want to ignore calls that look like:
* `assert.ok(...)`
* `assert.equal(...)`

We only care about calls that look like: 
* `assert(...)`
* `Ember.assert(...)`