### PR TITLE
fix: update 'no-test-and-then' rule to only run on test files.

### DIFF
--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('../utils/utils');
+const emberUtils = require('../utils/ember');
 
 const ERROR_MESSAGE = 'Use `await` instead of `andThen` test wait helper.';
 
@@ -22,6 +23,10 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
+        if (!emberUtils.isTestFile(context.getFilename())) {
+          return;
+        }
+
         const callee = node.callee;
         if (utils.isIdentifier(callee) && callee.name === 'andThen') {
           context.report({

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const emberUtils = require('../utils/ember');
+
 const NO_IMPORT_MESSAGE
   = 'Do not import from a test file (a file ending in "-test.js") in another test file. Doing so will cause the module and tests from the imported file to be executed again.';
 
@@ -24,8 +26,7 @@ module.exports = {
 
   create: function create(context) {
     const noExports = function (node) {
-      const fileName = context.getFilename();
-      if (!fileName.endsWith('-test.js')) {
+      if (!emberUtils.isTestFile(context.getFilename())) {
         return;
       }
 

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -6,6 +6,7 @@ module.exports = {
   isDSModel,
   isModule,
   isModuleByFilePath,
+  isTestFile,
 
   isEmberCoreModule,
   isEmberComponent,
@@ -107,6 +108,10 @@ function isModuleByFilePath(filePath, module) {
 
   /* Check both folder and filename to support both classic and POD's structure */
   return filePath.indexOf(fileName) > -1 || filePath.indexOf(folderName) > -1;
+}
+
+function isTestFile(fileName) {
+  return fileName.endsWith('-test.js');
 }
 
 function isEmberCoreModule(node, module, filePath) {

--- a/tests/lib/rules/no-test-and-then.js
+++ b/tests/lib/rules/no-test-and-then.js
@@ -18,17 +18,30 @@ const ruleTester = new RuleTester({
   }
 });
 
+const TEST_FILE_NAME = 'some-test.js';
+
 ruleTester.run('no-test-and-then', rule, {
   valid: [
     {
+      filename: TEST_FILE_NAME,
       code: "run(() => { console.log('Hello World.'); });"
     },
     {
+      filename: TEST_FILE_NAME,
       code: 'myCustomClass.andThen(myFunction);'
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: 'andThen.otherFunction(myFunction);'
+    },
+    {
+      filename: 'not-a-test-file.js',
+      code: 'andThen(() => { assert.ok(myBool); });'
     }
   ],
   invalid: [
     {
+      filename: TEST_FILE_NAME,
       code: 'andThen(() => { assert.ok(myBool); });',
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     }

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -82,6 +82,20 @@ describe('isModuleByFilePath', () => {
   });
 });
 
+describe('isTestFile', () => {
+  it('detects test files', () => {
+    const fileName = 'some-test.js';
+    expect(emberUtils.isTestFile(fileName)).toBeTruthy();
+  });
+
+  it('does not detect other files', () => {
+    expect(emberUtils.isTestFile('some-component.js')).toBeFalsy();
+    expect(emberUtils.isTestFile('my-testing-component.js')).toBeFalsy();
+    expect(emberUtils.isTestFile('router.js')).toBeFalsy();
+    expect(emberUtils.isTestFile('my-test.html')).toBeFalsy();
+  });
+});
+
 describe('isEmberCoreModule', () => {
   it('should check if current file is a component', () => {
     const node = parse('CustomComponent.extend()');


### PR DESCRIPTION
I'm assuming it's best practice to have the test-focused rules only run on test files (determined based on the filename).