### PR TITLE
Suggest using the eslint `consistent-return` rule alongside `require-return-from-computed` rule to help avoid false positives

### DIFF
--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -52,3 +52,13 @@ export default Component.extend({
 
 });
 ```
+
+### Migration
+
+To avoid false positives from relying on implicit returns in some code branches, you may want to enforce [consistent-return] alongside this rule.
+
+### Related Rules
+
+* [consistent-return] from eslint
+
+[consistent-return]: https://eslint.org/docs/rules/consistent-return


### PR DESCRIPTION
To help address #495.