### PR TITLE
Add null check in `new-module-imports` rule (again)

### DIFF
--- a/lib/utils/new-module.js
+++ b/lib/utils/new-module.js
@@ -157,7 +157,7 @@ function isInitImportedFrom(node, module) {
   const { name } = node.init;
   const pp = node.parent.parent;
 
-  if (!pp || !pp.body) {
+  if (!pp || !pp.body || !pp.body.some) {
     return false;
   }
 

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -53,6 +53,10 @@ eslintTester.run('new-module-imports', rule, {
       code: `export const Ember = 1;`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: `for (let i = 0; i < 10; i++) { }`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes this test case:

```
new-module-imports › valid › for (let i = 0; i < 10; i++) { }

    TypeError: pp.body.some is not a function
    Occurred while linting <input>:1

      162 |   }
      163 |
    > 164 |   return pp.body.some(n => {
          |                  ^
      165 |     function containsInitSpecifier(specifiers) {
      166 |       return specifiers.some(s => {
      167 |         return s.local.name === name;

      at some (lib/utils/new-module.js:164:18)
      at isInitImportedFrom (lib/rules/new-module-imports.js:59:44)
```

Same issue as in #459. Caused by #450.

@dcyriller the null check does not seem like a great fix, even though it solves the immediate problem. Can you please investigate if there is a better fix for this?