### PR TITLE
Add rule to enforce computed property style

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | Avoids state leakage |
+| | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
 
 
 ### Testing

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -11,20 +11,15 @@ This rule takes a single string option
 
 String option:
 
-* `"never"` (default) getters are *never allowed* in computed properties
+* `"always-with-setter"` (default) getters are *required* when computed property has a setter
 * `"always"` getters are *required* in computed properties
+* `"never"`  getters are *never allowed* in computed properties
 
-### never
+
+### always-with-setter
 
 ```javascript
-/// GOOD
-Ember.Object.extend({
-    fullName: computed('firstName', 'lastName', function() {
-        //...
-    })
-});
-
-// BAD
+/// BAD
 Ember.Object.extend({
     fullName: computed('firstName', 'lastName', {
         get() {
@@ -32,7 +27,27 @@ Ember.Object.extend({
         }
     })
 });
+
+// GOOD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', function() {
+        //...
+    })
+});
+
+// GOOD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', {
+        set() {
+            //...
+        },
+        get() {
+            //...
+        }
+    })
+});
 ```
+
 
 ### always
 
@@ -54,4 +69,34 @@ Ember.Object.extend({
 });
 ```
 
+### never
 
+```javascript
+/// GOOD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', function() {
+        //...
+    })
+});
+
+// BAD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', {
+        get() {
+            //...
+        }
+    })
+});
+
+// BAD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', {
+        get() {
+            //...
+        },
+        set() {
+            //...
+        }
+    })
+});
+```

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -1,0 +1,57 @@
+# Rule name: `computed-property-getters`
+
+## Enforce the consistent use of getters in computed properties
+
+Computed properties may be created with or without a `get` method. This rule ensures that the choice
+is consistent.
+
+## Options
+
+This rule takes a single string option
+
+String option:
+
+* `"never"` (default) getters are *never allowed* in computed properties
+* `"always"` getters are *required* in computed properties
+
+### never
+
+```javascript
+/// GOOD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', function() {
+        //...
+    })
+});
+
+// BAD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', {
+        get() {
+            //...
+        }
+    })
+});
+```
+
+### always
+
+```javascript
+/// GOOD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', {
+        get() {
+            //...
+        }
+    })
+});
+
+// BAD
+Ember.Object.extend({
+    fullName: computed('firstName', 'lastName', function() {
+        //...
+    })
+});
+```
+
+

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const ember = require('../utils/ember');
+const utils = require('../utils/utils');
+
+//------------------------------------------------------------------------------
+// General rule - Prevent using a getter inside computed properties.
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Warns about getters in computed properties',
+      category: 'Possible Errors',
+      recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/computed-property-getters.md'
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [
+      {
+        enum: ['always', 'never']
+      },
+    ],
+  },
+
+  create(context) {
+    const requireGetters = context.options[0] || 'never';
+    const message = 'Do not use a getter inside computed properties.';
+
+    const report = function (node) {
+      context.report(node, message);
+    };
+
+    const preventGetterInComputedProperty = function (node) {
+      const objectExpressions = node.arguments.filter(arg => utils.isObjectExpression(arg));
+      if (
+        objectExpressions.length
+      ) {
+        report(node);
+      }
+    };
+
+    const requireGetterInComputedProperty = function (node) {
+      const functionExpressions = node.arguments.filter(arg => utils.isFunctionExpression(arg));
+      if (
+        functionExpressions.length
+      ) {
+        report(node);
+      }
+    };
+
+    return {
+      CallExpression(node) {
+        if (
+          ember.isComputedProp(node) &&
+          node.arguments.length
+        ) {
+          if (requireGetters === 'always') {
+            requireGetterInComputedProperty(node);
+          } else {
+            preventGetterInComputedProperty(node);
+          }
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -31,7 +31,7 @@ module.exports = {
       context.report(node, message);
     };
 
-    const requireGetterWithSetterInComputedProperty = function (node) {
+    const requireGetterOnlyWithASetterInComputedProperty = function (node) {
       const objectExpressions = node.arguments.filter(arg => utils.isObjectExpression(arg));
       if (
         objectExpressions.length
@@ -40,8 +40,8 @@ module.exports = {
         const getters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'get');
         const setters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'set');
         if (
-          setters.length === 0 ||
-          (setters.length > 0 && getters.length === 0)
+          (setters.length > 0 && getters.length === 0) ||
+          (getters.length > 0 && setters.length === 0)
         ) {
           report(node);
         }
@@ -53,15 +53,26 @@ module.exports = {
       if (
         objectExpressions.length
       ) {
-        report(node);
+        const { properties } = objectExpressions[0];
+        const getters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'get');
+        const setters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'set');
+        if (getters.length > 0 || setters.length > 0) {
+          report(node);
+        }
       }
     };
 
     const requireGetterInComputedProperty = function (node) {
-      const functionExpressions = node.arguments.filter(arg => utils.isFunctionExpression(arg));
+      const objectExpressions = node.arguments.filter(arg => utils.isObjectExpression(arg));
       if (
-        functionExpressions.length
+        objectExpressions.length
       ) {
+        const { properties } = objectExpressions[0];
+        const getters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'get');
+        if (getters.length === 0) {
+          report(node);
+        }
+      } else {
         report(node);
       }
     };
@@ -73,7 +84,7 @@ module.exports = {
           node.arguments.length
         ) {
           if (requireGetters === 'always-with-setter') {
-            requireGetterWithSetterInComputedProperty(node);
+            requireGetterOnlyWithASetterInComputedProperty(node);
           }
           if (requireGetters === 'always') {
             requireGetterInComputedProperty(node);

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -18,17 +18,34 @@ module.exports = {
     fixable: null, // or "code" or "whitespace"
     schema: [
       {
-        enum: ['always', 'never']
+        enum: ['always-with-setter', 'always', 'never']
       },
     ],
   },
 
   create(context) {
-    const requireGetters = context.options[0] || 'never';
+    const requireGetters = context.options[0] || 'always-with-setter';
     const message = 'Do not use a getter inside computed properties.';
 
     const report = function (node) {
       context.report(node, message);
+    };
+
+    const requireGetterWithSetterInComputedProperty = function (node) {
+      const objectExpressions = node.arguments.filter(arg => utils.isObjectExpression(arg));
+      if (
+        objectExpressions.length
+      ) {
+        const { properties } = objectExpressions[0];
+        const getters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'get');
+        const setters = properties.filter(prop => prop.key && prop.key.name && prop.key.name === 'set');
+        if (
+          setters.length === 0 ||
+          (setters.length > 0 && getters.length === 0)
+        ) {
+          report(node);
+        }
+      }
     };
 
     const preventGetterInComputedProperty = function (node) {
@@ -55,9 +72,13 @@ module.exports = {
           ember.isComputedProp(node) &&
           node.arguments.length
         ) {
+          if (requireGetters === 'always-with-setter') {
+            requireGetterWithSetterInComputedProperty(node);
+          }
           if (requireGetters === 'always') {
             requireGetterInComputedProperty(node);
-          } else {
+          }
+          if (requireGetters === 'never') {
             preventGetterInComputedProperty(node);
           }
         }

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -1,0 +1,126 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/computed-property-getters');
+const RuleTester = require('eslint').RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const parserOptions = { ecmaVersion: 2018, sourceType: 'module' };
+
+const codeWithoutGetters = [
+  `
+  {
+    foo: computed('model', function() {})
+  }`,
+  `{
+      foo: computed('model', function() {}).volatile()
+    }`,
+  `{
+      foo: computed(function() {})
+    }`,
+  `{
+      foo: computed(async function() {})
+    }`,
+  `{
+      foo: computed('model', async function() {})
+    }`
+];
+
+const codeWithGetters = [
+  `{
+      foo: computed({
+        get() {
+          return true;
+        }
+      }).readonly()
+    }`,
+  `{
+      foo: computed({
+        get() {
+          return true;
+        }
+      })
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {
+          return true;
+        }
+      }).readonly()
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {
+          return true;
+        }
+      })
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {}
+      })
+    }`
+];
+
+
+const validWithDefaultOptions = codeWithoutGetters.map(code => ({ code, parserOptions }));
+
+const validWithNeverOption = codeWithoutGetters.map((code) => {
+  const options = ['never'];
+  return { code, parserOptions, options };
+});
+
+const validWithAlwaysOption = codeWithGetters.map((code) => {
+  const options = ['always'];
+  return { code, parserOptions, options };
+});
+
+const inValidWithDefaultOptions = codeWithGetters.map(code => (
+  {
+    code,
+    parserOptions,
+    output: null,
+    errors: [{
+      message: rule.meta.message,
+    }]
+  }
+));
+
+const inValidWithNeverOption = codeWithGetters.map((code) => {
+  const options = ['never'];
+  return {
+    code,
+    parserOptions,
+    options,
+    output: null,
+    errors: [{
+      message: rule.meta.message,
+    }]
+  };
+});
+
+const inValidWithAlwaysOption = codeWithoutGetters.map((code) => {
+  const options = ['always'];
+  return {
+    code,
+    parserOptions,
+    options,
+    output: null,
+    errors: [{
+      message: rule.meta.message,
+    }]
+  };
+});
+
+ruleTester.run('computed-property-getters', rule, {
+  valid: [...validWithDefaultOptions, ...validWithNeverOption, ...validWithAlwaysOption],
+  invalid: [...inValidWithDefaultOptions, ...inValidWithNeverOption, ...inValidWithAlwaysOption],
+});

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -70,8 +70,69 @@ const codeWithGetters = [
     }`
 ];
 
+const codeWithSettersAndGetters = [
+  `{
+      foo: computed({
+        get() {
+          return true;
+        },
+        set() {
+          return true;
+        }
+      }).readonly()
+    }`,
+  `{
+      foo: computed({
+        get() {
+          return true;
+        },
+        set() {
+          return true;
+        }
+      })
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {
+          return true;
+        },
+        set() {
+          return true;
+        }
+      }).readonly()
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {
+          return true;
+        },
+        set() {
+          return true;
+        }
+      })
+    }`,
+  `{
+      foo: computed('model.foo', {
+        get() {},
+        set() {},
+      })
+    }`
+];
 
-const validWithDefaultOptions = codeWithoutGetters.map(code => ({ code, parserOptions }));
+
+const validWithDefaultOptions = [];
+validWithDefaultOptions.push(...codeWithoutGetters.map(code => ({ code, parserOptions })));
+validWithDefaultOptions.push(...codeWithSettersAndGetters.map(code => ({ code, parserOptions })));
+
+const validWithAlwaysWithSetterOptions = [];
+validWithAlwaysWithSetterOptions.push(...codeWithoutGetters.map((code) => {
+  const options = ['always-with-setter'];
+  return { code, parserOptions, options };
+}));
+validWithAlwaysWithSetterOptions.push(...codeWithSettersAndGetters.map((code) => {
+  const options = ['always-with-setter'];
+  return { code, parserOptions, options };
+}));
 
 const validWithNeverOption = codeWithoutGetters.map((code) => {
   const options = ['never'];
@@ -121,6 +182,11 @@ const inValidWithAlwaysOption = codeWithoutGetters.map((code) => {
 });
 
 ruleTester.run('computed-property-getters', rule, {
-  valid: [...validWithDefaultOptions, ...validWithNeverOption, ...validWithAlwaysOption],
+  valid: [
+    ...validWithDefaultOptions,
+    ...validWithAlwaysWithSetterOptions,
+    ...validWithNeverOption,
+    ...validWithAlwaysOption
+  ],
   invalid: [...inValidWithDefaultOptions, ...inValidWithNeverOption, ...inValidWithAlwaysOption],
 });


### PR DESCRIPTION
Adds rule to fix #344

Which has options to `never` allow getters in computed properties or `always` require them.

```javascript
/// GOOD
Ember.Object.extend({
    fullName: computed('firstName', 'lastName', function() {
        //...
    })
});

// BAD
Ember.Object.extend({
    fullName: computed('firstName', 'lastName', {
        get() {
            //...
        }
    })
});
```