### PR TITLE
[BUGFIX] Fixing no-on-calls bug due to spread operator

### DIFF
--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -36,6 +36,7 @@ module.exports = {
     const filePath = context.getFilename();
 
     const isOnCall = function (node) {
+      if (!node.value) return false;
       const value = node.value;
       const callee = value.callee;
       const args = utils.parseArgs(value);

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -74,6 +74,16 @@ eslintTester.run('no-on-calls-in-components', rule, {
       code: 'export default Component.extend({abc: on("nonLifecycleEvent", function() {})});',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: `
+      let foo = { bar: 'baz' };
+
+      export default Component.extend({
+        ...foo,
+      });
+      `,
+      parserOptions: { ecmaVersion: 9, sourceType: 'module' },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #392 
1. Adding a check for node.value in the rule to identify nodes without
values
2. Adding a new invalid case in the tests