### PR TITLE
Test plugin under both eslint 5 and eslint 6 (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: yarn
 script:
   - yarn lint
   - yarn test:coverage --runInBand
-  - yarn add --dev eslint@6 && yarn test --runInBand
+  - yarn add --dev eslint@5 && yarn test --runInBand
 
 before_deploy:
   - yarn global add auto-dist-tag


### PR DESCRIPTION
Redoing #516. We should switch this to manually test eslint 5 so that we can allow Dependabot to keep us on the latest v6 eslint (which it did in #517).