### PR TITLE
Update `no-new-mixins` rule to handle native classes

### DIFF
--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -27,6 +27,12 @@ module.exports = {
           context.report(node, ERROR_MESSAGE);
         }
       },
+
+      ClassDeclaration(node) {
+        if (ember.isEmberMixin(context, node)) {
+          context.report(node, ERROR_MESSAGE);
+        }
+      },
     };
   },
 };

--- a/tests/lib/rules/no-new-mixins.js
+++ b/tests/lib/rules/no-new-mixins.js
@@ -29,11 +29,7 @@ eslintTester.run('no-new-mixins', rule, {
         export default Ember.Mixin.create({});
       `,
       output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-        },
-      ],
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: `
@@ -42,11 +38,15 @@ eslintTester.run('no-new-mixins', rule, {
         export default Mixin.create({});
       `,
       output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-        },
-      ],
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Mixin from "@ember/object/mixin";
+        class MyMixin extends Mixin {}
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ClassDeclaration' }],
     },
   ],
 });


### PR DESCRIPTION
Part of #560.