### PR TITLE
Fix decorator handling and improve error messages for `computed-property-getters` rule

### DIFF
--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -77,7 +77,7 @@ module.exports = {
 
     const requireGetterInComputedProperty = function(node) {
       const objectExpressions = node.arguments.filter(arg => types.isObjectExpression(arg));
-      const functionExpressions = node.arguments.filter(arg => utils.isFunctionExpression(arg));
+      const functionExpressions = node.arguments.filter(arg => types.isFunctionExpression(arg));
 
       if (objectExpressions.length) {
         const { properties } = objectExpressions[0];

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -7,7 +7,10 @@ const utils = require('../utils/utils');
 // General rule - Prevent using a getter inside computed properties.
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Do not use a getter inside computed properties.';
+const ALWAYS_GETTER_MESSAGE = 'Always use a getter inside computed properties.';
+const PREVENT_GETTER_MESSAGE = 'Do not use a getter inside computed properties.';
+const ALWAYS_WITH_SETTER_MESSAGE =
+  'Always define a getter inside computed properties when using a setter.';
 
 module.exports = {
   meta: {
@@ -26,13 +29,15 @@ module.exports = {
     ],
   },
 
-  ERROR_MESSAGE,
+  ALWAYS_GETTER_MESSAGE,
+  PREVENT_GETTER_MESSAGE,
+  ALWAYS_WITH_SETTER_MESSAGE,
 
   create(context) {
     const requireGetters = context.options[0] || 'always-with-setter';
 
-    const report = function(node) {
-      context.report(node, ERROR_MESSAGE);
+    const report = function(node, message) {
+      context.report(node, message);
     };
 
     const requireGetterOnlyWithASetterInComputedProperty = function(node) {
@@ -49,7 +54,7 @@ module.exports = {
           (setters.length > 0 && getters.length === 0) ||
           (getters.length > 0 && setters.length === 0)
         ) {
-          report(node);
+          report(node, ALWAYS_WITH_SETTER_MESSAGE);
         }
       }
     };
@@ -65,23 +70,26 @@ module.exports = {
           prop => prop.key && prop.key.name && prop.key.name === 'set'
         );
         if (getters.length > 0 || setters.length > 0) {
-          report(node);
+          report(node, PREVENT_GETTER_MESSAGE);
         }
       }
     };
 
     const requireGetterInComputedProperty = function(node) {
       const objectExpressions = node.arguments.filter(arg => utils.isObjectExpression(arg));
+      const functionExpressions = node.arguments.filter(arg => utils.isFunctionExpression(arg));
+
       if (objectExpressions.length) {
         const { properties } = objectExpressions[0];
+
         const getters = properties.filter(
           prop => prop.key && prop.key.name && prop.key.name === 'get'
         );
         if (getters.length === 0) {
-          report(node);
+          report(node, ALWAYS_GETTER_MESSAGE);
         }
-      } else {
-        report(node);
+      } else if (functionExpressions.length) {
+        report(node, ALWAYS_GETTER_MESSAGE);
       }
     };
 

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -192,6 +192,7 @@ const codeWithSettersAndGetters = [
 const validWithDefaultOptions = [];
 validWithDefaultOptions.push(...codeWithoutGettersOrSetters.map(code => ({ code, parserOptions })));
 validWithDefaultOptions.push(...codeWithSettersAndGetters.map(code => ({ code, parserOptions })));
+validWithDefaultOptions.push(...codeWithRawComputed.map(code => ({ code, parserOptions })));
 
 const validWithAlwaysWithSetterOptions = [];
 validWithAlwaysWithSetterOptions.push(

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -11,15 +11,43 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
-const { ERROR_MESSAGE } = rule;
+const { PREVENT_GETTER_MESSAGE, ALWAYS_GETTER_MESSAGE, ALWAYS_WITH_SETTER_MESSAGE } = rule;
 const ruleTester = new RuleTester();
 const parserOptions = { ecmaVersion: 2018, sourceType: 'module' };
-const errors = [
+const output = null;
+
+const alwaysWithSetterOptionErrors = [
   {
-    message: ERROR_MESSAGE,
+    message: ALWAYS_WITH_SETTER_MESSAGE,
   },
 ];
-const output = null;
+
+const neverOptionErrors = [
+  {
+    message: PREVENT_GETTER_MESSAGE,
+  },
+];
+
+const alwaysOptionErrors = [
+  {
+    message: ALWAYS_GETTER_MESSAGE,
+  },
+];
+
+const codeWithRawComputed = [
+  `
+  {
+    foo: computed('model')
+  }`,
+  `
+  {
+    foo: computed()
+  }`,
+  `
+  {
+    foo: computed
+  }`,
+];
 
 const codeWithoutGettersOrSetters = [
   `
@@ -178,11 +206,26 @@ validWithAlwaysWithSetterOptions.push(
     return { code, parserOptions, options };
   })
 );
+validWithAlwaysWithSetterOptions.push(
+  ...codeWithRawComputed.map(code => {
+    const options = ['always-with-setter'];
+    return { code, parserOptions, options };
+  })
+);
 
-const validWithNeverOption = codeWithoutGettersOrSetters.map(code => {
-  const options = ['never'];
-  return { code, parserOptions, options };
-});
+const validWithNeverOption = [];
+validWithNeverOption.push(
+  ...codeWithoutGettersOrSetters.map(code => {
+    const options = ['never'];
+    return { code, parserOptions, options };
+  })
+);
+validWithNeverOption.push(
+  ...codeWithRawComputed.map(code => {
+    const options = ['never'];
+    return { code, parserOptions, options };
+  })
+);
 
 const validWithAlwaysOption = [];
 validWithAlwaysOption.push(
@@ -197,32 +240,48 @@ validWithAlwaysOption.push(
     return { code, parserOptions, options };
   })
 );
+validWithAlwaysOption.push(
+  ...codeWithRawComputed.map(code => {
+    const options = ['always'];
+    return { code, parserOptions, options };
+  })
+);
 
 const inValidWithDefaultOptions = [];
 inValidWithDefaultOptions.push(
-  ...codeWithOnlyGetters.map(code => ({ code, parserOptions, output, errors }))
+  ...codeWithOnlyGetters.map(code => ({
+    code,
+    parserOptions,
+    output,
+    errors: alwaysWithSetterOptionErrors,
+  }))
 );
 inValidWithDefaultOptions.push(
-  ...codeWithOnlySetters.map(code => ({ code, parserOptions, output, errors }))
+  ...codeWithOnlySetters.map(code => ({
+    code,
+    parserOptions,
+    output,
+    errors: alwaysWithSetterOptionErrors,
+  }))
 );
 
 const inValidWithNeverOption = [];
 inValidWithNeverOption.push(
   ...codeWithOnlyGetters.map(code => {
     const options = ['never'];
-    return { code, parserOptions, options, output, errors };
+    return { code, parserOptions, options, output, errors: neverOptionErrors };
   })
 );
 inValidWithNeverOption.push(
   ...codeWithOnlySetters.map(code => {
     const options = ['never'];
-    return { code, parserOptions, options, output, errors };
+    return { code, parserOptions, options, output, errors: neverOptionErrors };
   })
 );
 inValidWithNeverOption.push(
   ...codeWithSettersAndGetters.map(code => {
     const options = ['never'];
-    return { code, parserOptions, options, output, errors };
+    return { code, parserOptions, options, output, errors: neverOptionErrors };
   })
 );
 
@@ -230,13 +289,13 @@ const inValidWithAlwaysOption = [];
 inValidWithAlwaysOption.push(
   ...codeWithoutGettersOrSetters.map(code => {
     const options = ['always'];
-    return { code, parserOptions, options, output, errors };
+    return { code, parserOptions, options, output, errors: alwaysOptionErrors };
   })
 );
 inValidWithAlwaysOption.push(
   ...codeWithOnlySetters.map(code => {
     const options = ['always'];
-    return { code, parserOptions, options, output, errors };
+    return { code, parserOptions, options, output, errors: alwaysOptionErrors };
   })
 );
 


### PR DESCRIPTION
This PR will fix #490 

- Fixes errors messages for each rule option
- Fixes "always" option which was incorrectly failing in case of `computed('property')`

@jrjohnson