### PR TITLE
Update metadata for `computed-property-getters` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | Avoids state leakage |
-| | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
+|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
 
 
 ### Testing

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -10,6 +10,7 @@ module.exports = {
   "ember/avoid-leaking-state-in-ember-objects": "error",
   "ember/avoid-using-needs-in-controllers": "error",
   "ember/closure-actions": "error",
+  "ember/computed-property-getters": "off",
   "ember/jquery-ember-run": "error",
   "ember/local-modules": "off",
   "ember/named-functions-in-promises": "off",

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -10,8 +10,8 @@ const utils = require('../utils/utils');
 module.exports = {
   meta: {
     docs: {
-      description: 'Warns about getters in computed properties',
-      category: 'Possible Errors',
+      description: 'Enforce the consistent use of getters in computed properties',
+      category: 'Ember Object',
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/computed-property-getters.md'
     },


### PR DESCRIPTION
This was forgotten / inconsistent in the original PR.

CC: @jrjohnson