### PR TITLE
Lint against unnecessary template literals internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,6 +77,7 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
+    'quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }], // Disallow unnecessary template literals.
     radix: 'error',
     'require-atomic-updates': 'error',
     'require-await': 'error',

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -2,7 +2,8 @@
 
 const utils = require('../utils/utils');
 
-const ERROR_MESSAGE = `Don't use computed properties with native classes. Use getters or @tracked properties instead.`;
+const ERROR_MESSAGE =
+  "Don't use computed properties with native classes. Use getters or @tracked properties instead.";
 
 /**
  * Locates all the ImportDeclaration with computed properties.

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -414,7 +414,7 @@ module.exports = {
           if (undeclaredKeys.length > 0) {
             context.report({
               node,
-              message: `Use of undeclared dependencies in computed property: {{undeclaredKeys}}`,
+              message: 'Use of undeclared dependencies in computed property: {{undeclaredKeys}}',
               data: { undeclaredKeys: undeclaredKeys.join(', ') },
               fix(fixer) {
                 const sourceCode = context.getSourceCode();

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -50,11 +50,11 @@ eslintTester.run('new-module-imports', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
-      code: `export const Ember = 1;`,
+      code: 'export const Ember = 1;',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
-      code: `for (let i = 0; i < 10; i++) { }`,
+      code: 'for (let i = 0; i < 10; i++) { }',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
   ],

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -27,27 +27,27 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
     'other(() => {})',
     'other.computed(() => {})',
     {
-      code: `computed('prop', function() { return this.prop; });`,
+      code: "computed('prop', function() { return this.prop; });",
       options: [{ onlyThisContexts: true }],
     },
     {
-      code: `computed('prop', function() { return this.prop; }).volatile();`,
+      code: "computed('prop', function() { return this.prop; }).volatile();",
       options: [{ onlyThisContexts: true }],
     },
     {
-      code: `computed(() => { return 123; });`,
+      code: 'computed(() => { return 123; });',
       options: [{ onlyThisContexts: true }],
     },
     {
-      code: `computed(() => { return "string stuff"; });`,
+      code: 'computed(() => { return "string stuff"; });',
       options: [{ onlyThisContexts: true }],
     },
     {
-      code: `computed(() => []);`,
+      code: 'computed(() => []);',
       options: [{ onlyThisContexts: true }],
     },
     {
-      code: `computed.map('products', product => { return someFunction(product); });`,
+      code: "computed.map('products', product => { return someFunction(product); });",
       options: [{ onlyThisContexts: true }],
     },
   ],

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -401,13 +401,13 @@ eslintTester.run('use-ember-get-and-set', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
     {
-      code: `this.set('test', 'value')`,
+      code: "this.set('test', 'value')",
       output: null,
       errors: [{ message: 'Use get/set' }],
       options: [{ ignoreNonThisExpressions: true }],
     },
     {
-      code: `this.get('value')`,
+      code: "this.get('value')",
       output: null,
       errors: [{ message: 'Use get/set' }],
       options: [{ ignoreNonThisExpressions: true }],

--- a/tests/lib/utils/new-module-test.js
+++ b/tests/lib/utils/new-module-test.js
@@ -11,24 +11,24 @@ const modulesData = {
 
 describe('isDestructuring', () => {
   it('should check a destructuring import', () => {
-    const node = babelEslint.parse(`const { destructured } = someVar;`).body[0].declarations[0];
+    const node = babelEslint.parse('const { destructured } = someVar;').body[0].declarations[0];
     expect(isDestructuring(node)).toBeTruthy();
   });
 
   it('should check a non-destructuring import', () => {
-    const node = babelEslint.parse(`const destructured = someVar;`).body[0].declarations[0];
+    const node = babelEslint.parse('const destructured = someVar;').body[0].declarations[0];
     expect(isDestructuring(node)).toBeFalsy();
   });
 
   it('should check a ForInStatement', () => {
-    const node = babelEslint.parse(`for (const item in list) {};`).body[0].left.declarations[0];
+    const node = babelEslint.parse('for (const item in list) {};').body[0].left.declarations[0];
     expect(isDestructuring(node)).toBeFalsy();
   });
 });
 
 describe('buildFix', () => {
   it('returns a function', () => {
-    const node = babelEslint.parse(`import Model from "ember-data/model"`).body[0];
+    const node = babelEslint.parse('import Model from "ember-data/model"').body[0];
     const fix = buildFix(node, modulesData);
     expect(typeof fix === 'function').toBeTruthy();
   });


### PR DESCRIPTION
Autofixed violations.

Related docs:
* https://eslint.org/docs/rules/quotes
* https://github.com/prettier/eslint-config-prettier#quotes
* https://prettier.io/docs/en/rationale.html#strings

Same as this PR: https://github.com/ember-template-lint/ember-template-lint/pull/891