### PR TITLE
Handle empty return statement in `require-computed-macros` rule

### DIFF
--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -165,6 +165,9 @@ module.exports = {
         }
 
         const statement = lastArg.body.body[0].argument;
+        if (!statement) {
+          return;
+        }
 
         if (
           types.isUnaryExpression(statement) &&

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -28,6 +28,7 @@ ruleTester.run('require-computed-macros', rule, {
     'computed()',
     'computed(true)',
     'computed(function() {})',
+    'computed(function() { return; })',
     'computed(function() { someCall(); return this.x; })', // Multiple statements in function body.
     'computed(function() { return this.x; }, SOME_OTHER_ARG)', // Function isn't last arg.
     'other(function() { return this.x; })',


### PR DESCRIPTION
```
  require-computed-macros › valid › computed(function() { return; })

    TypeError: Cannot read property 'type' of null
    Occurred while linting <input>:1

      273 |  */
      274 | function isUnaryExpression(node) {
    > 275 |   return node !== undefined && node.type === 'UnaryExpression';
          |                                     ^
      276 | }
      277 |
      278 | /**

      at Object.type [as isUnaryExpression] (lib/utils/types.js:275:37)
      at CallExpression (lib/rules/require-computed-macros.js:175:19)
```