### PR TITLE
Fix eslint 6 rule test parser error

### DIFF
--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -10,7 +10,7 @@ const {
 } = rule;
 
 const ruleTester = new RuleTester({
-  parser: 'babel-eslint',
+  parser: require.resolve('babel-eslint'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { disallowedMethodErrorMessage } = rule;
 
 const ruleTester = new RuleTester({
-  parser: 'babel-eslint',
+  parser: require.resolve('babel-eslint'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 


### PR DESCRIPTION
When testing the plugin with eslint 6 internally:

```
Parsers provided as strings to RuleTester must be absolute paths
```

https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-6.0.0.md#rule-tester-parser