### PR TITLE
Add `onlyThisContexts` option to `no-arrow-function-computed-properties` rule

### DIFF
--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -32,6 +32,12 @@ const Person = EmberObject.extend({
 });
 ```
 
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `onlyThisContexts` -- whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference (default: `false`)
+
 ## References
 
 * [Arrow function spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -17,13 +17,24 @@ module.exports = {
   },
 
   create(context) {
+    let isThisPresent = false;
+
     return {
-      CallExpression(node) {
-        if (
+      ThisExpression() {
+        isThisPresent = true;
+      },
+      CallExpression() {
+        isThisPresent = false;
+      },
+      'CallExpression:exit'(node) {
+        const isComputedArrow =
           emberUtils.isComputedProp(node) &&
           node.arguments.length > 0 &&
-          types.isArrowFunctionExpression(node.arguments[node.arguments.length - 1])
-        ) {
+          types.isArrowFunctionExpression(node.arguments[node.arguments.length - 1]);
+
+        const isLintApplicable = isComputedArrow && isThisPresent;
+
+        if (isLintApplicable) {
           context.report(node.arguments[node.arguments.length - 1], ERROR_MESSAGE);
         }
       },

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -17,6 +17,9 @@ module.exports = {
   },
 
   create(context) {
+    const options = context.options[0] || {};
+    const onlyThisContexts = options.onlyThisContexts || false;
+
     let isThisPresent = false;
 
     return {
@@ -32,9 +35,15 @@ module.exports = {
           node.arguments.length > 0 &&
           types.isArrowFunctionExpression(node.arguments[node.arguments.length - 1]);
 
-        const isLintApplicable = isComputedArrow && isThisPresent;
+        if (!isComputedArrow) {
+          return;
+        }
 
-        if (isLintApplicable) {
+        if (onlyThisContexts) {
+          if (isThisPresent) {
+            context.report(node.arguments[node.arguments.length - 1], ERROR_MESSAGE);
+          }
+        } else {
           context.report(node.arguments[node.arguments.length - 1], ERROR_MESSAGE);
         }
       },

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -19,19 +19,32 @@ const ruleTester = new RuleTester({
 });
 ruleTester.run('no-arrow-function-computed-properties', rule, {
   valid: [
-    'computed()',
-    'computed(function() { return 123; })',
-    "computed('prop', function() { return this.prop; })",
-    "computed('prop', function() { return this.prop; }).volatile()",
-    "computed.map('products', function(product) { return someFunction(product); })",
-    'other(() => {})',
-    'other.computed(() => {})',
-    'computed(() => { return 123; })',
-    'computed(() => { return "string stuff"; })',
-    'computed(() => [])',
-    "computed.map('products', product => { return someFunction(product); })",
+    {
+      code: `
+        computed('prop', function() { return this.prop; });
+        computed('prop', function() { return this.prop; }).volatile();
+        computed(() => { return 123; });
+        computed(() => { return "string stuff"; });
+        computed(() => []);
+        computed.map('products', product => { return someFunction(product); });
+      `,
+      options: [{ onlyThisContexts: true }],
+    },
+    `
+    computed();
+    computed(function() { return 123; });
+    computed('prop', function() { return this.prop; });
+    computed('prop', function() { return this.prop; }).volatile();
+    computed.map('products', function(product) { return someFunction(product); });
+    other(() => {});
+    other.computed(() => {});
+    `,
   ],
   invalid: [
+    {
+      code: 'computed(() => { return 123; })',
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
     {
       code: "computed('prop', () => { return this.prop; })",
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
@@ -39,6 +52,10 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
 
     {
       code: "computed('prop', () => { return this.prop; }).volatile()",
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+    {
+      code: "computed.map('products', product => { return someFunction(product); })",
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
   ],

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -19,26 +19,37 @@ const ruleTester = new RuleTester({
 });
 ruleTester.run('no-arrow-function-computed-properties', rule, {
   valid: [
+    'computed()',
+    'computed(function() { return 123; })',
+    'computed("prop", function() { return this.prop; })',
+    'computed("prop", function() { return this.prop; }).volatile()',
+    'computed.map("products", function(product) { return someFunction(product); })',
+    'other(() => {})',
+    'other.computed(() => {})',
     {
-      code: `
-        computed('prop', function() { return this.prop; });
-        computed('prop', function() { return this.prop; }).volatile();
-        computed(() => { return 123; });
-        computed(() => { return "string stuff"; });
-        computed(() => []);
-        computed.map('products', product => { return someFunction(product); });
-      `,
+      code: `computed('prop', function() { return this.prop; });`,
       options: [{ onlyThisContexts: true }],
     },
-    `
-    computed();
-    computed(function() { return 123; });
-    computed('prop', function() { return this.prop; });
-    computed('prop', function() { return this.prop; }).volatile();
-    computed.map('products', function(product) { return someFunction(product); });
-    other(() => {});
-    other.computed(() => {});
-    `,
+    {
+      code: `computed('prop', function() { return this.prop; }).volatile();`,
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: `computed(() => { return 123; });`,
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: `computed(() => { return "string stuff"; });`,
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: `computed(() => []);`,
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: `computed.map('products', product => { return someFunction(product); });`,
+      options: [{ onlyThisContexts: true }],
+    },
   ],
   invalid: [
     {
@@ -57,6 +68,21 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
     {
       code: "computed.map('products', product => { return someFunction(product); })",
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+    },
+    {
+      code: 'computed(() => { return 123; })',
+      errors: [],
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: "computed('prop', () => { return this.prop; })",
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+      options: [{ onlyThisContexts: true }],
+    },
+    {
+      code: "computed('prop', () => { return this.prop; }).volatile()",
+      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
+      options: [{ onlyThisContexts: true }],
     },
   ],
 });

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -26,13 +26,12 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
     "computed.map('products', function(product) { return someFunction(product); })",
     'other(() => {})',
     'other.computed(() => {})',
+    'computed(() => { return 123; })',
+    'computed(() => { return "string stuff"; })',
+    'computed(() => [])',
+    "computed.map('products', product => { return someFunction(product); })",
   ],
   invalid: [
-    {
-      code: 'computed(() => { return 123; })',
-      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
-    },
-
     {
       code: "computed('prop', () => { return this.prop; })",
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
@@ -40,11 +39,6 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
 
     {
       code: "computed('prop', () => { return this.prop; }).volatile()",
-      errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
-    },
-
-    {
-      code: "computed.map('products', product => { return someFunction(product); })",
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
   ],


### PR DESCRIPTION
arrow functions only affect the `this`, so if you have computed properties without a `this`, such as when primitives or empty objects are used as the value, the arrow function usage is totally valid :)

This PR skips the lint rule when this is not present, otherwise it behaves as it did before.