### PR TITLE
Update exporting of rule error messages to rule tests for consistency and for eslint 5 support

### DIFF
--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -7,6 +7,8 @@ const utils = require('../utils/utils');
 // General rule - Prevent using a getter inside computed properties.
 //------------------------------------------------------------------------------
 
+const ERROR_MESSAGE = 'Do not use a getter inside computed properties.';
+
 module.exports = {
   meta: {
     docs: {
@@ -24,12 +26,13 @@ module.exports = {
     ],
   },
 
+  ERROR_MESSAGE,
+
   create(context) {
     const requireGetters = context.options[0] || 'always-with-setter';
-    const message = 'Do not use a getter inside computed properties.';
 
     const report = function(node) {
-      context.report(node, message);
+      context.report(node, ERROR_MESSAGE);
     };
 
     const requireGetterOnlyWithASetterInComputedProperty = function(node) {

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -7,7 +7,7 @@ const utils = require('../utils/utils');
 // and `didUpdateAttrs`.
 //------------------------------------------------------------------------------
 
-const message =
+const ERROR_MESSAGE =
   'Do not use the attrs snapshot that is passed in `didReceiveAttrs` and `didUpdateAttrs`. Please see the following guide for more information: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-attrs-snapshot.md';
 
 module.exports = {
@@ -20,8 +20,10 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-snapshot.md',
     },
     fixable: null, // or "code" or "whitespace"
-    message,
   },
+
+  ERROR_MESSAGE,
+
   create(context) {
     const hasAttrsSnapShot = function(node) {
       const methodName = utils.getPropertyValue(node, 'parent.key.name');
@@ -31,7 +33,7 @@ module.exports = {
     };
 
     const report = function(node) {
-      context.report(node, message);
+      context.report(node, ERROR_MESSAGE);
     };
 
     return {

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -18,8 +18,9 @@ module.exports = {
       recommended: false,
     },
     fixable: null,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -2,7 +2,7 @@
 
 const emberUtils = require('../utils/ember');
 
-const MESSAGE = 'Dependent keys should not be repeated';
+const ERROR_MESSAGE = 'Dependent keys should not be repeated';
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,14 +17,15 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-duplicate-dependent-keys.md',
     },
     fixable: null,
-    message: MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {
       CallExpression(node) {
         if (emberUtils.hasDuplicateDependentKeys(node)) {
-          context.report(node, MESSAGE);
+          context.report(node, ERROR_MESSAGE);
         }
       },
     };

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -3,7 +3,7 @@
 const ember = require('../utils/ember');
 const utils = require('../utils/utils');
 
-const messages = [
+const ERROR_MESSAGES = [
   'Ember.testing is not set in module scope',
   'Ember.testing should not be assigned to a variable, use in place instead',
   'Can not use destructuring to reference Ember.testing',
@@ -19,8 +19,9 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-ember-testing-in-module-scope.md',
     },
     fixable: null,
-    messages,
   },
+
+  ERROR_MESSAGES,
 
   create(context) {
     let emberImportAliasName = 'Ember';
@@ -43,14 +44,14 @@ module.exports = {
           node.parent.object.name === emberImportAliasName
         ) {
           if (context.getScope().variableScope.type === 'module') {
-            context.report(node.parent, messages[0]);
+            context.report(node.parent, ERROR_MESSAGES[0]);
           }
           const nodeGrandParent = utils.getPropertyValue(node, 'parent.parent.type');
           if (
             nodeGrandParent === 'AssignmentExpression' ||
             nodeGrandParent === 'VariableDeclarator'
           ) {
-            context.report(node.parent.parent, messages[1]);
+            context.report(node.parent.parent, ERROR_MESSAGES[1]);
           }
         }
       },
@@ -64,7 +65,7 @@ module.exports = {
               parentNode.init.name === emberImportAliasName
           )
         ) {
-          context.report(node.parent.parent.parent, messages[2]);
+          context.report(node.parent.parent.parent, ERROR_MESSAGES[2]);
         }
       },
     };

--- a/lib/rules/no-get-properties.js
+++ b/lib/rules/no-get-properties.js
@@ -18,8 +18,9 @@ module.exports = {
       recommended: false,
     },
     deprecated: true,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -4,7 +4,7 @@ const ember = require('../utils/ember');
 const utils = require('../utils/utils');
 
 const ALIASES = ['$', 'jQuery'];
-const MESSAGE = 'Do not use global `$` or `jQuery`';
+const ERROR_MESSAGE = 'Do not use global `$` or `jQuery`';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -20,8 +20,9 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-global-jquery.md',
     },
     fixable: null, // or "code" or "whitespace"
-    message: MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     let destructuredAssignment;
@@ -93,7 +94,7 @@ module.exports = {
         if (hasJqueryImport) return;
 
         if (utils.isGlobalCallExpression(node, destructuredAssignment, ALIASES)) {
-          context.report(node, MESSAGE);
+          context.report(node, ERROR_MESSAGE);
         }
       },
     };

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -7,7 +7,7 @@ const utils = require('../utils/utils');
 // General rule -  Disallow usage of jQuery
 //------------------------------------------------------------------------------
 
-const message = 'Do not use jQuery';
+const ERROR_MESSAGE = 'Do not use jQuery';
 const ALIASES = ['$', 'jQuery'];
 
 module.exports = {
@@ -19,14 +19,16 @@ module.exports = {
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-jquery.md',
     },
     fixable: null, // or "code" or "whitespace"
-    message,
   },
+
+  ERROR_MESSAGE,
+
   create(context) {
     let destructuredAssignment;
     let emberImportAliasName;
     let jqueryImportAliasName;
     const report = function(node) {
-      context.report(node, message);
+      context.report(node, ERROR_MESSAGE);
     };
 
     return {

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -6,6 +6,8 @@ const ember = require('../utils/ember');
 // General rule - Don't create new mixins
 //------------------------------------------------------------------------------
 
+const ERROR_MESSAGE = "Don't create new mixins";
+
 module.exports = {
   meta: {
     docs: {
@@ -16,14 +18,15 @@ module.exports = {
     fixable: null, // or "code" or "whitespace"
   },
 
+  ERROR_MESSAGE,
+
   create(context) {
-    const message = "Don't create new mixins";
     const filePath = context.getFilename();
 
     return {
       CallExpression(node) {
         if (ember.isEmberMixin(node, filePath)) {
-          context.report(node, message);
+          context.report(node, ERROR_MESSAGE);
         }
       },
     };

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -14,8 +14,9 @@ module.exports = {
       recommended: false,
     },
     fixable: null,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -67,12 +67,13 @@ module.exports = {
       recommended: true,
     },
     fixable: null, // or "code" or "whitespace",
-    messages: {
-      getNoUnitTrueMessage,
-      getNoNeedsMessage,
-      getSingleStringArgumentMessage,
-      getNoPOJOWithoutIntegrationTrueMessage,
-    },
+  },
+
+  ERROR_MESSAGES: {
+    getNoUnitTrueMessage,
+    getNoNeedsMessage,
+    getSingleStringArgumentMessage,
+    getNoPOJOWithoutIntegrationTrueMessage,
   },
 
   create(context) {

--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -17,8 +17,9 @@ module.exports = {
       recommended: false,
     },
     fixable: null,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     if (!emberUtils.isTestFile(context.getFilename())) {

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -17,8 +17,9 @@ module.exports = {
       recommended: false,
     },
     fixable: null,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -17,8 +17,9 @@ module.exports = {
       recommended: false,
     },
     fixable: 'code',
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -18,8 +18,9 @@ module.exports = {
       recommended: false,
     },
     fixable: 'code',
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -18,8 +18,9 @@ module.exports = {
       recommended: false,
     },
     fixable: null,
-    ERROR_MESSAGE,
   },
+
+  ERROR_MESSAGE,
 
   create(context) {
     return {

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -11,11 +11,12 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
+const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester();
 const parserOptions = { ecmaVersion: 2018, sourceType: 'module' };
 const errors = [
   {
-    message: rule.meta.message,
+    message: ERROR_MESSAGE,
   },
 ];
 const output = null;

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -1,7 +1,7 @@
 const rule = require('../../../lib/rules/no-attrs-snapshot');
 const RuleTester = require('eslint').RuleTester;
 
-const message = rule.meta.message;
+const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester();
 
 eslintTester.run('no-attrs-snapshot', rule, {
@@ -66,7 +66,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -90,7 +90,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-duplicate-dependent-keys.js
+++ b/tests/lib/rules/no-duplicate-dependent-keys.js
@@ -11,6 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
+const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester();
 const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
 ruleTester.run('no-duplicate-dependent-keys', rule, {
@@ -114,7 +115,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -128,7 +129,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -142,7 +143,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -156,7 +157,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -170,7 +171,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -184,7 +185,7 @@ ruleTester.run('no-duplicate-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          message: rule.meta.message,
+          message: ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-ember-testing-in-module-scope.js
+++ b/tests/lib/rules/no-ember-testing-in-module-scope.js
@@ -3,7 +3,7 @@
 const rule = require('../../../lib/rules/no-ember-testing-in-module-scope');
 const RuleTester = require('eslint').RuleTester;
 
-const messages = rule.meta.messages;
+const { ERROR_MESSAGES } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
@@ -56,7 +56,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
         });
       `,
       output: null,
-      errors: [{ message: messages[1] }],
+      errors: [{ message: ERROR_MESSAGES[1] }],
     },
     {
       code: `
@@ -67,7 +67,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
         });
       `,
       output: null,
-      errors: [{ message: messages[0] }],
+      errors: [{ message: ERROR_MESSAGES[0] }],
     },
     {
       code: `
@@ -76,16 +76,16 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
         const testDelay = FooEmber.testing ? 0 : 400
       `,
       output: null,
-      errors: [{ message: messages[0] }],
+      errors: [{ message: ERROR_MESSAGES[0] }],
     },
     {
       code: 'const IS_TESTING = Ember.testing;',
       output: null,
-      errors: [{ message: messages[1] }, { message: messages[0] }],
+      errors: [{ message: ERROR_MESSAGES[1] }, { message: ERROR_MESSAGES[0] }],
     },
     {
       code: 'const { testing } = Ember;',
-      errors: [{ message: messages[2] }],
+      errors: [{ message: ERROR_MESSAGES[2] }],
     },
     {
       code: `
@@ -94,7 +94,7 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
         const { testing } = FooEmber;
       `,
       output: null,
-      errors: [{ message: messages[2] }],
+      errors: [{ message: ERROR_MESSAGES[2] }],
     },
   ],
 });

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -16,7 +16,7 @@ const parserOptions = {
   ecmaVersion: 6,
   sourceType: 'module',
 };
-const MESSAGE = rule.meta.message;
+const { ERROR_MESSAGE } = rule;
 
 ruleTester.run('no-global-jquery', rule, {
   valid: [
@@ -304,7 +304,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -321,7 +321,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -336,7 +336,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -353,7 +353,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -374,7 +374,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -395,7 +395,7 @@ ruleTester.run('no-global-jquery', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -1,7 +1,7 @@
 const rule = require('../../../lib/rules/no-jquery');
 const RuleTester = require('eslint').RuleTester;
 
-const message = rule.meta.message;
+const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester();
 
 eslintTester.run('no-jquery', rule, {
@@ -44,7 +44,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -61,7 +61,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -78,7 +78,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -96,7 +96,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -112,7 +112,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -128,7 +128,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -145,7 +145,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -162,7 +162,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -179,7 +179,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -195,7 +195,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },
@@ -216,7 +216,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          message,
+          ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-new-mixins.js
+++ b/tests/lib/rules/no-new-mixins.js
@@ -9,7 +9,7 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const MESSAGE = rule.meta.message;
+const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
@@ -35,7 +35,7 @@ eslintTester.run('no-new-mixins', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -48,7 +48,7 @@ eslintTester.run('no-new-mixins', rule, {
       output: null,
       errors: [
         {
-          message: MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -6,7 +6,7 @@ const rule = require('../../../lib/rules/no-restricted-resolver-tests');
 const RuleTester = require('eslint').RuleTester;
 
 const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
-const messages = rule.meta.messages;
+const { ERROR_MESSAGES } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -94,7 +94,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('moduleFor'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('moduleFor'),
         },
       ],
     },
@@ -109,7 +109,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('moduleFor'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('moduleFor'),
         },
       ],
     },
@@ -124,7 +124,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('moduleFor'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('moduleFor'),
         },
       ],
     },
@@ -137,7 +137,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleFor'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('moduleFor'),
         },
       ],
     },
@@ -150,7 +150,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('moduleForComponent'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('moduleForComponent'),
         },
       ],
     },
@@ -165,7 +165,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('moduleForComponent'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('moduleForComponent'),
         },
       ],
     },
@@ -180,7 +180,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('moduleForComponent'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('moduleForComponent'),
         },
       ],
     },
@@ -193,7 +193,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForComponent'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('moduleForComponent'),
         },
       ],
     },
@@ -206,7 +206,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('moduleForModel'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('moduleForModel'),
         },
       ],
     },
@@ -221,7 +221,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('moduleForModel'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('moduleForModel'),
         },
       ],
     },
@@ -236,7 +236,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('moduleForModel'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('moduleForModel'),
         },
       ],
     },
@@ -249,7 +249,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('moduleForModel'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('moduleForModel'),
         },
       ],
     },
@@ -262,7 +262,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('setupTest'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('setupTest'),
         },
       ],
     },
@@ -277,7 +277,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('setupTest'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('setupTest'),
         },
       ],
     },
@@ -292,7 +292,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('setupTest'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('setupTest'),
         },
       ],
     },
@@ -305,7 +305,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupTest'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('setupTest'),
         },
       ],
     },
@@ -318,7 +318,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('setupComponentTest'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('setupComponentTest'),
         },
       ],
     },
@@ -333,7 +333,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('setupComponentTest'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('setupComponentTest'),
         },
       ],
     },
@@ -348,7 +348,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('setupComponentTest'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('setupComponentTest'),
         },
       ],
     },
@@ -361,7 +361,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupComponentTest'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('setupComponentTest'),
         },
       ],
     },
@@ -374,7 +374,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getSingleStringArgumentMessage('setupModelTest'),
+          message: ERROR_MESSAGES.getSingleStringArgumentMessage('setupModelTest'),
         },
       ],
     },
@@ -389,7 +389,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoUnitTrueMessage('setupModelTest'),
+          message: ERROR_MESSAGES.getNoUnitTrueMessage('setupModelTest'),
         },
       ],
     },
@@ -404,7 +404,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoNeedsMessage('setupModelTest'),
+          message: ERROR_MESSAGES.getNoNeedsMessage('setupModelTest'),
         },
       ],
     },
@@ -417,7 +417,7 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
       output: null,
       errors: [
         {
-          message: messages.getNoPOJOWithoutIntegrationTrueMessage('setupModelTest'),
+          message: ERROR_MESSAGES.getNoPOJOWithoutIntegrationTrueMessage('setupModelTest'),
         },
       ],
     },


### PR DESCRIPTION
Moving the `ERROR_MESSAGE` exports to the right place will fix the tests that are currently failing with the eslint 5 dev-dependency upgrade. And I also improved the export naming for consistency while doing that.