### PR TITLE
Add eslint-plugin-node and enable recommended rules internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'eslint-plugin',
     'filenames',
     'import',
+    'node',
     'prettier'
   ],
   extends: [
@@ -17,6 +18,7 @@ module.exports = {
     'plugin:eslint-plugin/all',
     'plugin:import/errors',
     'plugin:import/warnings',
+    'plugin:node/recommended',
     'prettier'
   ],
   env: {

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -3,8 +3,10 @@
 function getTraverser() {
   let traverser;
   try {
+    // eslint-disable-next-line node/no-unpublished-require
     traverser = require('eslint/lib/shared/traverser'); // eslint >= 6
   } catch (e) {
+    // eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
     traverser = require('eslint/lib/util/traverser'); // eslint < 6
   }
   return traverser;

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-eslint-plugin": "^2.1.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "lerna-changelog": "^0.8.2",

--- a/tests/plugin-exports.js
+++ b/tests/plugin-exports.js
@@ -8,11 +8,11 @@ const utils = require('../lib/utils/utils');
 describe('plugin exports library functions', () => {
   it('should export functions from the ember', () => {
     assert.ok(plugin.utils.ember);
-    assert.equal(plugin.utils.ember, ember);
+    assert.strictEqual(plugin.utils.ember, ember);
   });
 
   it('should export functions from utils', () => {
     assert.ok(plugin.utils.utils);
-    assert.equal(plugin.utils.utils, utils);
+    assert.strictEqual(plugin.utils.utils, utils);
   });
 });

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -13,6 +13,7 @@ describe('rules setup is correct', function() {
     const path = join(__dirname, '../lib/rules');
     const files = readdirSync(path);
 
+    // eslint-disable-next-line node/no-deprecated-api
     assert.deepEqual(
       RULE_NAMES,
       files.filter(file => !file.startsWith('.')).map(file => file.replace('.js', ''))
@@ -20,7 +21,7 @@ describe('rules setup is correct', function() {
   });
 
   it('should list all rules in the recommended rules file', function() {
-    assert.deepEqual(
+    assert.deepStrictEqual(
       RULE_NAMES,
       Object.keys(recommendedRules).map(file => file.replace('ember/', ''))
     );
@@ -30,6 +31,7 @@ describe('rules setup is correct', function() {
     const path = join(__dirname, '../tests/lib/rules');
     const files = readdirSync(path);
 
+    // eslint-disable-next-line node/no-deprecated-api
     assert.deepEqual(
       RULE_NAMES,
       files.filter(file => !file.startsWith('.')).map(file => file.replace('.js', ''))
@@ -40,6 +42,7 @@ describe('rules setup is correct', function() {
     const path = join(__dirname, '../docs/rules');
     const files = readdirSync(path);
 
+    // eslint-disable-next-line node/no-deprecated-api
     assert.deepEqual(
       RULE_NAMES,
       files.filter(file => !file.startsWith('.')).map(file => file.replace('.md', ''))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,14 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
+eslint-plugin-es@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz#0f5f5da5f18aa21989feebe8a73eadefb3432976"
+  integrity sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==
+  dependencies:
+    eslint-utils "^1.4.2"
+    regexpp "^3.0.0"
+
 eslint-plugin-eslint-comments@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
@@ -1285,6 +1293,18 @@ eslint-plugin-import@^2.18.2:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
+
+eslint-plugin-node@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz#fd1adbc7a300cf7eb6ac55cf4b0b6fc6e577f5a6"
+  integrity sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==
+  dependencies:
+    eslint-plugin-es "^2.0.0"
+    eslint-utils "^1.4.2"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
 
 eslint-plugin-prettier@^3.1.1:
   version "3.1.1"
@@ -1929,7 +1949,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5:
+ignore@^5.0.5, ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -3646,6 +3666,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
+
 remove-trailing-separator@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
@@ -3735,7 +3760,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0:
+resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -3839,7 +3864,7 @@ sax@^1.2.4:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
-semver@^6.1.2, semver@^6.2.0:
+semver@^6.1.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Fixes these violations:

```
eslint-plugin-ember/lib/rules/require-computed-property-dependencies.js
  6:25  error  "eslint" is not published                 node/no-unpublished-require
  8:25  error  "eslint/lib/util/traverser" is not found  node/no-missing-require
  8:25  error  "eslint" is not published                 node/no-unpublished-require

eslint-plugin-ember/tests/plugin-exports.js
  11:5  error  'assert.equal' was deprecated since v10.0.0. Use 'assert.strictEqual' instead  node/no-deprecated-api
  16:5  error  'assert.equal' was deprecated since v10.0.0. Use 'assert.strictEqual' instead  node/no-deprecated-api

eslint-plugin-ember/tests/rule-setup.js
  16:5  error  'assert.deepEqual' was deprecated since v10.0.0. Use 'assert.deepStrictEqual' instead  node/no-deprecated-api
  23:5  error  'assert.deepEqual' was deprecated since v10.0.0. Use 'assert.deepStrictEqual' instead  node/no-deprecated-api
  33:5  error  'assert.deepEqual' was deprecated since v10.0.0. Use 'assert.deepStrictEqual' instead  node/no-deprecated-api
  43:5  error  'assert.deepEqual' was deprecated since v10.0.0. Use 'assert.deepStrictEqual' instead  node/no-deprecated-api
```