### PR TITLE
Add peer dependency on eslint version 5 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "ember-rfc176-data": "^0.3.12",
     "snake-case": "^2.1.0"
   },
+  "peerDependencies": {
+    "eslint": ">= 5"
+  },
   "changelog": {
     "repo": "ember-cli/eslint-plugin-ember",
     "labels": {


### PR DESCRIPTION
This matches the minimum requirement mentioned in the README. Most eslint plugins specify a peer dependency like this. Eslint >= 5 has been required since v7.