### PR TITLE
fix: address `require-tagless-components` PR feedback

### DIFF
--- a/docs/rules/require-tagless-components.md
+++ b/docs/rules/require-tagless-components.md
@@ -88,7 +88,6 @@ export default class MyComponent extends Component {}
 ### Caveats
 
 * Rule does not catch cases where a Mixin is included to configure the `tagName` property.
-* Rule does not catch cases where a decorator is applied to configure the `tagName` property.
 
 ## Fixing This Rule
 
@@ -106,5 +105,6 @@ Note that you might want to wrap the component template in an additional element
 ## Further Reading
 
 * [Glimmer Components](https://glimmerjs.com/guides/components-and-actions)
+  * Glimmer components are "the future" for Ember, and are _always_ tagless. Using them now, or changing your Ember components to be tagless, helps to modernize your codebase and prepare for a point in the future where components _never_ have a wrapper element.
 * [RFC #311 "Angle Bracket Invocation" (HTML Attributes section)](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html#html-attributes)
   * Discusses forwarding attributes on a component to a DOM element using `...attributes`

--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -47,13 +47,13 @@ ruleTester.run('require-tagless-components', rule, {
     `
       import SomeOtherThing from 'some-other-module';
       export default SomeOtherThing.extend({
-        tagName: ''
+        tagName: 'some-non-empty-value'
       });
     `,
     `
       import SomeOtherThing from 'some-other-module';
       export default class MyThing extends SomeOtherThing {
-        tagName = '';
+        tagName = 'some-non-empty-value';
       }
     `,
   ],


### PR DESCRIPTION
Responds to feedback left in #548

* Removes caveat around using the `tagName` decorator, which is no longer applicable
* Adds more information on how Glimmer components related to using tagless Ember Components
* Improve some tests to really verify what they were meant to verify