### PR TITLE
Add example of a getter with an if statement for `require-return-from-computed` rule

### DIFF
--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -29,7 +29,7 @@ export default Component.extend({
     if (this.get('firstName')) {
       return `Dr. ${this.get('firstName')}`
     }
-    return;
+    return '';
   }),
 
   // BAD

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -24,6 +24,13 @@ export default Component.extend({
       return value;
     }
   }),
+  
+  salutation: computed('firstName', function() {
+    if (this.get('firstName')) {
+      return `Dr. ${this.get('firstName')}`
+    }
+    return;
+  }),
 
   // BAD
   fullName: computed('firstName', 'lastName', {
@@ -35,6 +42,13 @@ export default Component.extend({
       this.set('firstName', firstName);
       this.set('lastName',  lastName);
     }
-  })
+  }),
+  
+  salutation: computed('firstName', function() {
+    if (this.get('firstName')) {
+      return `Dr. ${this.get('firstName')}`
+    }
+  }),
+
 });
 ```


### PR DESCRIPTION
Add an example of another very common style that `require-return-from-computed` lints for.

This one has caught me a couple of times, where the example doesn't really reflect the issue that it's linting for in this case.

Personally, I would love to split returning from `set` out from this. 
Returning from `set` is a serious cause for concern, whereas this other use-case is just a code style.