### PR TITLE
docs: improve `closure-action` rule examples

### DIFF
--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -13,12 +13,14 @@ export default Controller.extend({
 });
 ```
 
+### GOOD
 ```hbs
-{{! GOOD }}
+
 {{pretty-component boom=(action 'detonate')}}
 ```
 
 ```javascript
+// pretty-component.js
 export default Component.extend({
   actions: {
     pushLever() {
@@ -28,11 +30,13 @@ export default Component.extend({
 })
 ```
 
+### BAD
 ```hbs
-{{! BAD }}
 {{awful-component detonate='detonate'}}
 ```
+
 ```javascript
+// awful-component.js
 export default Component.extend({
   actions: {
     pushLever() {


### PR DESCRIPTION
It wasn't clear before which code snippets related to what. I have split them up with a decent markdown header for each so it is clear what is going on. It took me several read-throughs before to understand these examples.