### PR TITLE
Update `require-computed-macros` rule to suggest the `reads` macro instead of `readOnly` for computed properties with `return this.x`

### DIFF
--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -20,7 +20,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  propReadOnly: computed('x', function() {
+  propReads: computed('x', function() {
     return this.x;
   }),
 
@@ -63,10 +63,10 @@ Examples of **correct** code for this rule:
 
 ```js
 import Component from '@ember/component';
-import { readOnly, and, or, gt, gte, lt, lte, not, equal } from '@ember/object/computed';
+import { reads, and, or, gt, gte, lt, lte, not, equal } from '@ember/object/computed';
 
 export default Component.extend({
-  propReadOnly: readOnly('x'),
+  propReads: reads('x'),
 
   propAnd: and('x', 'y'),
 

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -11,7 +11,7 @@ function makeErrorMessage(macro) {
   return `Use the \`${macro}\` computed property macro.`;
 }
 
-const ERROR_MESSAGE_READ_ONLY = makeErrorMessage('readOnly');
+const ERROR_MESSAGE_READS = makeErrorMessage('reads');
 const ERROR_MESSAGE_AND = makeErrorMessage('and');
 const ERROR_MESSAGE_OR = makeErrorMessage('or');
 const ERROR_MESSAGE_GT = makeErrorMessage('gt');
@@ -114,7 +114,7 @@ module.exports = {
     fixable: 'code'
   },
 
-  ERROR_MESSAGE_READ_ONLY,
+  ERROR_MESSAGE_READS,
   ERROR_MESSAGE_AND,
   ERROR_MESSAGE_OR,
   ERROR_MESSAGE_GT,
@@ -229,7 +229,7 @@ module.exports = {
             reportBinaryExpression(node, statement, 'lte');
           }
         } else if (isSimpleThisExpression(statement)) {
-          reportSingleArg(node, statement, 'readOnly');
+          reportSingleArg(node, statement, 'reads');
         }
       }
     };

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -6,7 +6,7 @@ const rule = require('../../../lib/rules/require-computed-macros');
 const RuleTester = require('eslint').RuleTester;
 
 const {
-  ERROR_MESSAGE_READ_ONLY,
+  ERROR_MESSAGE_READS,
   ERROR_MESSAGE_AND,
   ERROR_MESSAGE_OR,
   ERROR_MESSAGE_GT,
@@ -32,8 +32,8 @@ ruleTester.run('require-computed-macros', rule, {
     'computed(function() { return this.x; }, SOME_OTHER_ARG)', // Function isn't last arg.
     'other(function() { return this.x; })',
 
-    // READ_ONLY
-    "readOnly('x')",
+    // READS
+    "reads('x')",
     'computed(function() { return this; })',
     'computed(function() { return SOME_VAR; })',
     'computed(function() { return this.prop[123]; })',
@@ -76,16 +76,16 @@ ruleTester.run('require-computed-macros', rule, {
     'computed(function() { return this.prop === MY_VAR; })',
   ],
   invalid: [
-    // READ_ONLY
+    // READS
     {
       code: 'computed(function() { return this.x; })',
-      output: "computed.readOnly('x')",
-      errors: [{ message: ERROR_MESSAGE_READ_ONLY, type: 'CallExpression' }]
+      output: "computed.reads('x')",
+      errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }]
     },
     {
       code: 'computed(function() { return this.x.y; })', // Nested path.
-      output: "computed.readOnly('x.y')",
-      errors: [{ message: ERROR_MESSAGE_READ_ONLY, type: 'CallExpression' }]
+      output: "computed.reads('x.y')",
+      errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }]
     },
 
     // AND


### PR DESCRIPTION
This fix avoids a potential behavior change.