### PR TITLE
Add `ignoreNonThisExpressions` option to `use-ember-get-and-set` rule

### DIFF
--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -12,6 +12,8 @@ ember/use-ember-get-and-set: [2, {
 
 Setting `ignoreThisExpressions` to `true` allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`.
 
+Setting `ignoreNonThisExpressions` to `true` allows use of non-Ember objects like `server.get()` and `map.set()`.
+
 #### Description
 
 This way you don't have to worry whether the object that you're trying to access is an `Ember.Object` or not. It also solves the problem of trying to wrap every object in `Ember.Object` in order to be able to use things like `getWithDefault`.

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -115,6 +115,13 @@ module.exports = {
         if (options.ignoreThisExpressions && isThisExpression(callee.object)) {
           return;
         }
+        // Only lint calls made on this
+        if (options.ignoreNonThisExpressions && isThisExpression(callee.object)) {
+          report(node);
+          return;
+        } else if (options.ignoreNonThisExpressions) {
+          return;
+        }
         // Skip calls made on Ember methods
         if (isIdentifier(callee.object) && callee.object.name === emberImportAliasName) {
           return;

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -48,6 +48,16 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import EmberAlias from "ember"; EmberAlias.get(this, "test")',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: "let a = new Map(); a.set('name', 'Tomster');",
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{ ignoreNonThisExpressions: true }],
+    },
+    {
+      code: "let a = new Map(); a.get('myKey')",
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{ ignoreNonThisExpressions: true }],
+    },
   ],
   invalid: [
     // Non-fixable errors
@@ -389,6 +399,18 @@ eslintTester.run('use-ember-get-and-set', rule, {
       output: 'import Ember from "ember"; Ember.getWithDefault(controller, "test", "default")',
       errors: [{ message: 'Use get/set' }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: `this.set('test', 'value')`,
+      output: null,
+      errors: [{ message: 'Use get/set' }],
+      options: [{ ignoreNonThisExpressions: true }],
+    },
+    {
+      code: `this.get('value')`,
+      output: null,
+      errors: [{ message: 'Use get/set' }],
+      options: [{ ignoreNonThisExpressions: true }],
     },
   ],
 });


### PR DESCRIPTION
The rule `use-ember-get-and-set rule` is too strict where it will flag get/set that are non-Ember related (see #243)

Examples:
```
// ember-cli-mirage
server.get(...);

// Map
let m = new Map(); m.set(...);
```

Given that it's difficult to figure out whether the callee is an Ember object, I've added a config option called `ignoreNonThisExpressions ` to allow devs to quiet these false positives