### PR TITLE
Add new rule `require-await-function-call`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 |:---|:--------|:------------|
 |  | [no-test-and-then](./docs/rules/no-test-and-then.md) | Disallow use of `andThen` test wait helper. |
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | Disallow importing of "-test.js" in a test file and exporting from a test file. |
+| :wrench: | [require-await-function-call](./docs/rules/require-await-function-call.md) | Enforces using `await` with calls to the specified functions (defaults to the async Ember test helpers like `click` and `visit`). |
 
 
 ### Stylistic Issues

--- a/docs/rules/no-test-and-then.md
+++ b/docs/rules/no-test-and-then.md
@@ -28,3 +28,7 @@ test('behaves correctly', async function(assert) {
 
 * [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
 * [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule
+
+## Related Rules
+
+* [require-await-function-call](require-await-function-call.md)

--- a/docs/rules/require-await-function-call.md
+++ b/docs/rules/require-await-function-call.md
@@ -1,0 +1,89 @@
+# require-await-function-call
+
+Some functions are asynchronous and we want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help us achieve this.
+
+## Rule Details
+
+This lint rule requires that specified functions (defaulting to the [async Ember test helpers](../../lib/utils/async-ember-test-helpers.js) like `click` and `visit`) be called with the `async` keyword. The benefits of this include:
+
+* Ensure code runs in the right (deterministic) order (potentially making tests more deterministic and reducing test flakiness)
+* Promote cleaner code by reducing unwieldy promise chain usage
+* Enforce a consistent way of calling/chaining asynchronous functions
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+// Lint rule configuration: ['error', { functions: ['asyncFunc1', 'asyncFunc2'] }]
+function doSomethingInvalid() {
+  return asyncFunc1().then(() => {
+    return asyncFunc2();
+  });
+}
+```
+
+```js
+// Lint rule configuration: ['error', { functions: ['click'] }]
+test('clicking the button sends the action', function(assert) {
+  click('.my-button');
+  assert.ok(this.myAction.calledOnce);
+});
+```
+
+```js
+// Lint rule configuration: ['error', { functions: ['click'] }]
+test('clicking the button sends the action', function(assert) {
+  click('.my-button').then(() => {
+    assert.ok(this.myAction.calledOnce);
+  });
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// Lint rule configuration: ['error', { functions: ['asyncFunc1', 'asyncFunc2'] }]
+async function doSomethingValid() {
+  await asyncFunc1();
+  await asyncFunc2();
+}
+```
+
+```js
+// Lint rule configuration: ['error', { functions: ['click'] }]
+test('clicking the button sends the action', async function(assert) {
+  await click('.my-button');
+  assert.ok(this.myAction.calledOnce);
+});
+```
+
+## Options
+
+* OPTIONAL: `functions` is an array of the names of functions that must be called with `await`. Defaults to the [async Ember test helpers](../../lib/utils/async-ember-test-helpers.js) like `click` and `visit`.
+
+## Migration
+
+* [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
+* [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule
+
+## When Not To Use It
+
+You should avoid enabling this rule if:
+
+* Your JavaScript/browser environment does not support `async` functions (an ES8/ES2017 feature)
+* You have no asynchronous functions
+* You prefer to use promise chains instead of the `async` keyword
+
+## Related Rules
+
+* [ember/no-test-and-then](no-test-and-then.md)
+* [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
+* [no-return-await](https://eslint.org/docs/rules/no-return-await)
+* [require-atomic-updates](https://eslint.org/docs/rules/require-atomic-updates)
+* [require-await](https://eslint.org/docs/rules/require-await)
+
+## Resources
+
+* See the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) for async functions
+* See the [guide](https://guides.emberjs.com/release/testing/acceptance/) with Ember acceptance test helpers

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,7 @@ module.exports = {
     'order-in-models': require('./rules/order-in-models'),
     'order-in-routes': require('./rules/order-in-routes'),
     'route-path-style': require('./rules/route-path-style'),
+    'require-await-function-call': require('./rules/require-await-function-call'),
     'require-computed-macros': require('./rules/require-computed-macros'),
     'require-return-from-computed': require('./rules/require-return-from-computed'),
     'require-super-in-init': require('./rules/require-super-in-init'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -49,6 +49,7 @@ module.exports = {
   "ember/order-in-controllers": "off",
   "ember/order-in-models": "off",
   "ember/order-in-routes": "off",
+  "ember/require-await-function-call": "off",
   "ember/require-computed-macros": "off",
   "ember/require-return-from-computed": "off",
   "ember/require-super-in-init": "error",

--- a/lib/rules/require-await-function-call.js
+++ b/lib/rules/require-await-function-call.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const utils = require('../utils/utils');
+const ASYNC_EMBER_TEST_HELPERS = require('../utils/async-ember-test-helpers');
+
+/**
+ * Checks if the given node is part of a call with the `await` keyword.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is part of a call with the `await` keyword.
+ */
+function isAwaitCall(node) {
+  if (!node.parent) {
+    // Can't be part of an AwaitExpression if it has no parent.
+    return false;
+  }
+
+  const parent = node.parent;
+
+  if (utils.isAwaitExpression(parent)) {
+    return true;
+  }
+
+  if (utils.isCallExpression(parent) || utils.isMemberExpression(parent)) {
+    // Check to see if the AwaitExpression is still another level above.
+    return isAwaitCall(parent);
+  }
+
+  return false;
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Enforces using `await` with calls to the specified functions (defaults to the async Ember test helpers like `click` and `visit`).',
+      category: 'Testing',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          functions: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            minItems: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const functions = context.options[0]
+          ? context.options[0].functions
+          : ASYNC_EMBER_TEST_HELPERS;
+
+        const callee = node.callee;
+        if (!utils.isIdentifier(callee) || !functions.includes(callee.name)) {
+          // Not one of the specified async functions.
+          return;
+        }
+
+        if (!isAwaitCall(node)) {
+          // Missing `await`.
+          context.report({
+            node,
+            message: 'Use `await` with `{{ calleeName }}` function call.',
+            data: {
+              calleeName: node.callee.name,
+            },
+            fix(fixer) {
+              // TODO: an improvement would be to add the `async` keyword to containing function if necessary.
+              return fixer.insertTextBefore(node, 'await ');
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/utils/async-ember-test-helpers.js
+++ b/lib/utils/async-ember-test-helpers.js
@@ -1,0 +1,15 @@
+const ASYNC_EMBER_TEST_HELPERS = [
+  'blur',
+  'click',
+  'doubleClick',
+  'fillIn',
+  'focus',
+  'tap',
+  'triggerEvent',
+  'triggerKeyEvent',
+  'typeIn',
+  'visit',
+  'wait',
+];
+
+module.exports = ASYNC_EMBER_TEST_HELPERS;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -22,6 +22,7 @@ module.exports = {
   isGlobalCallExpression,
   isString,
   isStringLiteral,
+  isAwaitExpression,
   getSize,
   parseCallee,
   parseArgs,
@@ -285,6 +286,10 @@ function isString(node) {
 
 function isStringLiteral(node) {
   return isLiteral(node) && typeof node.value === 'string';
+}
+
+function isAwaitExpression(node) {
+  return node.type === 'AwaitExpression';
 }
 
 /**

--- a/tests/lib/rules/require-await-function-test.js
+++ b/tests/lib/rules/require-await-function-test.js
@@ -1,0 +1,91 @@
+const rule = require('../../../lib/rules/require-await-function-call');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
+});
+
+const VALID_USAGES = [
+  {
+    code: 'async function myFunction() { await click(); }',
+  },
+  {
+    code: 'async function myFunction() { await asyncFunc(); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
+    // When the 'AwaitExpression' isn't the direct parent of the 'CallExpression'.
+    code: 'async function myFunction() { await asyncFunc().then(() => {}); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
+    // Not one of the specified functions.
+    code: 'otherFunc();',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+  {
+    // Not one of the specified functions.
+    code: 'async function myFunction() { await otherAsyncFunc(); }',
+    options: [{ functions: ['asyncFunc'] }],
+  },
+];
+
+const INVALID_USAGES = [
+  {
+    // Missing `await`.
+    code: 'async function test() { asyncFunc(); }',
+    options: [{ functions: ['asyncFunc'] }],
+    output: 'async function test() { await asyncFunc(); }',
+    errors: [
+      {
+        message: 'Use `await` with `asyncFunc` function call.',
+        type: 'CallExpression',
+      },
+    ],
+  },
+  {
+    // Missing `await` and part of promise chain.
+    code: 'async function test() { asyncFunc().then(() => {}); }',
+    options: [{ functions: ['asyncFunc'] }],
+    output: 'async function test() { await asyncFunc().then(() => {}); }',
+    errors: [
+      {
+        message: 'Use `await` with `asyncFunc` function call.',
+        type: 'CallExpression',
+      },
+    ],
+  },
+  {
+    // Missing `await` but inside another `await` function call.
+    code:
+      'async function topLevelFunction() { await otherAsyncFunc(async () => { asyncFunc(); }); }',
+    options: [{ functions: ['asyncFunc'] }],
+    output:
+      'async function topLevelFunction() { await otherAsyncFunc(async () => { await asyncFunc(); }); }',
+    errors: [
+      {
+        message: 'Use `await` with `asyncFunc` function call.',
+        type: 'CallExpression',
+      },
+    ],
+  },
+  {
+    // Missing `await` on one of the default Ember async test helpers.
+    code: 'async function test() { click(); }',
+    output: 'async function test() { await click(); }',
+    errors: [
+      {
+        message: 'Use `await` with `click` function call.',
+        type: 'CallExpression',
+      },
+    ],
+  },
+];
+
+ruleTester.run('require-await-function-call', rule, {
+  valid: VALID_USAGES,
+  invalid: INVALID_USAGES,
+});


### PR DESCRIPTION
This lint rule requires that the specified functions (defaulting to the async Ember test helpers like `click` and `visit`) be called with the `async` keyword.