### PR TITLE
Update `require-computed-property-dependencies` rule to ignore injected service names by default

### DIFF
--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -45,6 +45,7 @@ export default EmberObject.extend({
 This rule takes an optional object containing:
 
 * `boolean` -- `allowDynamicKeys` -- whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties (default `true`)
+* `boolean` -- `requireServiceNames` -- whether the rule should require injected service names to be listed as dependency keys in computed properties (default `false`)
 
 ## References
 

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -11,6 +11,7 @@ function getTraverser() {
 }
 
 const Traverser = getTraverser();
+const emberUtils = require('../utils/ember');
 const types = require('../utils/types');
 const propertyGetterUtils = require('../utils/property-getter');
 
@@ -174,6 +175,33 @@ function findEmberGetCalls(node) {
 }
 
 /**
+ * Recursively finds the names of all injected services.
+ *
+ * In this example: `intl` would be one of the results:
+ * `Component.extend({ intl: service() });`
+ *
+ * @param {ASTNode} node
+ * @returns {Array<String>}
+ */
+function findInjectedServiceNames(node) {
+  const results = [];
+
+  new Traverser().traverse(node, {
+    enter(child) {
+      if (
+        types.isProperty(child) &&
+        emberUtils.isInjectedServiceProp(child.value) &&
+        types.isIdentifier(child.key)
+      ) {
+        results.push(child.key.name);
+      }
+    },
+  });
+
+  return results;
+}
+
+/**
  * Recursively finds all `this.property` usages.
  *
  * @param {ASTNode} node
@@ -279,6 +307,13 @@ function removeRedundantKeys(keys) {
   return keys.filter(currentKey => !keyExistsAsPrefixInList(keys, currentKey));
 }
 
+function removeServiceNames(keys, serviceNames) {
+  if (!serviceNames || serviceNames.length === 0) {
+    return keys;
+  }
+  return keys.filter(key => !serviceNames.includes(key));
+}
+
 const ERROR_MESSAGE_NON_STRING_VALUE = 'Non-string value used as computed property dependency';
 
 module.exports = {
@@ -297,8 +332,14 @@ module.exports = {
         properties: {
           allowDynamicKeys: {
             type: 'boolean',
+            default: true,
+          },
+          requireServiceNames: {
+            type: 'boolean',
+            default: false,
           },
         },
+        additionalProperties: false,
       },
     ],
   },
@@ -306,12 +347,23 @@ module.exports = {
   ERROR_MESSAGE_NON_STRING_VALUE,
 
   create(context) {
+    // Options:
+    const requireServiceNames = context.options[0] && context.options[0].requireServiceNames;
+    const allowDynamicKeys = !context.options[0] || context.options[0].allowDynamicKeys;
+
+    let serviceNames = [];
+
     return {
+      Program(node) {
+        // If service names aren't required dependencies, then we need to keep track of them so that we can ignore them.
+        serviceNames = requireServiceNames ? [] : findInjectedServiceNames(node);
+      },
+
       CallExpression(node) {
         if (isEmberComputed(node.callee) && node.arguments.length >= 1) {
           const declaredDependencies = parseComputedDependencies(node.arguments);
 
-          if (context.options[0] && !context.options[0].allowDynamicKeys) {
+          if (!allowDynamicKeys) {
             declaredDependencies.dynamicKeys.forEach(key => {
               context.report({
                 node: key,
@@ -335,7 +387,7 @@ module.exports = {
             declaredDependencies.keys.map(node => node.value)
           );
 
-          const undeclaredKeys = removeRedundantKeys(
+          const undeclaredKeysBeforeServiceCheck = removeRedundantKeys(
             usedKeys
               .filter(usedKey =>
                 expandedDeclaredKeys.every(
@@ -352,6 +404,10 @@ module.exports = {
               }, [])
               .sort()
           );
+
+          const undeclaredKeys = requireServiceNames
+            ? undeclaredKeysBeforeServiceCheck
+            : removeServiceNames(undeclaredKeysBeforeServiceCheck, serviceNames);
 
           if (undeclaredKeys.length > 0) {
             context.report({

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -18,6 +18,7 @@ module.exports = {
   isNewExpression,
   isObjectExpression,
   isObjectPattern,
+  isProperty,
   isReturnStatement,
   isString,
   isStringLiteral,
@@ -204,6 +205,16 @@ function isObjectExpression(node) {
  */
 function isObjectPattern(node) {
   return node !== undefined && node.type === 'ObjectPattern';
+}
+
+/**
+ * Check whether or not a node is an Property.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an Property.
+ */
+function isProperty(node) {
+  return node !== undefined && node.type === 'Property';
 }
 
 /**


### PR DESCRIPTION
This change adds an option to the rule `requireServiceNames` (default false).

Adding service names as dependencies isn't strictly necessary and causes extra churn for those wanting to adopt this rule.

Fixes #477.

CC: @BlueRaja