### PR TITLE
Modernize documentation for `alias-model-in-controller` rule

### DIFF
--- a/docs/rules/alias-model-in-controller.md
+++ b/docs/rules/alias-model-in-controller.md
@@ -2,34 +2,39 @@
 
 ### Rule name: `alias-model-in-controller`
 
-It makes code more readable if model has the same name as a subject. It’s more maintainable, and will conform to future  routable components. We can do this in two ways:
+It makes code more readable if model has the same name as a subject. We can do this in two ways:
 
-- set alias to model (in case when there is a `Nail Controller`):
+- Alias the model to another property name in the Controller:
+
+  ```javascript
+  import Controller from '@ember/controller';
+  import { alias } from '@ember/object/computed';
+
+  export default Controller.extend({
+    nail: alias('model'),
+  });
+  ```
+
+- Set it as a property in the Route's `setupController` method:
+
+  ```javascript
+  import Route from '@ember/routing/route';
+
+  export default Route.extend({
+    setupController(controller, model) {
+      controller.set('nail', model);
+    },
+  });
+  ```
+
+If you're passing [multiple models](https://guides.emberjs.com/v2.13.0/routing/specifying-a-routes-model/#toc_multiple-models) as an [`RSVP.hash`](https://emberjs.com/api/classes/RSVP.html#method_hash), you can also alias nested properties:
+
 ```javascript
-const { alias } = Ember.computed;
-export default Ember.Controller.extend({
-  nail: alias('model'),
-});
-```
+import Controller from '@ember/controller';
+import { reads } from '@ember/object/computed';
 
-- set it in `setupController` method:
-```javascript
-export default Ember.Route.extend({
-  setupController(controller, model) {
-    controller.set('nail', model);
-  },
-});
-```
-
-If you're passing
-[multiple models](https://guides.emberjs.com/v2.13.0/routing/specifying-a-routes-model/#toc_multiple-models) as an
-[`RSVP.hash`](https://emberjs.com/api/classes/RSVP.html#method_hash),
-you can also alias nested properties:
-
-```javascript
-const { reads } = Ember.computed;
-export default Ember.Controller.extend({
+export default Controller.extend({
   people: reads('model.people'),
-  pets:   reads('model.pets')
+  pets: reads('model.pets')
 });
 ```


### PR DESCRIPTION
- Removes reference to Routable Components from the `alias-model-in-controller` documentation
- Re-formats the document to render more clearly
- Updates code examples to match modern Ember usage

Fixes #535