### PR TITLE
no-test-and-then: slight optimization

### DIFF
--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -21,12 +21,12 @@ module.exports = {
   },
 
   create(context) {
+    if (!emberUtils.isTestFile(context.getFilename())) {
+      return {};
+    }
+
     return {
       CallExpression(node) {
-        if (!emberUtils.isTestFile(context.getFilename())) {
-          return;
-        }
-
         const callee = node.callee;
         if (utils.isIdentifier(callee) && callee.name === 'andThen') {
           context.report({


### PR DESCRIPTION
The filename only needs to be checked once per file. We don't need to check it while traversing the AST.