### PR TITLE
Improve detection of missing dependencies in `require-computed-property-dependencies` rule

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -186,8 +186,7 @@ function findThisGetCalls(node) {
     enter(child) {
       if (
         utils.isMemberExpression(child) &&
-        !utils.isCallExpression(child.parent) &&
-        !utils.isMemberExpression(child.parent) &&
+        !(utils.isCallExpression(child.parent) && child.parent.callee === child) &&
         propertyGetterUtils.isSimpleThisExpression(child)
       ) {
         results.push(child);
@@ -273,7 +272,7 @@ function extractThisGetDependencies(memberExpression, context) {
  * @returns boolean
  */
 function keyExistsAsPrefixInList(keys, key) {
-  return keys.some(currentKey => currentKey.startsWith(`${key}.`));
+  return keys.some(currentKey => computedPropertyDependencyMatchesKeyPath(currentKey, key));
 }
 
 function removeRedundantKeys(keys) {
@@ -323,21 +322,23 @@ module.exports = {
             declaredDependencies.keys.map(node => node.value)
           );
 
-          const undeclaredKeys = usedKeys
-            .filter(usedKey =>
-              expandedDeclaredKeys.every(
-                declaredKey =>
-                  declaredKey !== usedKey &&
-                  !computedPropertyDependencyMatchesKeyPath(declaredKey, usedKey)
+          const undeclaredKeys = removeRedundantKeys(
+            usedKeys
+              .filter(usedKey =>
+                expandedDeclaredKeys.every(
+                  declaredKey =>
+                    declaredKey !== usedKey &&
+                    !computedPropertyDependencyMatchesKeyPath(declaredKey, usedKey)
+                )
               )
-            )
-            .reduce((keys, key) => {
-              if (keys.indexOf(key) < 0) {
-                keys.push(key);
-              }
-              return keys;
-            }, [])
-            .sort();
+              .reduce((keys, key) => {
+                if (keys.indexOf(key) < 0) {
+                  keys.push(key);
+                }
+                return keys;
+              }, [])
+              .sort()
+          );
 
           if (undeclaredKeys.length > 0) {
             context.report({


### PR DESCRIPTION
Follow-up to improve new rule added in #458.