### PR TITLE
no-invalid-debug-function-arguments: Fix false positives

### DIFF
--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -22,7 +22,7 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        if (emberUtils.isComputedProp(node)) {
+        if (emberUtils.isComputedProp(node) && (!node.callee.property || node.callee.property.name === 'computed')) {
           emberUtils.parseDependentKeys(node).forEach((key) => {
             const parts = key.split('.');
             const indexOfAtEach = parts.indexOf('@each');

--- a/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -16,27 +16,35 @@ ruleTester.run('no-deeply-nested-dependent-keys-with-each', rule, {
   valid: [
     'Ember.computed(function() {})',
     "Ember.computed('foo', function() {})",
+    "Ember.computed('foo', function() {}).readOnly()",
     "Ember.computed('foo.bar', function() {})",
     "Ember.computed('foo.bar.@each.baz', function() {})",
     "Ember.computed('foo.@each.bar', function() {})",
     "Ember.computed('foo.@each.{bar,baz}', function() {})",
     'computed(function() {})',
     "computed('foo', function() {})",
+    "computed('foo', function() {}).readOnly()",
     "computed('foo.bar', function() {})",
     "computed('foo.bar.@each.baz', function() {})",
     "computed('foo.@each.bar', function() {})",
     "computed('foo.@each.{bar,baz}', function() {})",
     "computed('foo.@each.{bar,baz}', function() {})",
 
-    // Not Ember's `computed`:
+    // Not Ember's `computed` function:
     "otherClass.computed('foo.@each.bar.baz', function() {})",
     "otherClass.myFunction('foo.@each.bar.baz', function() {})",
     "myFunction('foo.@each.bar.baz', function() {})",
-    "Ember.myFunction('foo.@each.bar.baz', function() {})"
+    "Ember.myFunction('foo.@each.bar.baz', function() {})",
+    "computed.unrelatedFunction('foo.@each.bar.baz', function() {})",
+    "Ember.computed.unrelatedFunction('foo.@each.bar.baz', function() {})"
   ],
   invalid: [
     {
       code: "Ember.computed('foo.@each.bar.baz', function() {})",
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    },
+    {
+      code: "Ember.computed('foo.@each.bar.baz', function() {}).readOnly()",
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
@@ -49,6 +57,10 @@ ruleTester.run('no-deeply-nested-dependent-keys-with-each', rule, {
     },
     {
       code: "computed('foo.@each.bar.baz', function() {})",
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
+    },
+    {
+      code: "computed('foo.@each.bar.baz', function() {}).readOnly()",
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {


### PR DESCRIPTION
Update rule to ignore unrelated function calls underneath `computed`.

For example, we want to ignore calls that look like:

* `computed.equal(...)`
* `Ember.computed.readOnly(...)`

We only care about calls that look like:

* `computed(...)`
* `Ember.computed(...)`