### PR TITLE
Refactor null checks for `new-module-imports` and `use-ember-data-rfc-395-imports` rules

### DIFF
--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const MAPPING = require('ember-rfc176-data');
-const { buildMessage, getFullNames, isInitImportedFrom } = require('../utils/new-module');
+const {
+  buildMessage,
+  getFullNames,
+  isDestructuring,
+  isInitImportedFrom,
+} = require('../utils/new-module');
 
 const GLOBALS = MAPPING.reduce((memo, exportDefinition) => {
   if (exportDefinition.deprecated) {
@@ -53,7 +58,7 @@ module.exports = {
 
     return {
       VariableDeclarator(node) {
-        if (!node.init) {
+        if (!isDestructuring(node)) {
           return;
         }
 

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -58,11 +58,7 @@ module.exports = {
 
     return {
       VariableDeclarator(node) {
-        if (!isDestructuring(node)) {
-          return;
-        }
-
-        if (!isIdentifierImportedFrom(node, 'ember')) {
+        if (!isDestructuring(node) || !isIdentifierImportedFrom(node, 'ember')) {
           return;
         }
 

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -5,7 +5,7 @@ const {
   buildMessage,
   getFullNames,
   isDestructuring,
-  isInitImportedFrom,
+  isIdentifierImportedFrom,
 } = require('../utils/new-module');
 
 const GLOBALS = MAPPING.reduce((memo, exportDefinition) => {
@@ -62,8 +62,7 @@ module.exports = {
           return;
         }
 
-        // Filter out non-Ember variable declarations
-        if (node.init.name !== 'Ember' && !isInitImportedFrom(node, 'ember')) {
+        if (!isIdentifierImportedFrom(node, 'ember')) {
           return;
         }
 

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -6,7 +6,7 @@ const {
   buildMessage,
   getFullNames,
   isDestructuring,
-  isInitImportedFrom,
+  isIdentifierImportedFrom,
 } = require('../utils/new-module');
 
 /**
@@ -120,7 +120,7 @@ module.exports = {
         }
 
         // Filter out non-DS variable declarations
-        if (node.init.name !== 'DS' && !isInitImportedFrom(node, 'ember-data')) {
+        if (!isIdentifierImportedFrom(node, 'ember-data')) {
           return;
         }
 

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -115,12 +115,8 @@ module.exports = {
        * and against `const { Model } = ED` (only) if ED is imported from ember-data
        */
       VariableDeclarator(node) {
-        if (!isDestructuring(node)) {
-          return;
-        }
-
-        // Filter out non-DS variable declarations
-        if (!isIdentifierImportedFrom(node, 'ember-data')) {
+        // Filter out non-ember-data variable declarations
+        if (!isDestructuring(node) || !isIdentifierImportedFrom(node, 'ember-data')) {
           return;
         }
 

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const MAPPINGS = require('@ember-data/rfc395-data');
-const { buildFix, buildMessage, getFullNames, isInitImportedFrom } = require('../utils/new-module');
+const {
+  buildFix,
+  buildMessage,
+  getFullNames,
+  isDestructuring,
+  isInitImportedFrom,
+} = require('../utils/new-module');
 
 /**
  * This function returns an object like this:
@@ -109,7 +115,7 @@ module.exports = {
        * and against `const { Model } = ED` (only) if ED is imported from ember-data
        */
       VariableDeclarator(node) {
-        if (!node.init) {
+        if (!isDestructuring(node)) {
           return;
         }
 

--- a/lib/utils/new-module.js
+++ b/lib/utils/new-module.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isIdentifier, isVariableDeclarator } = require('./types');
+const { isIdentifier, isObjectPattern, isVariableDeclarator } = require('./types');
 
 const EMBER_NAMESPACES = ['inject.controller', 'inject.service'];
 
@@ -156,7 +156,13 @@ function getFullNames(prefix, node) {
 }
 
 function isDestructuring(node) {
-  return isVariableDeclarator(node) && node.init && isIdentifier(node.init);
+  return (
+    isVariableDeclarator(node) &&
+    node.init &&
+    isIdentifier(node.init) &&
+    node.id &&
+    isObjectPattern(node.id)
+  );
 }
 
 function isIdentifierImportedFrom(node, module) {

--- a/lib/utils/new-module.js
+++ b/lib/utils/new-module.js
@@ -159,11 +159,13 @@ function isDestructuring(node) {
   return isVariableDeclarator(node) && node.init && isIdentifier(node.init);
 }
 
-function isInitImportedFrom(node, module) {
+function isIdentifierImportedFrom(node, module) {
   const { name } = node.init;
   const pp = node.parent.parent;
 
-  if (!pp || !pp.body || !pp.body.some) {
+  // `import` may only appear at the top level, ie. in a `Program` node
+  // also, a `Program` node will always have a `body` attribute
+  if (!pp || pp.type !== 'Program') {
     return false;
   }
 
@@ -187,5 +189,5 @@ module.exports = {
   buildMessage,
   getFullNames,
   isDestructuring,
-  isInitImportedFrom,
+  isIdentifierImportedFrom,
 };

--- a/lib/utils/new-module.js
+++ b/lib/utils/new-module.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isIdentifier, isVariableDeclarator } = require('./types');
+
 const EMBER_NAMESPACES = ['inject.controller', 'inject.service'];
 
 // Both the Controller module and Service module each make available the
@@ -153,6 +155,10 @@ function getFullNames(prefix, node) {
   return fullNames;
 }
 
+function isDestructuring(node) {
+  return isVariableDeclarator(node) && node.init && isIdentifier(node.init);
+}
+
 function isInitImportedFrom(node, module) {
   const { name } = node.init;
   const pp = node.parent.parent;
@@ -180,5 +186,6 @@ module.exports = {
   buildFix,
   buildMessage,
   getFullNames,
+  isDestructuring,
   isInitImportedFrom,
 };

--- a/tests/lib/utils/new-module-test.js
+++ b/tests/lib/utils/new-module-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const babelEslint = require('babel-eslint');
+const { isDestructuring } = require('../../../lib/utils/new-module');
+
+describe('isDestructuring', () => {
+  it('should check a destructuring import', () => {
+    const node = babelEslint.parse(`const { destructured } = someVar;`).body[0].declarations[0];
+    expect(isDestructuring(node)).toBeTruthy();
+  });
+
+  it('should check a non-destructuring import', () => {
+    const node = babelEslint.parse(`const destructured = someVar;`).body[0].declarations[0];
+    expect(isDestructuring(node)).toBeFalsy();
+  });
+
+  it('should check a ForInStatement', () => {
+    const node = babelEslint.parse(`for (const item in list) {};`).body[0].left.declarations[0];
+    expect(isDestructuring(node)).toBeFalsy();
+  });
+});

--- a/tests/lib/utils/new-module-test.js
+++ b/tests/lib/utils/new-module-test.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const babelEslint = require('babel-eslint');
-const { isDestructuring } = require('../../../lib/utils/new-module');
+const { buildFix, isDestructuring } = require('../../../lib/utils/new-module');
+
+const modulesData = {
+  'ember-data/model': {
+    default: ['@ember-data/model'],
+  },
+};
 
 describe('isDestructuring', () => {
   it('should check a destructuring import', () => {
@@ -17,5 +23,13 @@ describe('isDestructuring', () => {
   it('should check a ForInStatement', () => {
     const node = babelEslint.parse(`for (const item in list) {};`).body[0].left.declarations[0];
     expect(isDestructuring(node)).toBeFalsy();
+  });
+});
+
+describe('buildFix', () => {
+  it('returns a function', () => {
+    const node = babelEslint.parse(`import Model from "ember-data/model"`).body[0];
+    const fix = buildFix(node, modulesData);
+    expect(typeof fix === 'function').toBeTruthy();
   });
 });


### PR DESCRIPTION
Refactor https://github.com/ember-cli/eslint-plugin-ember/pull/460 and https://github.com/ember-cli/eslint-plugin-ember/pull/461 to check against node types.

Updated fix for #459.