### PR TITLE
Add eslint-plugin-eslint-comments and fix violations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+coverage/
 node_modules
 lib/recommended-rules.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   extends: [
     'eslint:recommended',
+    'plugin:eslint-comments/recommended',
     'plugin:eslint-plugin/all',
     'plugin:import/errors',
     'plugin:import/warnings',
@@ -82,6 +83,9 @@ module.exports = {
 
     // Prettier:
     'prettier/prettier': 'error',
+
+    // eslint-comments rules:
+    'eslint-comments/no-unused-disable': 'error',
 
     // eslint-plugin rules:
     'eslint-plugin/no-deprecated-report-api': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/* eslint-disable global-require */
 module.exports = {
   rules: {
     'alias-model-in-controller': require('./rules/alias-model-in-controller'),

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-eslint-plugin": "^2.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.1",

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -27,7 +27,6 @@ const readmeContent = fs.readFileSync(readmeFile, 'utf8');
 const STAR = ':white_check_mark:';
 const PEN = ':wrench:';
 
-/* eslint-disable global-require, import/no-dynamic-require */
 const rules = fs
   .readdirSync(root)
   .filter(file => path.extname(file) === '.js')
@@ -92,8 +91,7 @@ const recommendedRules = rules.reduce((obj, entry) => {
   const name = `ember/${entry[0]}`;
   const recommended = entry[1].meta.docs.recommended;
   const status = recommended ? 'error' : 'off';
-  /* eslint-disable no-param-reassign */
-  obj[name] = status;
+  obj[name] = status; // eslint-disable-line no-param-reassign
   return obj;
 }, {});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,14 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-eslint-plugin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz#a7a00f15a886957d855feacaafee264f039e62d5"
@@ -1910,6 +1918,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This neat plugin checks for poor practices around `// eslint-disable` comments.

In particular, it prevents adding unnecessary disable comments!

https://github.com/mysticatea/eslint-plugin-eslint-comments