### PR TITLE
Test plugin under both eslint 5 and eslint 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache: yarn
 script:
   - yarn lint
   - yarn test:coverage --runInBand
+  - yarn add --dev eslint@6 && yarn test --runInBand
 
 before_deploy:
   - yarn global add auto-dist-tag


### PR DESCRIPTION
Ensure tests pass under both of our supported eslint versions.

I tested this by temporarily adding a non-eslint-6-compatible change and verified that the build failed.

Much simpler implementation than in #468. 