### PR TITLE
Update `require-computed-property-dependencies` rule to support eslint 3 and 4

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -183,10 +183,10 @@ function findThisGetCalls(node) {
   const results = [];
 
   new Traverser().traverse(node, {
-    enter(child) {
+    enter(child, parent) {
       if (
         utils.isMemberExpression(child) &&
-        !(utils.isCallExpression(child.parent) && child.parent.callee === child) &&
+        !(utils.isCallExpression(parent) && parent.callee === child) &&
         propertyGetterUtils.isSimpleThisExpression(child)
       ) {
         results.push(child);


### PR DESCRIPTION
Before this PR: Rule supports eslint 5-6.
After this PR: Rule supports eslint 3-6.

Before eslint 5, the node `parent` property can be undefined: https://eslint.org/docs/user-guide/migrating-to-5.0.0#-the-parent-property-of-ast-nodes-is-now-set-before-rules-start-running

The following example code produces this incorrect error message: `Use of undeclared dependencies in computed property: get`

```
Ember.computed('name', function() {
  return this.get('name');
});
```