### PR TITLE
Add missing rules `classic-decorator-hooks` and `classic-decorator-no-classic-methods` to index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ module.exports = {
     'avoid-leaking-state-in-components': require('./rules/avoid-leaking-state-in-components'),
     'avoid-leaking-state-in-ember-objects': require('./rules/avoid-leaking-state-in-ember-objects'),
     'avoid-using-needs-in-controllers': require('./rules/avoid-using-needs-in-controllers'),
+    'classic-decorator-hooks': require('./rules/classic-decorator-hooks'),
+    'classic-decorator-no-classic-methods': require('./rules/classic-decorator-no-classic-methods'),
     'closure-actions': require('./rules/closure-actions'),
     'jquery-ember-run': require('./rules/jquery-ember-run'),
     'local-modules': require('./rules/local-modules'),


### PR DESCRIPTION
Forgotten in #436.

Fixes #439.

CC: @pzuraq 