### PR TITLE
Add CI check to ensure yarn.lock is up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
 
 cache: yarn
 
+install:
+  - yarn install --frozen-lockfile --non-interactive
+
 script:
   - yarn lint
   - yarn test:coverage --runInBand


### PR DESCRIPTION
This will ensure `yarn install` is run after any changes to package.json.

Example output of the CI failure caused by forgetting to run `yarn install`: 

```
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
```

Example of a similar PR: https://github.com/emberjs/ember.js/pull/16929