### PR TITLE
Add new `no-proxies` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |  | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | Ensure correct hooks are used for both classic and non-classic classes |
 |  | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | Prevent usage of classic APIs such as get/set in classes that aren't explicitly decorated with @classic |
 |  | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
+|  | [no-proxies](./docs/rules/no-proxies.md) | Disallows using array or object proxies |
 
 
 ### Testing

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -55,6 +55,10 @@ const { prop1, prop2 } = this;
 const foo = { prop1: this.prop1, prop2: this.prop2 };
 ```
 
+## Related Rules
+
+* [no-proxies](no-proxies.md)
+
 ## References
 
 * [Ember 3.1 Release Notes](https://blog.emberjs.com/2018/04/13/ember-3-1-released.html) describing "ES5 Getters for Computed Properties"

--- a/docs/rules/no-proxies.md
+++ b/docs/rules/no-proxies.md
@@ -1,0 +1,33 @@
+# no-proxies
+
+You may want to disallow the use of Ember proxy objects (`ObjectProxy`, `ArrayProxy`) in your application for a number of reasons:
+
+1. Proxies are relatively rare compared to direct property access on objects.
+2. In part due to their rarity, proxies are not as widely understood.
+3. Proxies can add unnecessary complexity.
+4. Proxies do not support ES5 getters which were introduced in [Ember 3.1](https://blog.emberjs.com/2018/04/13/ember-3-1-released.html) (they still require using `this.get()`)
+
+## Rule Details
+
+This rule disallows using Ember proxy objects (`ObjectProxy`, `ArrayProxy`).
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+import ObjectProxy from '@ember/object/proxy';
+```
+
+```js
+import ArrayProxy from '@ember/array/proxy';
+```
+
+## Related Rules
+
+* [no-get](no-get.md) which may need to be disabled for `this.get()` usages in proxy objects
+
+## References
+
+* [ObjectProxy](https://api.emberjs.com/ember/release/classes/ObjectProxy) spec
+* [ArrayProxy](https://api.emberjs.com/ember/release/classes/ArrayProxy) spec

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ module.exports = {
     'no-observers': require('./rules/no-observers'),
     'no-old-shims': require('./rules/no-old-shims'),
     'no-on-calls-in-components': require('./rules/no-on-calls-in-components'),
+    'no-proxies': require('./rules/no-proxies'),
     'no-restricted-resolver-tests': require('./rules/no-restricted-resolver-tests'),
     'no-side-effects': require('./rules/no-side-effects'),
     'no-test-and-then': require('./rules/no-test-and-then'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -35,6 +35,7 @@ module.exports = {
   "ember/no-observers": "error",
   "ember/no-old-shims": "error",
   "ember/no-on-calls-in-components": "error",
+  "ember/no-proxies": "off",
   "ember/no-restricted-resolver-tests": "error",
   "ember/no-side-effects": "error",
   "ember/no-test-and-then": "off",

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const ERROR_MESSAGE = 'Do not use array or object proxies.';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallows using array or object proxies',
+      category: 'Ember Object',
+      recommended: false,
+    },
+    fixable: null,
+    ERROR_MESSAGE,
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source.value === '@ember/object/proxy' ||
+          node.source.value === '@ember/array/proxy'
+        ) {
+          context.report(node, ERROR_MESSAGE);
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/no-proxies.js
+++ b/tests/lib/rules/no-proxies.js
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-proxies');
+const RuleTester = require('eslint').RuleTester;
+
+const { ERROR_MESSAGE } = rule;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-proxies', rule, {
+  valid: [
+    "import ANYTHING from '@ember/object';",
+    "import { ANYTHING } from '@ember/object';",
+
+    "import ObjectProxy from 'something/else';",
+    "import { ObjectProxy } from 'something/else';",
+  ],
+  invalid: [
+    {
+      code: "import ObjectProxy from '@ember/object/proxy';",
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
+    },
+    {
+      code: "import ArrayProxy from '@ember/array/proxy';",
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
+    },
+  ],
+});


### PR DESCRIPTION
@rwjblue @Turbo87 I'm interested to hear feedback on the following questions:

1. Do you think there are legitimate reasons to avoid using `ObjectProxy` / `ArrayProxy`?
2. If so, do you think the documentation I added for the new rule fully captures those reasons?
3. How do [ES2015 proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) relate to Ember's `ObjectProxy` / `ArrayProxy`?