### PR TITLE
[NEW RULE] no-callback-leaks

### DIFF
--- a/lib/rules/no-callback-leaks-in-ember-objects.js
+++ b/lib/rules/no-callback-leaks-in-ember-objects.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// const ember = require('../utils/ember');
+const utils = require('../utils/utils');
+
+
+//------------------------------------------------------------------------------
+// Ember object rule - Avoid callback memory leaks
+// Callback leaks are memory leaks that occur due to state being caught
+// in a callback function that is never released from memory.
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Avoids callback memory leaks',
+      category: 'Ember Object',
+      recommended: true,
+      url: 'https://github.com/ember-best-practices/memory-leak-examples/blob/master/exercises/exercise-2.md'
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [{
+      type: 'array',
+      items: { type: 'string' },
+    }],
+  },
+
+
+  create(context) {
+    const report = function (node) {
+      const message = "Event listeners and interval timers must be unregistered or ensure that the context they're registered with is destroyed, when no longer needed.";
+      context.report(node, message);
+    };
+
+    const addedListeners = [];
+    const removedListeners = [];
+    return {
+      'ExportDefaultDeclaration:exit': function (node) {
+        addedListeners.forEach((a) => {
+          const idx = removedListeners.findIndex(r => r.el === a.el);
+
+          if (idx < 0) {
+            // No removeEventListener
+            report(node);
+          }
+        });
+      },
+
+      CallExpression(node) {
+        // console.log(node.callee.property);
+        if (utils.getPropertyValue(node, 'callee.property.name') === 'addEventListener') {
+        // if (node.callee.property.name === 'addEventListener') {
+          const listener = {
+            el: node.callee.object.name,
+            event: node.arguments[0].value,
+          };
+
+          addedListeners.push(listener);
+        }
+
+        if (utils.getPropertyValue(node, 'callee.property.name') === 'removeEventListener') {
+          const listener = {
+            el: node.callee.object.name,
+            event: node.arguments[0].value
+          };
+
+          removedListeners.push(listener);
+        }
+      }
+    };
+  },
+};

--- a/tests/lib/rules/no-callback-leaks-in-ember-objects.js
+++ b/tests/lib/rules/no-callback-leaks-in-ember-objects.js
@@ -1,0 +1,152 @@
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-callback-leaks-in-ember-objects');
+const RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+
+const message = "Event listeners and interval timers must be unregistered or ensure that the context they're registered with is destroyed, when no longer needed.";
+
+const eslintTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  }
+});
+eslintTester.run('no-callback-leaks-in-ember-objects', rule, {
+  valid: [
+    {
+      code: `
+export default Ember.Component.extend({
+  didInsertElement() {
+    if (this.get('onScroll')) {
+      this._onScrollHandler = (...args) => this.get('onScroll')(...args);
+      window.addEventListener('scroll', this._onScrollHandler);
+    }
+  },
+
+  willDestroyElement() {
+    window.removeEventListener("scroll", this._onScrollHandler);
+    this._super(...arguments);
+  }
+});`,
+    },
+    {
+      code: `
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    if (this.get('onScroll')) {
+      this._onScrollHandler = (...args) => this.get('onScroll')(...args);
+      window.addEventListener('scroll', this._onScrollHandler);
+    }
+  },
+
+  willDestroyElement() {
+    window.removeEventListener("scroll", this._onScrollHandler);
+    this._super(...arguments);
+  }
+});
+      `,
+    },
+    {
+      code: `
+import Component from '@ember/component';
+
+export default Component.extend({});`,
+    },
+    {
+      code: `
+export default Ember.Service.extend({
+  init() {
+    if (this.get('onScroll')) {
+      this._onScrollHandler = (...args) => this.get('onScroll')(...args);
+      window.addEventListener('scroll', this._onScrollHandler);
+    }
+  },
+
+  willDestroy() {
+    window.removeEventListener("scroll", this._onScrollHandler);
+    this._super(...arguments);
+  }
+});`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      export default Ember.Component.extend({ 
+        didInsertElement() { 
+          if (this.get("onScroll")) { 
+            window.addEventListener("scroll", (...args) => this.get("onScroll")(...args)); 
+          } 
+        } 
+      });`,
+      output: null,
+      errors: [{
+        message,
+      }],
+    },
+    {
+      code: `
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    if (this.get('onScroll')) {
+      window.addEventListener('scroll', (...args) => this.get('onScroll')(...args));
+    }
+  }
+});`,
+      output: null,
+      errors: [{
+        message,
+      }],
+    },
+    {
+      code: `
+export default Ember.Service.extend({
+  init() {
+    if (this.get('onScroll')) {
+      window.addEventListener('scroll', (...args) => this.get('onScroll')(...args));
+    }
+  }
+});
+      `,
+      output: null,
+      errors: [{
+        message,
+      }],
+    },
+    {
+      code: `
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    if (this.get('onScroll')) {
+      window.addEventListener('scroll', (...args) => this.get('onScroll')(...args));
+    }
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+  }
+
+});
+      `,
+      output: null,
+      errors: [{
+        message,
+      }],
+    },
+
+
+  ],
+});


### PR DESCRIPTION
Added new rule and tests to avoid callback memory leaks
Callback leaks are memory leaks that occur due to state being caught in a callback function that is never released from memory.

Read more on callback leaks [here](https://github.com/ember-best-practices/memory-leak-examples/blob/master/exercises/exercise-2.md)