### PR TITLE
[FEATURE] Adds classic decorator rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | Avoids state leakage |
+|  | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | Ensure correct hooks are used for both classic and non-classic classes |
+|  | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | Prevent usage of classic APIs such as get/set in classes that aren't explicitly decorated with @classic |
 |  | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
 
 

--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -1,0 +1,59 @@
+## Use the correct hooks in classic/non-classic classes
+
+### Rule name: `classic-decorator-hooks`
+
+Use the correct lifecycle hooks in classic and non-classic classes. Classic
+classes should use `init`, and non-classic classes should use `constructor`.
+Additionally, non-classic classes may not use `destroy`.
+
+```javascript
+// Bad
+export default class MyService extends Service {
+  init() {
+    // ...
+  }
+
+  destroy() {
+    // ...
+  }
+}
+
+@classic
+export default class MyService extends Service {
+  constructor() {
+    // ...
+  }
+}
+```
+
+```javascript
+// Good
+@classic
+export default class MyService extends Service {
+  init() {
+    // ...
+  }
+
+  destroy() {
+    // ...
+  }
+}
+
+export default class MyService extends Service {
+  constructor() {
+    // ...
+  }
+
+  willDestroy() {
+
+  }
+}
+```
+
+### References
+
+- [ember-classic-decorator](https://github.com/pzuraq/ember-classic-decorator)
+
+### Related Rules
+
+- [classic-decorator-no-classic-methods](classic-decorator-no-classic-methods.md)

--- a/docs/rules/classic-decorator-no-classic-methods.md
+++ b/docs/rules/classic-decorator-no-classic-methods.md
@@ -1,0 +1,60 @@
+## Disallow the use of classic API methods
+
+### Rule name: `classic-decorator-no-classic-methods`
+
+Disallows the use of the following API methods within a class:
+
+- `get`
+- `set`
+- `getProperties`
+- `setProperties`
+- `getWithDefault`
+- `incrementProperty`
+- `decrementProperty`
+- `toggleProperty`
+- `addObserver`
+- `removeObserver`
+- `notifyPropertyChange`
+- `cacheFor`
+- `proto`
+
+These are "classic" API methods, and their usage is discouraged in Octane.
+Non-method versions of them can still be used, e.g. `@ember/object#get` and
+`@ember/object#set` instead of `this.get` and `this.set`.
+
+```javascript
+// Bad
+export default class MyService extends Service {
+  constructor(...args) {
+    super(...args);
+    this.set('foo', 'bar');
+  }
+}
+```
+
+```javascript
+// Good
+@classic
+export default class MyService extends Service {
+  constructor(...args) {
+    super(...args);
+    this.set('foo', 'bar');
+  }
+}
+
+export default class MyService extends Service {
+  constructor(...args) {
+    super(...args);
+    set(this, 'foo', 'bar');
+  }
+}
+```
+
+### References
+
+- [ember-classic-decorator](https://github.com/pzuraq/ember-classic-decorator)
+
+### Related Rules
+
+- [no-get](no-get.md)
+- [classic-decorator-hooks](classic-decorator-hooks.md)

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -9,6 +9,8 @@ module.exports = {
   "ember/avoid-leaking-state-in-components": "off",
   "ember/avoid-leaking-state-in-ember-objects": "error",
   "ember/avoid-using-needs-in-controllers": "error",
+  "ember/classic-decorator-hooks": "off",
+  "ember/classic-decorator-no-classic-methods": "off",
   "ember/closure-actions": "error",
   "ember/computed-property-getters": "off",
   "ember/jquery-ember-run": "error",

--- a/lib/rules/classic-decorator-hooks.js
+++ b/lib/rules/classic-decorator-hooks.js
@@ -1,0 +1,70 @@
+const ERROR_MESSAGE_INIT_IN_NON_CLASSIC =
+  'You cannot use define the init() lifecycle hook in non-classic classes, it is a classic lifecycle hook. Convert to using the constructor instead, or add the @classic decorator to the class to mark it as classic.';
+const ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC =
+  'You cannot use define the destroy() lifecycle hook in non-classic classes, it is a classic lifecycle hook. Convert to using the willDestroy() lifecycle hook instead, or add the @classic decorator to the class to mark it as classic.';
+const ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC =
+  'You cannot use the constructor in a classic class. If the class can be converted, you can convert it to remove all classic APIs and remove the @classic decorator, then switch to the constructor.';
+
+module.exports = {
+  ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
+  ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,
+  ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC,
+
+  meta: {
+    docs: {
+      description: 'Ensure correct hooks are used for both classic and non-classic classes',
+      category: 'Ember Object',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/classic-decorator-hooks.md',
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [],
+  },
+
+  create(context) {
+    let inClassicClass = false;
+    let inNonClassicClass = false;
+
+    return {
+      ClassDeclaration(node) {
+        if (node.superClass) {
+          if (node.decorators && node.decorators.find(d => d.expression.name === 'classic')) {
+            inClassicClass = true;
+          } else {
+            inNonClassicClass = true;
+          }
+        }
+      },
+
+      'ClassDeclaration:exit'() {
+        inClassicClass = inNonClassicClass = false;
+      },
+
+      MethodDefinition(node) {
+        if (!inClassicClass && !inNonClassicClass) return;
+
+        if (inClassicClass && node.key.name === 'constructor') {
+          context.report({
+            node,
+            message: ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC,
+          });
+        }
+
+        if (inNonClassicClass && node.key.name === 'init') {
+          context.report({
+            node,
+            message: ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
+          });
+        }
+
+        if (inNonClassicClass && node.key.name === 'destroy') {
+          context.report({
+            node,
+            message: ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/classic-decorator-no-classic-methods.js
+++ b/lib/rules/classic-decorator-no-classic-methods.js
@@ -1,0 +1,67 @@
+const disallowedMethods = [
+  'get',
+  'set',
+  'getProperties',
+  'setProperties',
+  'getWithDefault',
+  'incrementProperty',
+  'decrementProperty',
+  'toggleProperty',
+  'addObserver',
+  'removeObserver',
+  'notifyPropertyChange',
+  'cacheFor',
+  'proto',
+];
+
+function disallowedMethodErrorMessage(name) {
+  return `The this.${name}() method is a classic ember object method, and can't be used in octane classes. You can refactor this usage to use a utility version instead (e.g. get(this, 'foo')), or to use native/modern syntax instead. Alternatively, you can add the @classic decorator to this class to continue using classic APIs.`;
+}
+
+module.exports = {
+  disallowedMethodErrorMessage,
+
+  meta: {
+    docs: {
+      description:
+        "Prevent usage of classic APIs such as get/set in classes that aren't explicitly decorated with @classic",
+      category: 'Ember Object',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/classic-decorator-no-classic-methods.md',
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [],
+  },
+
+  create(context) {
+    let inClassExtends = false;
+
+    return {
+      ClassDeclaration(node) {
+        if (
+          node.superClass &&
+          !(node.decorators && node.decorators.find(d => d.expression.name === 'classic'))
+        ) {
+          inClassExtends = true;
+        }
+      },
+
+      'ClassDeclaration:exit'() {
+        inClassExtends = false;
+      },
+
+      MemberExpression(node) {
+        if (!inClassExtends) return;
+        if (node.object.type !== 'ThisExpression') return;
+
+        if (disallowedMethods.includes(node.property.name)) {
+          context.report({
+            node,
+            message: disallowedMethodErrorMessage(node.property.name),
+          });
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const rule = require('../../../lib/rules/classic-decorator-hooks');
+const RuleTester = require('eslint').RuleTester;
+
+const {
+  ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
+  ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,
+  ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC,
+} = rule;
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
+ruleTester.run('classic-decorator-hooks', rule, {
+  valid: [
+    `
+      const Foo = EmberObject.extend({
+        init() {},
+        destroy() {}
+      })
+    `,
+    `
+      class Foo extends Bar {
+        constructor() {}
+        willDestroy() {}
+      }
+    `,
+    `
+      @classic
+      class Foo extends Bar {
+        init() {}
+        destroy() {}
+      }
+    `,
+    `
+      class Foo {
+        init() {}
+        destroy() {}
+      }
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        class Foo extends Bar {
+          init() {}
+        }
+      `,
+      errors: [
+        {
+          message: ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
+        },
+      ],
+    },
+    {
+      code: `
+        class Foo extends Bar {
+          destroy() {}
+        }
+      `,
+      errors: [
+        {
+          message: ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,
+        },
+      ],
+    },
+    {
+      code: `
+        @classic
+        class Foo extends Bar {
+          constructor() {}
+        }
+      `,
+      errors: [
+        {
+          message: ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const rule = require('../../../lib/rules/classic-decorator-no-classic-methods');
+const RuleTester = require('eslint').RuleTester;
+
+const { disallowedMethodErrorMessage } = rule;
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
+ruleTester.run('classic-decorator-no-classic-methods', rule, {
+  valid: [
+    `
+      const Foo = EmberObject.extend({
+        foo() {
+          this.get('bar');
+        }
+      })
+    `,
+    `
+      class Foo extends Bar {
+        foo() {
+          get(this, 'bar');
+          this.baz();
+        }
+      }
+    `,
+    `
+      @classic
+      class Foo extends Bar {
+        foo() {
+          this.get('bar');
+        }
+      }
+    `,
+    `
+      class Foo {
+        foo() {
+          this.get('bar');
+        }
+      }
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        class Foo extends Bar {
+          foo() {
+            this.get('bar');
+          }
+        }
+      `,
+      errors: [
+        {
+          message: disallowedMethodErrorMessage('get'),
+          type: 'MemberExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        class Foo extends Bar {
+          foo = this.get('bar');
+        }
+      `,
+      errors: [
+        {
+          message: disallowedMethodErrorMessage('get'),
+          type: 'MemberExpression',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds two rules for users who are using the `@classic` decorator to help
with upgrading to native classes and Ember Octane.