### PR TITLE
Fix typo in error message for `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -7,7 +7,7 @@ Starting in Ember 3.1, native ES5 getters are available, which eliminates much o
 This rule disallows:
 
 * `this.get('someProperty')` when `this.someProperty` can be used
-* `this.getProperties('prop1', 'prop2')` when `{ this.prop1, this.prop2 }` can be used
+* `this.getProperties('prop1', 'prop2')` when `{ prop1: this.prop1, prop2: this.prop2 }` can be used
 
 **WARNING**: there are a number of circumstances where `get` / `getProperties` still need to be used, and you may need to manually disable the rule for these:
 
@@ -52,7 +52,7 @@ const { prop1, prop2 } = this;
 ```
 
 ```js
-const foo = { this.prop1, this.prop2 };
+const foo = { prop1: this.prop1, prop2: this.prop2 };
 ```
 
 ## References

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -8,7 +8,7 @@ function makeErrorMessageForGet(property, isImportedGet) {
     : `Use \`this.${property}\` instead of \`this.get('${property}')\``;
 }
 
-const ERROR_MESSAGE_GET_PROPERTIES = "Use `{ this.prop1, this.prop2, ... }` instead of Ember's `getProperties` function";
+const ERROR_MESSAGE_GET_PROPERTIES = "Use `{ prop1: this.prop1, prop2: this.prop2, ... }` instead of Ember's `getProperties` function";
 
 module.exports = {
   makeErrorMessageForGet,


### PR DESCRIPTION
The typo is in the error message which suggests an alternative to the `getProperties` function.