### PR TITLE
test: add null output assertions for lint rules / test cases with no autofixer.

### DIFF
--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -121,6 +121,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -128,6 +129,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend({resetPassword: service()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -135,6 +137,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend({resetPassword: inject.service()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -142,6 +145,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend({resetPassword: Ember.inject.service()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -149,6 +153,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend(TestMixin, {});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -156,6 +161,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -164,6 +170,7 @@ eslintTester.run('alias-model-in-controller', rule, {
       filename: 'example-app/controllers/path/to/some-feature.js',
       code: 'export default CustomController.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -172,6 +179,7 @@ eslintTester.run('alias-model-in-controller', rule, {
       filename: 'example-app/some-feature/controller.js',
       code: 'export default CustomController.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],
@@ -180,6 +188,7 @@ eslintTester.run('alias-model-in-controller', rule, {
       filename: 'example-app/twisted-path/some-file.js',
       code: 'export default Controller.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Alias your model',
       }],

--- a/tests/lib/rules/avoid-leaking-state-in-components.js
+++ b/tests/lib/rules/avoid-leaking-state-in-components.js
@@ -49,6 +49,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: []});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using arrays as default properties',
       }],
@@ -56,6 +57,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: new Ember.A()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using arrays as default properties',
       }],
@@ -63,6 +65,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: new A()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using arrays as default properties',
       }],
@@ -70,6 +73,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: {}});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using objects as default properties',
       }],
@@ -77,6 +81,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: new Ember.Object()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using objects as default properties',
       }],
@@ -84,6 +89,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
     {
       code: 'export default Component.extend({someProp: new Object()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using objects as default properties',
       }],
@@ -92,6 +98,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
       filename: 'example-app/components/some-component.js',
       code: 'export default CustomComponent.extend({someProp: []});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using arrays as default properties',
       }],
@@ -100,6 +107,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
       filename: 'example-app/components/some-component/component.js',
       code: 'export default CustomComponent.extend({someProp: new A()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using arrays as default properties',
       }],
@@ -108,6 +116,7 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
       filename: 'example-app/twisted-path/some-file.js',
       code: 'export default Component.extend({someProp: {}});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Avoid using objects as default properties',
       }],

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -127,36 +127,42 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
   invalid: [
     {
       code: 'export default Foo.extend({someProp: []});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({someProp: new Ember.A()});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({someProp: new A()});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({someProp: {}});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({someProp: new Ember.Object()});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({someProp: new Object()});',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
@@ -164,24 +170,28 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
 
     {
       code: 'export default Foo.extend(SomeMixin, { derp: [] });',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.extend({ badThing: new Set() });',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: "export default Foo['extend']({ otherThing: {} });",
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],
     },
     {
       code: 'export default Foo.reopen({ otherThing: {} });',
+      output: null,
       errors: [{
         message: 'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
       }],

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -39,24 +39,28 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
   invalid: [
     {
       code: 'export default Controller.extend({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
     },
     {
       code: 'Controller.reopenClass({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
     },
     {
       code: 'Controller.reopen({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
     },
     {
       code: "export default Controller['extend']({ needs: [] });",
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
@@ -64,6 +68,7 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
     {
       filename: 'example-app/controllers/some-controller.js',
       code: 'export default FooController.extend({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
@@ -71,6 +76,7 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
     {
       filename: 'example-app/controllers/some-controller.js',
       code: 'FooController.reopenClass({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
@@ -78,6 +84,7 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
     {
       filename: 'example-app/controllers/some-controller.js',
       code: 'FooController.reopen({ needs: [] });',
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],
@@ -85,6 +92,7 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
     {
       filename: 'example-app/controllers/some-controller.js',
       code: "export default FooController['extend']({ needs: [] });",
+      output: null,
       errors: [{
         message: '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
       }],

--- a/tests/lib/rules/closure-actions.js
+++ b/tests/lib/rules/closure-actions.js
@@ -25,6 +25,7 @@ eslintTester.run('closure-actions', rule, {
     {
       code: 'export default Component.extend({actions: {pushLever() {this.sendAction("detonate");}}});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use closure actions, unless you need bubbling',
       }],

--- a/tests/lib/rules/jquery-ember-run.js
+++ b/tests/lib/rules/jquery-ember-run.js
@@ -21,6 +21,7 @@ eslintTester.run('jquery-ember-run', rule, {
     {
       code: 'Ember.$("#something-rendered-by-jquery-plugin").on("click", () => {this._handlerActionFromController();});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use jQuery without Ember Run Loop',
       }],

--- a/tests/lib/rules/local-modules.js
+++ b/tests/lib/rules/local-modules.js
@@ -41,6 +41,7 @@ eslintTester.run('local-modules', rule, {
     {
       code: 'export default DS.Model.extend({})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         {
           message: 'Create local version of DS.Model',
@@ -50,6 +51,7 @@ eslintTester.run('local-modules', rule, {
     {
       code: 'export default Ember.Route.extend({});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         {
           message: 'Create local version of Ember.Route',
@@ -59,6 +61,7 @@ eslintTester.run('local-modules', rule, {
     {
       code: 'title: DS.attr("string")',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         {
           message: 'Create local version of DS.attr',
@@ -68,6 +71,7 @@ eslintTester.run('local-modules', rule, {
     {
       code: 'title: Ember.computed.alias("test")',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         {
           message: 'Create local version of Ember.computed',

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -69,18 +69,21 @@ eslintTester.run('named-functions-in-promises', rule, {
     {
       code: 'user.save().then(() => {return user.reload();});',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().catch(() => {return error.handle();});',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().finally(() => {return finallyDo();});',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
@@ -90,6 +93,7 @@ eslintTester.run('named-functions-in-promises', rule, {
       options: [{
         allowSimpleArrowFunction: true,
       }],
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
@@ -99,6 +103,7 @@ eslintTester.run('named-functions-in-promises', rule, {
       options: [{
         allowSimpleArrowFunction: true,
       }],
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
@@ -108,30 +113,35 @@ eslintTester.run('named-functions-in-promises', rule, {
       options: [{
         allowSimpleArrowFunction: true,
       }],
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().then(() => this._reloadUser(user));',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().catch(err => this._handleError(err));',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().finally(() => this._finallyDo());',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
     }, {
       code: 'user.save().then(() => user.reload());',
       parserOptions: { ecmaVersion: 6 },
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],
@@ -141,6 +151,7 @@ eslintTester.run('named-functions-in-promises', rule, {
       options: [{
         allowSimpleArrowFunction: true,
       }],
+      output: null,
       errors: [{
         message: 'Use named functions defined on objects to handle promises',
       }],

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -52,6 +52,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         { message: 'Use import EmberObject from \'@ember/object\'; instead of using Ember destructuring', line: 3 }
       ]
@@ -64,6 +65,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Controller.extend({});
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         { message: 'Use import $ from \'jquery\'; instead of using Ember destructuring', line: 3 },
         { message: 'Use import Controller from \'@ember/controller\'; instead of using Ember destructuring', line: 3 }
@@ -78,6 +80,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         { message: 'Use import Component from \'@ember/component\'; instead of using Ember destructuring', line: 3 },
         { message: 'Use import { htmlSafe } from \'@ember/template\'; instead of using Ember destructuring', line: 3 }
@@ -93,6 +96,7 @@ eslintTester.run('new-module-imports', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         { message: 'Use import { inject as controller } from \'@ember/controller\'; instead of using Ember destructuring', line: 3 },
         { message: 'Use import { inject as service } from \'@ember/service\'; instead of using Ember destructuring', line: 3 },
@@ -109,6 +113,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [
         { message: 'Use import { alias } from \'@ember/object/computed\'; instead of using Ember destructuring', line: 5 },
         { message: 'Use import { uniq } from \'@ember/object/computed\'; instead of using Ember destructuring', line: 5 }
@@ -117,6 +122,7 @@ eslintTester.run('new-module-imports', rule, {
     {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: 'export default Ember.Service;',
+      output: null,
       errors: [
         { message: 'Use import Service from \'@ember/service\'; instead of using Ember.Service', line: 1 }
       ],
@@ -124,42 +130,49 @@ eslintTester.run('new-module-imports', rule, {
     {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: 'export default Ember.Service.extend({});',
+      output: null,
       errors: [
         { message: 'Use import Service from \'@ember/service\'; instead of using Ember.Service', line: 1 }
       ],
     },
     {
       code: 'Ember.computed();',
+      output: null,
       errors: [
         { message: 'Use import { computed } from \'@ember/object\'; instead of using Ember.computed', line: 1 }
       ],
     },
     {
       code: 'Ember.computed.not();',
+      output: null,
       errors: [
         { message: 'Use import { not } from \'@ember/object/computed\'; instead of using Ember.computed.not', line: 1 }
       ],
     },
     {
       code: 'Ember.inject.service(\'foo\');',
+      output: null,
       errors: [
         { message: 'Use import { inject } from \'@ember/service\'; instead of using Ember.inject.service', line: 1 }
       ],
     },
     {
       code: 'var Router = Ember.Router.extend({});',
+      output: null,
       errors: [
         { message: 'Use import EmberRouter from \'@ember/routing/router\'; instead of using Ember.Router', line: 1 }
       ],
     },
     {
       code: 'Ember.$(\'.foo\')',
+      output: null,
       errors: [
         { message: 'Use import $ from \'jquery\'; instead of using Ember.$', line: 1 }
       ],
     },
     {
       code: 'new Ember.RSVP.Promise();',
+      output: null,
       errors: [
         { message: 'Use import { Promise } from \'rsvp\'; instead of using Ember.RSVP.Promise', line: 1 }
       ],

--- a/tests/lib/rules/no-attrs-in-components.js
+++ b/tests/lib/rules/no-attrs-in-components.js
@@ -33,6 +33,7 @@ ruleTester.run('no-attrs-in-components', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Do not use this.attrs',
       }]

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -63,6 +63,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -84,6 +85,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]

--- a/tests/lib/rules/no-capital-letters-in-routes.js
+++ b/tests/lib/rules/no-capital-letters-in-routes.js
@@ -29,16 +29,19 @@ eslintTester.run('no-capital-letters-in-routes', rule, {
 
   invalid: [{
     code: 'this.route("Sign-in");',
+    output: null,
     errors: [{
       message: 'Unexpected capital letter in route\'s name',
     }]
   }, {
     code: 'this.route("hOme");',
+    output: null,
     errors: [{
       message: 'Unexpected capital letter in route\'s name',
     }]
   }, {
     code: 'this.route("DASH_TAB.ACTIVITY");',
+    output: null,
     errors: [{
       message: 'Unexpected capital letter in route\'s name',
     }]

--- a/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -41,34 +41,42 @@ ruleTester.run('no-deeply-nested-dependent-keys-with-each', rule, {
   invalid: [
     {
       code: "Ember.computed('foo.@each.bar.baz', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "Ember.computed('foo.@each.bar.baz', function() {}).readOnly()",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "Ember.computed('foo.@each.bar.[]', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "Ember.computed('foo.@each.bar.@each.baz', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "computed('foo.@each.bar.baz', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "computed('foo.@each.bar.baz', function() {}).readOnly()",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "computed('foo.@each.bar.[]', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     },
     {
       code: "computed('foo.@each.bar.@each.baz', function() {})",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     }
   ]

--- a/tests/lib/rules/no-duplicate-dependent-keys.js
+++ b/tests/lib/rules/no-duplicate-dependent-keys.js
@@ -18,8 +18,8 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
   valid: [
     {
       code: `
-      { 
-        test: computed.match("email", /^.+@.+/) 
+      {
+        test: computed.match("email", /^.+@.+/)
       }
       `,
       parserOptions,
@@ -112,6 +112,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]
@@ -123,6 +124,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]
@@ -134,6 +136,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]
@@ -145,6 +148,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]
@@ -156,6 +160,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]
@@ -167,6 +172,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       }
       `,
       parserOptions,
+      output: null,
       errors: [{
         message: rule.meta.message,
       }]

--- a/tests/lib/rules/no-ember-testing-in-module-scope.js
+++ b/tests/lib/rules/no-ember-testing-in-module-scope.js
@@ -55,6 +55,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
           }
         });
       `,
+      output: null,
       errors: [{ message: messages[1] }]
     },
     {
@@ -65,6 +66,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
           isTesting: Ember.testing
         });
       `,
+      output: null,
       errors: [{ message: messages[0] }]
     },
     {
@@ -73,10 +75,12 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
 
         const testDelay = FooEmber.testing ? 0 : 400
       `,
+      output: null,
       errors: [{ message: messages[0] }]
     },
     {
       code: 'const IS_TESTING = Ember.testing;',
+      output: null,
       errors: [{ message: messages[1] }, { message: messages[0] }]
     },
     {
@@ -89,6 +93,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
 
         const { testing } = FooEmber;
       `,
+      output: null,
       errors: [{ message: messages[2] }]
     }
   ]

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -49,6 +49,7 @@ eslintTester.run('no-empty-attrs', rule, {
         dob: attr("date")
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -58,6 +59,7 @@ eslintTester.run('no-empty-attrs', rule, {
         dob: attr()
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 4 }],
     },
     {
@@ -67,6 +69,7 @@ eslintTester.run('no-empty-attrs', rule, {
         dob: attr("date")
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 3 }],
     },
     {
@@ -77,6 +80,7 @@ eslintTester.run('no-empty-attrs', rule, {
         someComputedProperty: computed.bool(true)
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 3 }, { message, line: 4 }],
     },
     {
@@ -86,12 +90,14 @@ eslintTester.run('no-empty-attrs', rule, {
         dob: attr()
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }, { message, line: 3 }, { message, line: 4 }],
     },
     {
       filename: 'example-app/models/some-model.js',
       code: 'export default CustomModel.extend({name: attr()});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 1 }]
     },
   ],

--- a/tests/lib/rules/no-function-prototype-extensions.js
+++ b/tests/lib/rules/no-function-prototype-extensions.js
@@ -77,6 +77,7 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     {
       code: 'export default Controller.extend({test: function() {}.property("abc")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use Ember\'s function prototype extensions',
       }],
@@ -84,6 +85,7 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     {
       code: 'export default Controller.extend({test: function() {}.observes("abc")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use Ember\'s function prototype extensions',
       }],
@@ -91,6 +93,7 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     {
       code: 'export default Controller.extend({test: function() {}.on("init")});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use Ember\'s function prototype extensions',
       }],

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -282,7 +282,7 @@ ruleTester.run('no-global-jquery', rule, {
       code: `
         import $ from 'jquery';
         import Ember from 'ember';
-        
+
         export default Ember.Component({
           actions: {
             valid() {
@@ -302,6 +302,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]
@@ -316,6 +317,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]
@@ -328,6 +330,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]
@@ -342,6 +345,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]
@@ -360,6 +364,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]
@@ -378,6 +383,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      output: null,
       errors: [{
         message: MESSAGE
       }]

--- a/tests/lib/rules/no-invalid-debug-function-arguments.js
+++ b/tests/lib/rules/no-invalid-debug-function-arguments.js
@@ -73,30 +73,37 @@ const VALID_USAGES = [
 const INVALID_USAGES = flatten(DEBUG_FUNCTIONS.map(debugFunction => [
   {
     code: `${debugFunction}(true, 'My description.');`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `Ember.${debugFunction}(true, 'My description.');`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `${debugFunction}(true, 'My description.', { id: 'some-id' });`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `Ember.${debugFunction}(true, 'My description.', { id: 'some-id' });`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `${debugFunction}(true, \`My \${123} description.\`);`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `const CONDITION = true; ${debugFunction}(CONDITION, 'My description.');`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   },
   {
     code: `const CONDITION = true; ${debugFunction}(CONDITION, \`My \${123} description.\`);`,
+    output: null,
     errors: [{ message: getErrorMessage(debugFunction), type: 'CallExpression' }]
   }
 ]));

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -41,6 +41,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -55,6 +56,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -69,6 +71,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -84,6 +87,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -97,6 +101,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -110,6 +115,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -124,6 +130,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -138,6 +145,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -152,6 +160,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -165,6 +174,7 @@ eslintTester.run('no-jquery', rule, {
           }
         });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]
@@ -183,6 +193,7 @@ eslintTester.run('no-jquery', rule, {
           assert.equal(this.$('.some-component').text().trim(), 'hello world');
         })`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message
       }]

--- a/tests/lib/rules/no-new-mixins.js
+++ b/tests/lib/rules/no-new-mixins.js
@@ -32,6 +32,7 @@ eslintTester.run('no-new-mixins', rule, {
 
         export default Ember.Mixin.create({});
       `,
+      output: null,
       errors: [{
         message: MESSAGE,
       }],
@@ -42,6 +43,7 @@ eslintTester.run('no-new-mixins', rule, {
 
         export default Mixin.create({});
       `,
+      output: null,
       errors: [{
         message: MESSAGE,
       }],

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -25,6 +25,7 @@ eslintTester.run('no-observers', rule, {
     {
       code: 'Ember.observer("text", function() {});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use observers if possible',
       }],

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -81,6 +81,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
         test: on("didInsertElement", function () {})
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -91,6 +92,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
         someComputedProperty: computed.bool(true)
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -100,12 +102,14 @@ eslintTester.run('no-on-calls-in-components', rule, {
         anotherTest: Ember.on("willDestroyElement", function () {})
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }, { message, line: 4 }],
     },
     {
       filename: 'example-app/components/some-component/component.js',
       code: 'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use .on() for component lifecycle events.',
       }],
@@ -114,6 +118,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
       filename: 'example-app/components/some-component.js',
       code: 'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use .on() for component lifecycle events.',
       }],
@@ -122,6 +127,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
       filename: 'example-app/twised-path/some-file.js',
       code: 'export default Component.extend({test: on("didInsertElement", function () {})});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t use .on() for component lifecycle events.',
       }],

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -91,6 +91,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleFor('service:session');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('moduleFor')
@@ -105,6 +106,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('moduleFor')
@@ -119,6 +121,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('moduleFor')
@@ -131,6 +134,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleFor('service:session', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleFor')
@@ -143,6 +147,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleForComponent('display-page');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('moduleForComponent')
@@ -157,6 +162,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('moduleForComponent')
@@ -171,6 +177,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('moduleForComponent')
@@ -183,6 +190,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleForComponent('display-page', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForComponent')
@@ -195,6 +203,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleForModel('post');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('moduleForModel')
@@ -209,6 +218,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('moduleForModel')
@@ -223,6 +233,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('moduleForModel')
@@ -235,6 +246,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               moduleForModel('post', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForModel')
@@ -247,6 +259,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupTest('service:session');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('setupTest')
@@ -261,6 +274,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('setupTest')
@@ -275,6 +289,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('setupTest')
@@ -287,6 +302,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupTest('service:session', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupTest')
@@ -299,6 +315,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupComponentTest('display-page');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('setupComponentTest')
@@ -313,6 +330,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('setupComponentTest')
@@ -327,6 +345,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('setupComponentTest')
@@ -339,6 +358,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupComponentTest('display-page', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupComponentTest')
@@ -351,6 +371,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupModelTest('post');
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getSingleStringArgumentMessage('setupModelTest')
@@ -365,6 +386,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoUnitTrueMessage('setupModelTest')
@@ -379,6 +401,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               });
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoNeedsMessage('setupModelTest')
@@ -391,6 +414,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
               setupModelTest('post', arg2, {});
             `,
       parserOptions,
+      output: null,
       errors: [
         {
           message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupModelTest')

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -46,6 +46,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'prop: computed("test", function() {this.set("testAmount", test.length); return "";})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties',
       }],
@@ -53,6 +54,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'prop: computed("test", function() { this.setProperties("testAmount", test.length); return "";})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties',
       }],
@@ -60,6 +62,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'prop: computed("test", function() {if (get(this, "testAmount")) { set(this, "testAmount", test.length); } return "";})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -67,6 +70,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'prop: computed("test", function() {if (get(this, "testAmount")) { setProperties(this, "testAmount", test.length); } return "";})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -74,6 +78,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'testAmount: computed("test.length", { get() { set(this, "testAmount", test.length); }, set() { set(this, "testAmount", test.length); }})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -81,6 +86,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'testAmount: computed("test.length", { get() { setProperties(this, "testAmount", test.length); }, set() { setProperties(this, "testAmount", test.length); }})',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -88,6 +94,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'testAmount: computed("test.length", function() { const setSomething = () => { set(this, "testAmount", test.length); }; setSomething(); })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -95,6 +102,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'testAmount: computed("test.length", function() { const setSomething = () => { setProperties(this, "testAmount", test.length); }; setSomething(); })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -102,6 +110,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'let foo = computed("test", function() { Ember.set(this, "testAmount", test.length); return ""; })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -109,6 +118,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'let foo = computed("test", function() { Ember.setProperties(this, "testAmount", test.length); return ""; })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -116,6 +126,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'import Foo from "ember"; let foo = computed("test", function() { Foo.set(this, "testAmount", test.length); return ""; })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -123,6 +134,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'import Foo from "ember"; let foo = computed("test", function() { Foo.setProperties(this, "testAmount", test.length); return ""; })',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -130,6 +142,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'import EmberFoo from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { EmberFoo.set(this, "testAmount", test.length); return ""; });',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]
@@ -137,6 +150,7 @@ eslintTester.run('no-side-effects', rule, {
     {
       code: 'import EmberFoo from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { EmberFoo.setProperties(this, "testAmount", test.length); return ""; });',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Don\'t introduce side-effects in computed properties'
       }]

--- a/tests/lib/rules/no-test-and-then.js
+++ b/tests/lib/rules/no-test-and-then.js
@@ -43,6 +43,7 @@ ruleTester.run('no-test-and-then', rule, {
     {
       filename: TEST_FILE_NAME,
       code: 'andThen(() => { assert.ok(myBool); });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }]
     }
   ]

--- a/tests/lib/rules/no-test-import-export.js
+++ b/tests/lib/rules/no-test-import-export.js
@@ -35,6 +35,7 @@ ruleTester.run('no-test-file-importing', rule, {
 
         module('Acceptance | module', setupModule());
       `,
+      output: null,
       errors: [
         {
           message: NO_IMPORT_MESSAGE
@@ -51,6 +52,7 @@ ruleTester.run('no-test-file-importing', rule, {
 
         module('Acceptance | module', beforeEachSetup());
       `,
+      output: null,
       errors: [
         {
           message: NO_IMPORT_MESSAGE
@@ -64,6 +66,7 @@ ruleTester.run('no-test-file-importing', rule, {
 
         module('Acceptance | module', testModule());
       `,
+      output: null,
       errors: [
         {
           message: NO_IMPORT_MESSAGE
@@ -75,6 +78,7 @@ ruleTester.run('no-test-file-importing', rule, {
       code: `
         export function beforeEachSetup(){};
       `,
+      output: null,
       errors: [
         {
           message: NO_EXPORT_MESSAGE
@@ -88,6 +92,7 @@ ruleTester.run('no-test-file-importing', rule, {
 
         export default {beforeEachSetup};
       `,
+      output: null,
       errors: [
         {
           message: NO_EXPORT_MESSAGE

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -201,6 +201,7 @@ eslintTester.run('require-super-in-init', rule, {
         init() {},
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -210,6 +211,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -220,6 +222,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -227,6 +230,7 @@ eslintTester.run('require-super-in-init', rule, {
         init() {},
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -236,6 +240,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -246,6 +251,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -253,6 +259,7 @@ eslintTester.run('require-super-in-init', rule, {
         init() {},
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -262,6 +269,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -272,6 +280,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -279,6 +288,7 @@ eslintTester.run('require-super-in-init', rule, {
         init() {},
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -288,6 +298,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -298,6 +309,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -305,6 +317,7 @@ eslintTester.run('require-super-in-init', rule, {
         init() {},
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -314,6 +327,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -324,6 +338,7 @@ eslintTester.run('require-super-in-init', rule, {
         },
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }],
     },
     {
@@ -333,6 +348,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -342,6 +358,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -360,6 +377,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -369,6 +387,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -378,6 +397,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -387,6 +407,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -396,6 +417,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -405,6 +427,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -414,6 +437,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -423,6 +447,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -432,6 +457,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -441,6 +467,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -450,6 +477,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -459,6 +487,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -468,6 +497,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -477,6 +507,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -486,6 +517,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -495,6 +527,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     },
     {
@@ -504,6 +537,7 @@ eslintTester.run('require-super-in-init', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{ message, line: 2 }]
     }
   ],

--- a/tests/lib/rules/routes-segments-snake-case.js
+++ b/tests/lib/rules/routes-segments-snake-case.js
@@ -31,6 +31,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     {
       code: 'this.route("tree", { path: ":treeId"});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use snake case in dynamic segments of routes',
       }],
@@ -38,6 +39,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     {
       code: 'this.route("tree", { path: ":tree-id" });',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use snake case in dynamic segments of routes',
       }],
@@ -45,6 +47,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     {
       code: 'this.route("tree", { path: "/test/:treeId"});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use snake case in dynamic segments of routes',
       }],
@@ -52,6 +55,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     {
       code: 'this.route("tree", { path: "/test/treeId/:treeChildId"});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use snake case in dynamic segments of routes',
       }],
@@ -59,6 +63,7 @@ eslintTester.run('routes-segments-snake-case', rule, {
     {
       code: 'this.route("tree", { path: "/test/tree-id/:tree-child-id"});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      output: null,
       errors: [{
         message: 'Use snake case in dynamic segments of routes',
       }],

--- a/tests/lib/rules/use-brace-expansion.js
+++ b/tests/lib/rules/use-brace-expansion.js
@@ -26,42 +26,49 @@ eslintTester.run('use-brace-expansion', rule, {
   invalid: [
     {
       code: '{ test: computed("foo.{name,place}", "foo.[]", "foo.{thing,@each.stuff}", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.test", "a.test2", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.{same,level}", "a.{not,nested}", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.b.c.d", "a.b.deep.props", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.{test,test2}", "c", "a.test3.test4", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.{test,test2}", "a.test3", function() {}) }',
+      output: null,
       errors: [{
         message: 'Use brace expansion',
       }],
     },
     {
       code: '{ test: computed("a.test", "a.test2", function() {}).volatile() }',
+      output: null,
       errors: [{
         message: 'Use brace expansion'
       }],


### PR DESCRIPTION
If there's no autofixer for a particular rule or test case, we should assert that there is no `output` (`output` refers to the fixed version of the code produced by the autofixer). This helps make our tests more comprehensive, especially so that the tests will catch any future autofixer changes.

The documentation for the `output` property is [here](https://eslint.org/docs/developer-guide/nodejs-api#ruletester):

> output (string, optional): Asserts the output that will be produced when using this rule for a single pass of autofixing (e.g. with the --fix command line flag). If this is null, asserts that none of the reported problems suggest autofixes.