### PR TITLE
Avoid crash when missing arguments to `this.route()` in `route-path-style` rule

### DIFF
--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -25,7 +25,7 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        if (!ember.isRoute(node)) {
+        if (!ember.isRoute(node) || node.arguments.length === 0) {
           return;
         }
 
@@ -34,6 +34,7 @@ module.exports = {
         // 2. this.route('route', { path: 'path' });
 
         const hasExplicitPathOption =
+          node.arguments.length >= 2 &&
           types.isObjectExpression(node.arguments[1]) &&
           hasPropertyWithKeyName(node.arguments[1], 'path');
         const pathValueNode = hasExplicitPathOption

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -75,6 +75,9 @@ ruleTester.run('route-path-style', rule, {
     "MyClass.route('blog-posts', { path: '/blog_posts' });",
     "route.unrelatedFunction('blog_posts');",
     "this.route.unrelatedFunction('blog_posts');",
+
+    // Incorrect usage:
+    'this.route();',
   ],
   invalid: [
     {


### PR DESCRIPTION
Handle this test case:

```
this.route();
```

Which caused this error:

```
TypeError: Cannot read property 'value' of undefined
```

CC: @kimroen. Fixes #509.

