### PR TITLE
Add `yarn lint:js` script which is called by `yarn lint`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "changelog": "lerna-changelog",
-    "lint": "eslint . --cache",
+    "lint": "yarn lint:js",
+    "lint:js": "eslint . --cache",
     "start": "yarn run test:watch",
     "test": "jest",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
For convenience/consistency.

Similar to: https://github.com/ember-template-lint/ember-template-lint/pull/806