### PR TITLE
Add new `no-incorrect-calls-with-inline-anonymous-functions` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | Disallow repeating dependent keys |
 | :wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | Prevents use of `this._super` in ES class methods |
 | :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | Prevents use of Ember.testing in module scope |
+|  | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | Disallows inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
 |  | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | Catch usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
 | :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | Warns about unexpected side effects in computed properties |
 | :wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | Requires dependencies to be declared statically in computed properties |

--- a/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
+++ b/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
@@ -1,0 +1,57 @@
+# no-incorrect-calls-with-inline-anonymous-functions
+
+The following functions keep track of the function references they have been passed:
+ - `debounce`
+ - `once`
+ - `scheduleOnce`
+
+To use them, make sure you are passing the same function reference each time. When an inline function is passed as an argument, the function reference will be different each time.
+
+## Rule Details
+
+This rule disallows using inline anonymous functions with the `debounce`, `once`, and `scheduleOnce` methods when imported from `@ember/runloop`.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { scheduleOnce, once, debounce } from '@ember/runloop';
+
+export default Component.extend({
+  didInsertElement() {
+    this.doWork();
+    this.doWork();
+  },
+  doWork() {
+    debounce(() => { /* this will run twice */ }, 300);
+    once(() => { /* this will run twice */ });
+    scheduleOnce('afterRender', function() { /* this will run twice */ });
+  }
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { scheduleOnce } from '@ember/runloop';
+
+export default Component.extend({
+  didInsertElement() {
+    this.doWork();
+    this.doWork();
+  },
+  doWork() {
+    scheduleOnce('afterRender', this, this.deferredWork);
+  },
+  deferredWork() {
+    /* this will only run once */
+  }
+});
+```
+
+## References
+
+* [Ember debounce API Docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/debounce)
+* [Ember once API Docs](http://api.emberjs.com/ember/release/functions/@ember%2Frunloop/once)
+* [Ember scheduleOnce API Docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/scheduleOnce)

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ module.exports = {
     'no-get-properties': require('./rules/no-get-properties'),
     'no-get': require('./rules/no-get'),
     'no-global-jquery': require('./rules/no-global-jquery'),
+    'no-incorrect-calls-with-inline-anonymous-functions': require('./rules/no-incorrect-calls-with-inline-anonymous-functions'),
     'no-invalid-debug-function-arguments': require('./rules/no-invalid-debug-function-arguments'),
     'no-jquery': require('./rules/no-jquery'),
     'no-new-mixins': require('./rules/no-new-mixins'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -30,6 +30,7 @@ module.exports = {
   "ember/no-get-properties": "off",
   "ember/no-get": "off",
   "ember/no-global-jquery": "error",
+  "ember/no-incorrect-calls-with-inline-anonymous-functions": "off",
   "ember/no-invalid-debug-function-arguments": "off",
   "ember/no-jquery": "off",
   "ember/no-new-mixins": "off",

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const utils = require('../utils/utils');
+const ERROR_MESSAGE =
+  'Do not use anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`.';
+
+function isMemberExpressionOnRun(node) {
+  return utils.isMemberExpression(node.callee) && node.callee.object.name === 'run';
+}
+
+const functionRules = [
+  { importPath: '@ember/runloop', importName: 'debounce' },
+  { importPath: '@ember/runloop', importName: 'once' },
+  { importPath: '@ember/runloop', importName: 'scheduleOnce' },
+];
+
+const allDedupingRunMethodNames = functionRules.map(rule => rule.importName);
+
+module.exports = {
+  ERROR_MESSAGE,
+
+  meta: {
+    docs: {
+      description:
+        'Disallows inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+  },
+
+  create(context) {
+    function checkArgumentsForInlineFunction(node) {
+      node.arguments.forEach((argument, index) => {
+        if (utils.isAnyFunctionExpression(argument)) {
+          context.report(node.arguments[index], ERROR_MESSAGE);
+        }
+      });
+    }
+    function checkFunctionRule(functionRule, node) {
+      if (functionRule.importName === node.callee.name) {
+        checkArgumentsForInlineFunction(node);
+      }
+    }
+
+    let importedRun = false;
+    let inactiveFunctionRules = new Set(functionRules);
+    let activeFunctionRules = new Set();
+
+    return {
+      ImportDeclaration(node) {
+        const importPath = node.source.value;
+        const namedImports = node.specifiers
+          .filter(specifier => specifier.imported)
+          .map(specifier => {
+            return specifier.imported.name;
+          });
+
+        [...inactiveFunctionRules].forEach(functionRule => {
+          if (
+            functionRule.importPath === importPath &&
+            namedImports.includes(functionRule.importName)
+          ) {
+            inactiveFunctionRules.delete(functionRule);
+            activeFunctionRules.add(functionRule);
+          }
+        });
+
+        if (node.source.value === '@ember/runloop' && namedImports.includes('run')) {
+          importedRun = true;
+        }
+      },
+      CallExpression(node) {
+        [...activeFunctionRules].forEach(functionRule => {
+          checkFunctionRule(functionRule, node);
+        });
+
+        if (importedRun && isMemberExpressionOnRun(node)) {
+          if (allDedupingRunMethodNames.includes(node.callee.property.name)) {
+            checkArgumentsForInlineFunction(node);
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -12,6 +12,7 @@ module.exports = {
   isArrayExpression,
   isFunctionExpression,
   isExpressionStatement,
+  isAnyFunctionExpression,
   isArrowFunctionExpression,
   isConciseArrowFunctionWithCallExpression,
   isNewExpression,
@@ -171,6 +172,16 @@ function isFunctionExpression(node) {
  */
 function isExpressionStatement(node) {
   return node !== undefined && node.type === 'ExpressionStatement';
+}
+
+/**
+ * Check whether or not a node is an ArrowFunctionExpression or FunctionExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an ArrowFunctionExpression or FunctionExpression.
+ */
+function isAnyFunctionExpression(node) {
+  return isArrowFunctionExpression(node) || isFunctionExpression(node);
 }
 
 /**

--- a/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -1,0 +1,258 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-incorrect-calls-with-inline-anonymous-functions');
+const RuleTester = require('eslint').RuleTester;
+
+const { ERROR_MESSAGE } = rule;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
+  valid: [
+    `
+      import { once, scheduleOnce, debounce } from '@ember/runloop';
+      scheduleOnce('afterRender', this, this.methodToInvokeOnce);
+      scheduleOnce('afterRender', this, methodToInvokeOnce);
+      scheduleOnce('afterRender', methodToInvokeOnce);
+      scheduleOnce('afterRender', this.methodToInvokeOnce);
+      once(this, this.methodToInvokeOnce);
+      once(this, methodToInvokeOnce);
+      once(methodToInvokeOnce);
+      once(this.methodToInvokeOnce);
+      schedule('afterRender', this, this.methodToInvoke);
+      schedule('afterRender', this, methodToInvoke);
+      schedule('afterRender', this.methodToInvoke);
+      schedule('afterRender', methodToInvoke);
+      debounce(this, this.methodToDebounce, 300);
+      debounce(this, methodToDebounce, 300);
+      debounce(this.methodToDebounce, 300);
+      debounce(methodToDebounce, 300);
+
+      // schedule always allows inline functions
+      schedule('afterRender', this, function() {});
+      schedule('afterRender', function() {});
+      schedule('afterRender', () => {});
+
+      someOtherMethod('foo', this, function() {});
+      someOtherMethod('foo', function() {});
+      someOtherMethod(function() {});
+      someOtherMethod(() => {});
+    `,
+    `
+      import { run } from '@ember/runloop';
+      run.scheduleOnce('afterRender', this, this.methodToInvokeOnce);
+      run.scheduleOnce('afterRender', this, methodToInvokeOnce);
+      run.scheduleOnce('afterRender', methodToInvokeOnce);
+      run.scheduleOnce('afterRender', this.methodToInvokeOnce);
+      run.once(this, this.methodToInvokeOnce);
+      run.once(this, methodToInvokeOnce);
+      run.once(methodToInvokeOnce);
+      run.once(this.methodToInvokeOnce);
+      run.debounce(this, this.methodToDebounce, 300);
+      run.debounce(this, methodToDebounce, 300);
+      run.debounce(this.methodToDebounce, 300);
+      run.debounce(methodToDebounce, 300);
+
+      run.schedule('afterRender', this, this.methodToInvoke);
+      run.schedule('afterRender', this, methodToInvoke);
+      run.schedule('afterRender', this.methodToInvoke);
+      run.schedule('afterRender', methodToInvoke);
+
+      // schedule always allows inline functions
+      run.schedule('afterRender', this, function() {});
+      run.schedule('afterRender', function() {});
+      run.schedule('afterRender', () => {});
+
+      someOtherMethod('foo', this, function() {});
+      someOtherMethod('foo', function() {});
+      someOtherMethod(function() {});
+      someOtherMethod(() => {});
+    `,
+    `
+      import { somethingElse } from '@ember/runloop';
+      scheduleOnce('afterRender', this, function() {});
+      scheduleOnce('afterRender', function() {});
+      once(this, function() {});
+      once(function() {});
+      debounce(this, function() {}, 300);
+      debounce(function() {}, 300);
+
+      run.scheduleOnce('afterRender', this, function() {});
+      run.scheduleOnce('afterRender', function() {});
+      run.once(this, function() {});
+      run.once(function() {});
+
+      scheduleOnce('afterRender', this, () => {});
+      scheduleOnce('afterRender', () => {});
+      once(this, () => {});
+      once(() => {});
+      debounce(this, () => {}, 300);
+      debounce(() => {}, 300);
+      run.scheduleOnce('afterRender', this, () => {});
+      run.scheduleOnce('afterRender', () => {});
+      run.once(this, () => {});
+      run.once(() => {});
+    `,
+    `
+      import { run } from 'not-ember';
+
+      run.once(this, function() {});
+      run.scheduleOnce('afterRender', this, function() {});
+      run.once(function() {});
+      run.scheduleOnce('afterRender', function() {});
+      run.debounce(this, function() {}, 300);
+
+      run.once(this, () => {});
+      run.scheduleOnce('afterRender', this, () => {});
+      run.once(() => {});
+      run.scheduleOnce('afterRender', () => {});
+      run.debounce(this, () => {}, 300);
+    `,
+    `
+      import { run } from '@ember/runloop';
+
+      run.once.somethingElse(this, function() {});
+      run.scheduleOnce.somethingElse('afterRender', this, function() {});
+      run.debounce.somethingElse(this, function() {}, 300);
+      somethingElse.run.once(this, function() {});
+      somethingElse.run.scheduleOnce('afterRender', this, function() {});
+      somethingElse.run.debounce(this, function() {}, 300);
+
+      run.once.somethingElse(this, () => {});
+      run.scheduleOnce.somethingElse('afterRender', this, () => {});
+      run.debounce.somethingElse(this, () => {}, 300);
+      somethingElse.run.once(this, () => {});
+      somethingElse.run.scheduleOnce('afterRender', this, () => {});
+      somethingElse.run.debounce(this, () => {}, 300);
+    `,
+    "someOtherMethod('foo', this, function() {})",
+    "someOtherMethod('foo', function() {})",
+    'someOtherMethod(function() {})',
+    "import OtherThing from 'other-thing';",
+    "import YetOtherThing, { namedThing, anotherNamedThing } from 'yet-other-thing';",
+  ],
+  invalid: [
+    {
+      code: `
+        import { once } from '@ember/runloop';
+        once(function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { once } from '@ember/runloop';
+        once(this, function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { once, scheduleOnce } from '@ember/runloop';
+        once(function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { scheduleOnce } from '@ember/runloop';
+        scheduleOnce('afterRender', function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { scheduleOnce } from '@ember/runloop';
+        scheduleOnce('afterRender', this, function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { once, scheduleOnce } from '@ember/runloop';
+        scheduleOnce('afterRender', this, function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { debounce } from '@ember/runloop';
+        debounce(this, function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { run } from '@ember/runloop';
+        run.once(function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { run } from '@ember/runloop';
+        run.once(this, function() {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { run } from '@ember/runloop';
+        run.scheduleOnce('afterRender', function() {})
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { run } from '@ember/runloop';
+        run.scheduleOnce('afterRender', this, function() {})
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { once, scheduleOnce, run } from '@ember/runloop';
+        run.scheduleOnce('afterRender', this, function() {})
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
+    },
+    {
+      code: `
+        import { run } from '@ember/runloop';
+        run.scheduleOnce('afterRender', this, () => {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+    {
+      code: `
+        import { scheduleOnce } from '@ember/runloop';
+        scheduleOnce('afterRender', this, () => {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+    {
+      code: `
+        import { once } from '@ember/runloop';
+        once(this, () => {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+    {
+      code: `
+        import { debounce } from '@ember/runloop';
+        debounce(this, () => {});
+      `,
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+  ],
+});


### PR DESCRIPTION
https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/scheduleOnce

Calling `scheduleOnce` or `once` implies that the runloop will ensure that the given functionality only runs once. Passing an inline function reference will result in a different function reference for each occurrence, and the implied deduplication will not take place.

Similarly, `debounce` also relies on being passed the same function reference to understand when to debounce its calls.