### PR TITLE
Add `allowDynamicKeys` option (default true) to `require-computed-property-dependencies` rule

### DIFF
--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -40,6 +40,12 @@ export default EmberObject.extend({
 });
 ```
 
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `allowDynamicKeys` -- whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties (default `true`)
+
 ## References
 
 * [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -290,6 +290,17 @@ module.exports = {
     },
 
     fixable: 'code',
+
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowDynamicKeys: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
   },
 
   ERROR_MESSAGE_NON_STRING_VALUE,
@@ -300,12 +311,14 @@ module.exports = {
         if (isEmberComputed(node.callee) && node.arguments.length >= 1) {
           const declaredDependencies = parseComputedDependencies(node.arguments);
 
-          declaredDependencies.dynamicKeys.forEach(key => {
-            context.report({
-              node: key,
-              message: ERROR_MESSAGE_NON_STRING_VALUE,
+          if (context.options[0] && !context.options[0].allowDynamicKeys) {
+            declaredDependencies.dynamicKeys.forEach(key => {
+              context.report({
+                node: key,
+                message: ERROR_MESSAGE_NON_STRING_VALUE,
+              });
             });
-          });
+          }
 
           const computedPropertyFunction = node.arguments[node.arguments.length - 1];
 
@@ -347,9 +360,19 @@ module.exports = {
                 ', '
               )}`,
               fix(fixer) {
-                const missingDependenciesAsArguments = collapseKeys(
+                const sourceCode = context.getSourceCode();
+
+                const missingDependenciesAsArgumentsForDynamicKeys = declaredDependencies.dynamicKeys.map(
+                  dynamicKey => sourceCode.getText(dynamicKey)
+                );
+                const missingDependenciesAsArgumentsForStringKeys = collapseKeys(
                   removeRedundantKeys([...undeclaredKeys, ...expandedDeclaredKeys])
                 );
+
+                const missingDependenciesAsArguments = [
+                  ...missingDependenciesAsArgumentsForDynamicKeys,
+                  ...missingDependenciesAsArgumentsForStringKeys,
+                ].join(', ');
 
                 if (node.arguments.length > 1) {
                   const firstDependency = node.arguments[0];
@@ -379,7 +402,7 @@ module.exports = {
  *
  * Example:
  * Input: ["foo.bar", "foo.baz", "quux.[]"]
- * Output: "'foo.{bar,baz}', 'quux.[]'"
+ * Output: ["foo.{bar,baz}", "quux.[]"]
  *
  * @param {Array<string>} keys
  * @returns string
@@ -412,10 +435,7 @@ function collapseKeys(keys) {
     return `${parent}.${children[0]}`;
   });
 
-  return [...bareKeys, ...joined]
-    .sort()
-    .map(key => `'${key}'`)
-    .join(', ');
+  return [...bareKeys, ...joined].sort().map(key => `'${key}'`);
 }
 
 /**


### PR DESCRIPTION
Fixes #475. CC: @boris-petrov

Also fixes handling of dynamic keys in the rule's autofixer.