### PR TITLE
Add rule documentation template

### DIFF
--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -1,0 +1,55 @@
+# (rule name goes here)
+
+(context about the problem goes here)
+
+## Rule Details
+
+(what the rule does goes here)
+
+## Examples
+
+This rule **forbids** the following:
+
+```js
+// Example 1
+```
+
+```js
+// Example 2
+```
+
+This rule **allows** the following:
+
+```js
+// Example 1
+```
+
+```js
+// Example 2
+```
+
+## Migration
+
+(suggest any fast/automated techniques for fixing violations in a large codebase)
+
+* suggestion on how to fix violations using find-and-replace / regexp
+* suggestion on how to fix violations using a codemod
+
+## Configuration
+
+(exclude this section if the rule has no extra configuration)
+
+* object -- containing the following properties:
+  * string -- `parameterName1` -- description of parameter including the possible values and default value
+  * boolean -- `parameterName2` -- description of parameter including the possible values and default value
+
+## Related Rules
+
+* [related-rule-name1](related-rule-name1.md)
+* [related-rule-name2](related-rule-name2.md)
+
+## References
+
+* (link to relevant documentation goes here)
+* (link to relevant function spec goes here)
+* (link to relevant guide goes here)

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -45,7 +45,9 @@ describe('rules setup is correct', function() {
     // eslint-disable-next-line node/no-deprecated-api
     assert.deepEqual(
       RULE_NAMES,
-      files.filter(file => !file.startsWith('.')).map(file => file.replace('.md', ''))
+      files
+        .filter(file => !file.startsWith('.') && file !== '_TEMPLATE_.md')
+        .map(file => file.replace('.md', ''))
     );
   });
 


### PR DESCRIPTION
Makes it easier to write better documentation for new rules.

Based on: https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/_TEMPLATE_.md