### PR TITLE
no-unnecessary-route-path-option: fix error when `path` is `undefined`

### DIFF
--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -65,6 +65,10 @@ function getPropertyByKeyName(objectExpression, keyName) {
 }
 
 function pathMatchesRouteName(path, routeName) {
+  if (!path || !routeName) {
+    return false;
+  }
+
   const pathWithoutOptionalLeadingSlash = path.substring(0, 1) === '/' ? path.substring(1) : path;
   return pathWithoutOptionalLeadingSlash === routeName;
 }

--- a/tests/lib/rules/no-unnecessary-route-path-option.js
+++ b/tests/lib/rules/no-unnecessary-route-path-option.js
@@ -16,6 +16,7 @@ ruleTester.run('no-unnecessary-route-path-option', rule, {
   valid: [
     'this.route("blog");',
     'this.route("blog", function() {});',
+    'this.route("blog", { path: undefined });',
     'this.route("blog", { path: "" });',
     'this.route("blog", { path: "/" });',
     'this.route("blog", { path: "blog-posts" });',


### PR DESCRIPTION
This error could show up when typing a new route definition as the `path` would momentarily be `undefined`.

```
TypeError: Cannot read property 'substring' of undefined
```