### PR TITLE
Avoid crash from missing function check in `require-super-in-init` rule

### DIFF
--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -103,7 +103,7 @@ module.exports = {
           .getModuleProperties(node)
           .find(property => property.key.name === 'init');
 
-        if (initProperty) {
+        if (initProperty && types.isFunctionExpression(initProperty.value)) {
           const initPropertyBody = initProperty.value.body.body;
           const nodes = findStmtNodes(initPropertyBody);
           const hasSuper = checkForSuper(nodes);

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -194,6 +194,12 @@ eslintTester.run('require-super-in-init', rule, {
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    {
+      code: `export default Service({
+        init
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes the following error caused by the included test case.

```
TypeError: Cannot read property 'body' of undefined
```