### PR TITLE
Fix false positives for import statements with `use-ember-data-rfc-395-imports` rule

### DIFF
--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -99,7 +99,7 @@ module.exports = {
           return;
         }
 
-        if (node.source.value.startsWith('ember-data')) {
+        if (node.source.value === 'ember-data' || node.source.value.startsWith('ember-data/')) {
           context.report(node, message);
         }
       },

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -25,6 +25,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
      });
     `,
     `import LOL from 'who-knows-but-definitely-not-ember-data';
+     import Fragment from 'ember-data-model-fragments/fragment';
 
      const { Model } = LOL;
     `,


### PR DESCRIPTION
After enabling the `use-ember-data-rfc-395-imports` rule, I found that I was getting errors for imports from `ember-data-model-fragments` and `ember-data-factory-guy`.

Here's my attempt to fix it!