### PR TITLE
Simplify some tests by setting `parserOptions` globally instead of in each individual test case

### DIFF
--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -9,122 +9,51 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('alias-model-in-controller', rule, {
   valid: [
     // direct alias
 
-    {
-      code: 'export default Ember.Controller.extend({nail: alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: Ember.computed.alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: readOnly("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.readOnly("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: Ember.computed.readOnly("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: reads("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.reads("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: Ember.computed.reads("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Ember.Controller.extend({nail: alias("model")});',
+    'export default Ember.Controller.extend({nail: computed.alias("model")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.alias("model")});',
+    'export default Ember.Controller.extend({nail: readOnly("model")});',
+    'export default Ember.Controller.extend({nail: computed.readOnly("model")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.readOnly("model")});',
+    'export default Ember.Controller.extend({nail: reads("model")});',
+    'export default Ember.Controller.extend({nail: computed.reads("model")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.reads("model")});',
+    'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model")});',
+    'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
     {
       filename: 'example-app/controllers/path/to/some-feature.js',
       code: 'export default CustomController.extend({nail: alias("model")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
 
     // nested alias
 
-    {
-      code: 'export default Ember.Controller.extend({nail: alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: Ember.computed.alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: readOnly("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.readOnly("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Ember.Controller.extend({nail: Ember.computed.readOnly("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: reads("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: computed.reads("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Ember.Controller.extend({nail: Ember.computed.reads("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Ember.Controller.extend({nail: alias("model.nail")});',
+    'export default Ember.Controller.extend({nail: computed.alias("model.nail")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.alias("model.nail")});',
+    'export default Ember.Controller.extend({nail: readOnly("model.nail")});',
+    'export default Ember.Controller.extend({nail: computed.readOnly("model.nail")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.readOnly("model.nail")});',
+    'export default Ember.Controller.extend({nail: reads("model.nail")});',
+    'export default Ember.Controller.extend({nail: computed.reads("model.nail")});',
+    'export default Ember.Controller.extend({nail: Ember.computed.reads("model.nail")});',
+    'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model.nail")});',
+    'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model.nail")});',
     {
       filename: 'example-app/controllers/path/to/some-feature.js',
       code: 'export default CustomController.extend({nail: alias("model.nail")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
   ],
   invalid: [
     {
       code: 'export default Ember.Controller.extend({});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -134,7 +63,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend({resetPassword: service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -144,7 +72,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend({resetPassword: inject.service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -154,7 +81,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend({resetPassword: Ember.inject.service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -164,7 +90,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend(TestMixin, {});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -174,7 +99,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     },
     {
       code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -185,7 +109,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       filename: 'example-app/controllers/path/to/some-feature.js',
       code: 'export default CustomController.extend({});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -196,7 +119,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       filename: 'example-app/some-feature/controller.js',
       code: 'export default CustomController.extend({});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -207,7 +129,6 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       filename: 'example-app/twisted-path/some-file.js',
       code: 'export default Controller.extend({});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/closure-actions.js
+++ b/tests/lib/rules/closure-actions.js
@@ -11,23 +11,19 @@ const { ERROR_MESSAGE } = rule;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('closure-actions', rule, {
   valid: [
-    {
-      code: 'export default Component.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({actions: {pushLever() {this.attr.boom();}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Component.extend();',
+    'export default Component.extend({actions: {pushLever() {this.attr.boom();}}});',
   ],
   invalid: [
     {
       code:
         'export default Component.extend({actions: {pushLever() {this.sendAction("detonate");}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/jquery-ember-run.js
+++ b/tests/lib/rules/jquery-ember-run.js
@@ -9,20 +9,18 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('jquery-ember-run', rule, {
   valid: [
-    {
-      code:
-        'Ember.$("#something-rendered-by-jquery-plugin").on("click", () => {Ember.run.bind(this, this._handlerActionFromController);});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'Ember.$("#something-rendered-by-jquery-plugin").on("click", () => {Ember.run.bind(this, this._handlerActionFromController);});',
   ],
   invalid: [
     {
       code:
         'Ember.$("#something-rendered-by-jquery-plugin").on("click", () => {this._handlerActionFromController();});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -9,48 +9,23 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6 },
+});
+
 eslintTester.run('named-functions-in-promises', rule, {
   valid: [
-    {
-      code: 'user.save().then(this._reloadUser.bind(this));',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().catch(this._handleError.bind(this));',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().finally(this._finallyDo.bind(this));',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().then(this._reloadUser);',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().catch(this._handleError);',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().finally(this._finallyDo);',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().then(_reloadUser);',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().catch(_handleError);',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'user.save().finally(_finallyDo);',
-      parserOptions: { ecmaVersion: 6 },
-    },
+    'user.save().then(this._reloadUser.bind(this));',
+    'user.save().catch(this._handleError.bind(this));',
+    'user.save().finally(this._finallyDo.bind(this));',
+    'user.save().then(this._reloadUser);',
+    'user.save().catch(this._handleError);',
+    'user.save().finally(this._finallyDo);',
+    'user.save().then(_reloadUser);',
+    'user.save().catch(_handleError);',
+    'user.save().finally(_finallyDo);',
     {
       code: 'user.save().then(() => this._reloadUser(user));',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -59,7 +34,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().catch(err => this._handleError(err));',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -68,7 +42,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().finally(() => this._finallyDo());',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -77,7 +50,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().then(() => user.reload());',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -88,7 +60,6 @@ eslintTester.run('named-functions-in-promises', rule, {
   invalid: [
     {
       code: 'user.save().then(() => {return user.reload();});',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -98,7 +69,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().catch(() => {return error.handle();});',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -108,7 +78,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().finally(() => {return finallyDo();});',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -118,7 +87,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().then(() => {return user.reload();});',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -133,7 +101,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().catch(() => {return error.handle();});',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -148,7 +115,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().finally(() => {return finallyDo();});',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,
@@ -163,7 +129,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().then(() => this._reloadUser(user));',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -173,7 +138,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().catch(err => this._handleError(err));',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -183,7 +147,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().finally(() => this._finallyDo());',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -193,7 +156,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().then(() => user.reload());',
-      parserOptions: { ecmaVersion: 6 },
       output: null,
       errors: [
         {
@@ -203,7 +165,6 @@ eslintTester.run('named-functions-in-promises', rule, {
     },
     {
       code: 'user.save().then(user => user.name);',
-      parserOptions: { ecmaVersion: 6 },
       options: [
         {
           allowSimpleArrowFunction: true,

--- a/tests/lib/rules/no-attrs-in-components.js
+++ b/tests/lib/rules/no-attrs-in-components.js
@@ -11,17 +11,17 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 ruleTester.run('no-attrs-in-components', rule, {
   valid: [
-    {
-      code: `Component.extend({
+    `Component.extend({
         init() {
           const newName = get(this, '_name');
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
 
   invalid: [
@@ -31,7 +31,6 @@ ruleTester.run('no-attrs-in-components', rule, {
           const newName = this.attrs.name;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -2,12 +2,13 @@ const rule = require('../../../lib/rules/no-attrs-snapshot');
 const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
 
 eslintTester.run('no-attrs-snapshot', rule, {
   valid: [
-    {
-      code: `
+    `
         export default Ember.Component({
           init() {
             this._super(...arguments);
@@ -23,10 +24,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
             }
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `
+    `
         export default Ember.Component({
           init() {
             this._super(...arguments);
@@ -42,8 +40,6 @@ eslintTester.run('no-attrs-snapshot', rule, {
             }
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
   invalid: [
     {
@@ -62,7 +58,6 @@ eslintTester.run('no-attrs-snapshot', rule, {
             }
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -86,7 +81,6 @@ eslintTester.run('no-attrs-snapshot', rule, {
             }
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-ember-super-in-es-classes.js
+++ b/tests/lib/rules/no-ember-super-in-es-classes.js
@@ -9,46 +9,36 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6 },
+});
+
 eslintTester.run('no-ember-super-in-es-classes', rule, {
   valid: [
-    {
-      code: 'EmberObject.extend({ init() { this._super(); } })',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'EmberObject.extend({ init(a, b) { this._super(a, b); } })',
-      parserOptions: { ecmaVersion: 6 },
-    },
-    {
-      code: 'EmberObject.extend({ init() { this._super(...arguments); } })',
-      parserOptions: { ecmaVersion: 6 },
-    },
+    'EmberObject.extend({ init() { this._super(); } })',
+    'EmberObject.extend({ init(a, b) { this._super(a, b); } })',
+    'EmberObject.extend({ init() { this._super(...arguments); } })',
   ],
   invalid: [
     {
       code: 'class Foo { init() { this._super(); } }',
       output: 'class Foo { init() { super.init(); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { init(a, b) { this._super(a); } }',
       output: 'class Foo { init(a, b) { super.init(a); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { init() { this._super(...arguments); } }',
       output: 'class Foo { init() { super.init(...arguments); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { init() { this._super.apply(this, arguments); } }',
       output: 'class Foo { init() { super.init.apply(this, arguments); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { init() { if (x) { this._super(1); } else { this._super(2); } } }',
@@ -57,19 +47,16 @@ eslintTester.run('no-ember-super-in-es-classes', rule, {
         { message: "Don't use `this._super` in ES classes" },
         { message: "Don't use `this._super` in ES classes" },
       ],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { "a b"() { this._super(); } }',
       output: 'class Foo { "a b"() { super["a b"](); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code: 'class Foo { [Symbol.iterator]() { this._super(); } }',
       output: 'class Foo { [Symbol.iterator]() { super[Symbol.iterator](); } }',
       errors: [{ message: "Don't use `this._super` in ES classes" }],
-      parserOptions: { ecmaVersion: 6 },
     },
   ],
 });

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -9,38 +9,28 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 const message = 'Supply proper attribute type';
 
 eslintTester.run('no-empty-attrs', rule, {
   valid: [
-    {
-      code: 'export default Model.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Model.extend({name: attr("string"), points: attr("number"), dob: attr("date")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Model.extend({name: attr("string")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Model.extend();',
+    'export default Model.extend({name: attr("string"), points: attr("number"), dob: attr("date")});',
+    'export default Model.extend({name: attr("string")});',
     {
       code: `someArrayOfStrings.filter(function(attr) {
         return attr.underscore();
       });`,
       parserOptions: { ecmaVersion: 6 },
     },
-    {
-      code: `export default Model.extend({
+    `export default Model.extend({
         someArray: someArrayOfStrings.filter(function(attr) {
           return attr.underscore();
         }),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
   invalid: [
     {
@@ -49,7 +39,6 @@ eslintTester.run('no-empty-attrs', rule, {
         points: attr("number"),
         dob: attr("date")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -59,7 +48,6 @@ eslintTester.run('no-empty-attrs', rule, {
         points: attr("number"),
         dob: attr()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 4 }],
     },
@@ -69,7 +57,6 @@ eslintTester.run('no-empty-attrs', rule, {
         points: attr(),
         dob: attr("date")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 3 }],
     },
@@ -80,7 +67,6 @@ eslintTester.run('no-empty-attrs', rule, {
         dob: attr(),
         someComputedProperty: computed.bool(true)
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 3 }, { message, line: 4 }],
     },
@@ -90,14 +76,12 @@ eslintTester.run('no-empty-attrs', rule, {
         points: attr(),
         dob: attr()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }, { message, line: 3 }, { message, line: 4 }],
     },
     {
       filename: 'example-app/models/some-model.js',
       code: 'export default CustomModel.extend({name: attr()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 1 }],
     },

--- a/tests/lib/rules/no-function-prototype-extensions.js
+++ b/tests/lib/rules/no-function-prototype-extensions.js
@@ -9,80 +9,32 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('no-function-prototype-extensions', rule, {
   valid: [
-    {
-      code: 'export default Controller.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({actions: {}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: function () {}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({init() {}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: computed("abc", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: observer("abc", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: beforeObserver("abc", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({actions: {test() {}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({actions: {test: function () {}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: on("init", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: observer("abc", function () {abc.on();})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Controller.extend({test: beforeObserver("abc", function () {abc.on();})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test: function () {$("body").on("click", abc);}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({test() {$("body").on("click", abc);}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Controller.extend({test() {$("body").on("click", abc).on("click", function () {});}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Controller.extend();',
+    'export default Controller.extend({actions: {}});',
+    'export default Controller.extend({test: function () {}});',
+    'export default Controller.extend({init() {}});',
+    'export default Controller.extend({test: computed("abc", function () {})});',
+    'export default Controller.extend({test: observer("abc", function () {})});',
+    'export default Controller.extend({test: beforeObserver("abc", function () {})});',
+    'export default Controller.extend({test: service()});',
+    'export default Controller.extend({actions: {test() {}}});',
+    'export default Controller.extend({actions: {test: function () {}}});',
+    'export default Controller.extend({test: on("init", function () {})});',
+    'export default Controller.extend({test: observer("abc", function () {abc.on();})});',
+    'export default Controller.extend({test: beforeObserver("abc", function () {abc.on();})});',
+    'export default Controller.extend({test: function () {$("body").on("click", abc);}});',
+    'export default Controller.extend({test() {$("body").on("click", abc);}});',
+    'export default Controller.extend({test() {$("body").on("click", abc).on("click", function () {});}});',
   ],
   invalid: [
     {
       code: 'export default Controller.extend({test: function() {}.property("abc")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -92,7 +44,6 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     },
     {
       code: 'export default Controller.extend({test: function() {}.observes("abc")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -102,7 +53,6 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     },
     {
       code: 'export default Controller.extend({test: function() {}.observesBefore("abc")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -112,7 +62,6 @@ eslintTester.run('no-function-prototype-extensions', rule, {
     },
     {
       code: 'export default Controller.extend({test: function() {}.on("init")});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -2,19 +2,18 @@ const rule = require('../../../lib/rules/no-jquery');
 const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
 
 eslintTester.run('no-jquery', rule, {
   valid: [
-    {
-      code: `
+    `
         export default Ember.Component({
           didInsertElement() {
             this.element.classList.add('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
     {
       filename: 'example-app/tests/integration/component/some-component-test.js',
       code: `
@@ -28,7 +27,6 @@ eslintTester.run('no-jquery', rule, {
         test('assert something', function() {
           assert.equal(find('.some-component').textContent.trim(), 'hello world');
         })`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
   ],
   invalid: [
@@ -40,7 +38,6 @@ eslintTester.run('no-jquery', rule, {
             $(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -57,7 +54,6 @@ eslintTester.run('no-jquery', rule, {
             $(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -74,7 +70,6 @@ eslintTester.run('no-jquery', rule, {
             return $.extend({}, a, b);
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -92,7 +87,6 @@ eslintTester.run('no-jquery', rule, {
             return jq.extend({}, a, b);
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -108,7 +102,6 @@ eslintTester.run('no-jquery', rule, {
             Ember.$(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -124,7 +117,6 @@ eslintTester.run('no-jquery', rule, {
             Em.$(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -141,7 +133,6 @@ eslintTester.run('no-jquery', rule, {
             E.$(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -158,7 +149,6 @@ eslintTester.run('no-jquery', rule, {
             jq(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -175,7 +165,6 @@ eslintTester.run('no-jquery', rule, {
             $(body).addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -191,7 +180,6 @@ eslintTester.run('no-jquery', rule, {
             this.$().addClass('active')
           }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -212,7 +200,6 @@ eslintTester.run('no-jquery', rule, {
         test('assert something', function() {
           assert.equal(this.$('.some-component').text().trim(), 'hello world');
         })`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -9,22 +9,18 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('no-observers', rule, {
   valid: [
-    {
-      code: 'export default Controller.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend({actions: {},});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Controller.extend();',
+    'export default Controller.extend({actions: {},});',
   ],
   invalid: [
     {
       code: 'Ember.observer("text", function() {});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-old-shims.js
+++ b/tests/lib/rules/no-old-shims.js
@@ -9,61 +9,48 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('no-old-shims', rule, {
-  valid: [
-    {
-      code: "import Ember from 'ember';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: "import RSVP from 'rsvp';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-  ],
+  valid: ["import Ember from 'ember';", "import RSVP from 'rsvp';"],
   invalid: [
     {
       code: "import Component from 'ember-component';",
       output: "import Component from '@ember/component';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import { capitalize, dasherize, foo } from 'ember-string';",
       output:
         "import { capitalize, dasherize } from '@ember/string';\nimport { foo } from 'ember-string';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import computed, { not } from 'ember-computed';",
       output:
         "import { computed } from '@ember/object';\nimport { not } from '@ember/object/computed';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import { log } from 'ember-debug';",
       output: "import { debug as log } from '@ember/debug';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import { log as debug } from 'ember-debug';",
       output: "import { debug } from '@ember/debug';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import Sortable from 'ember-controllers/sortable';",
       output: "import Sortable from 'ember-controllers/sortable';", // eslint-disable-line eslint-plugin/prefer-output-null
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{ message: "Don't use import paths from ember-cli-shims" }],
     },
     {
       code: "import Service from 'ember-service';\nimport inject from 'ember-service/inject';",
       output: "import Service from '@ember/service';\nimport { inject } from '@ember/service';",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         { message: "Don't use import paths from ember-cli-shims" },
         { message: "Don't use import paths from ember-cli-shims" },

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -9,74 +9,29 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 const message = "Don't use .on() for component lifecycle events.";
 
 eslintTester.run('no-on-calls-in-components', rule, {
   valid: [
-    {
-      code: 'export default Component.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({actions: {}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: inject.service()});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: false});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({classNames: ["abc", "def"]});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: computed(function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: observer("abc", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Component.extend({abc: observer("abc", function () {test.on("xyz", def)})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: function () {test.on("xyz", def)}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc() {$("body").on("click", def)}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Component.extend({didInsertElement() {$("body").on("click", def).on("click", function () {})}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({actions: {abc() {test.on("xyz", def)}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'export default Component.extend({actions: {abc() {$("body").on("click", def).on("click", function () {})}}});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend({abc: on("nonLifecycleEvent", function() {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'export default Component.extend();',
+    'export default Component.extend({actions: {}});',
+    'export default Component.extend({abc: service()});',
+    'export default Component.extend({abc: inject.service()});',
+    'export default Component.extend({abc: false});',
+    'export default Component.extend({classNames: ["abc", "def"]});',
+    'export default Component.extend({abc: computed(function () {})});',
+    'export default Component.extend({abc: observer("abc", function () {})});',
+    'export default Component.extend({abc: observer("abc", function () {test.on("xyz", def)})});',
+    'export default Component.extend({abc: function () {test.on("xyz", def)}});',
+    'export default Component.extend({abc() {$("body").on("click", def)}});',
+    'export default Component.extend({didInsertElement() {$("body").on("click", def).on("click", function () {})}});',
+    'export default Component.extend({actions: {abc() {test.on("xyz", def)}}});',
+    'export default Component.extend({actions: {abc() {$("body").on("click", def).on("click", function () {})}}});',
+    'export default Component.extend({abc: on("nonLifecycleEvent", function() {})});',
     {
       code: `
       let foo = { bar: 'baz' };
@@ -93,7 +48,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
       code: `export default Component.extend({
         test: on("didInsertElement", function () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -104,7 +58,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
         })),
         someComputedProperty: computed.bool(true)
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -114,7 +67,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
         someComputedProperty: Ember.computed.readOnly('Hello World!'),
         anotherTest: Ember.on("willDestroyElement", function () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }, { message, line: 4 }],
     },
@@ -122,7 +74,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
       filename: 'example-app/components/some-component/component.js',
       code:
         'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -134,7 +85,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
       filename: 'example-app/components/some-component.js',
       code:
         'export default CustomComponent.extend({test: on("didInsertElement", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -145,7 +95,6 @@ eslintTester.run('no-on-calls-in-components', rule, {
     {
       filename: 'example-app/twised-path/some-file.js',
       code: 'export default Component.extend({test: on("didInsertElement", function () {})});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -9,48 +9,24 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('no-side-effects', rule, {
   valid: [
-    {
-      code: 'testAmount: alias("test.length")',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'testAmount: computed("test.length", { get() { return ""; }, set() { set(this, "testAmount", test.length); }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'let foo = computed("test", function() { someMap.set(this, "testAmount", test.length); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'testAmount: computed("test.length", { get() { return ""; }, set() { setProperties(); }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'let foo = computed("test", function() { someMap.setProperties(); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'import Ember from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { Foo.set(this, "testAmount", test.length); return ""; });',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'testAmount: alias("test.length")',
+    'testAmount: computed("test.length", { get() { return ""; }, set() { set(this, "testAmount", test.length); }})',
+    'let foo = computed("test", function() { someMap.set(this, "testAmount", test.length); return ""; })',
+    'testAmount: computed("test.length", { get() { return ""; }, set() { setProperties(); }})',
+    'let foo = computed("test", function() { someMap.setProperties(); return ""; })',
+    'import Ember from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { Foo.set(this, "testAmount", test.length); return ""; });',
 
-    {
-      code:
-        'import Ember from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { Foo.setProperties(); return ""; });',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'import Ember from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { Foo.setProperties(); return ""; });',
   ],
   invalid: [
     {
       code: 'prop: computed("test", function() {this.set("testAmount", test.length); return "";})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -61,7 +37,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'prop: computed("test", function() { this.setProperties("testAmount", test.length); return "";})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -72,7 +47,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'prop: computed("test", function() {if (get(this, "testAmount")) { set(this, "testAmount", test.length); } return "";})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -83,7 +57,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'prop: computed("test", function() {if (get(this, "testAmount")) { setProperties(this, "testAmount", test.length); } return "";})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -94,7 +67,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'testAmount: computed("test.length", { get() { set(this, "testAmount", test.length); }, set() { set(this, "testAmount", test.length); }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -105,7 +77,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'testAmount: computed("test.length", { get() { setProperties(this, "testAmount", test.length); }, set() { setProperties(this, "testAmount", test.length); }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -116,7 +87,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'testAmount: computed("test.length", function() { const setSomething = () => { set(this, "testAmount", test.length); }; setSomething(); })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -127,7 +97,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'testAmount: computed("test.length", function() { const setSomething = () => { setProperties(this, "testAmount", test.length); }; setSomething(); })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -138,7 +107,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'let foo = computed("test", function() { Ember.set(this, "testAmount", test.length); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -149,7 +117,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'let foo = computed("test", function() { Ember.setProperties(this, "testAmount", test.length); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -160,7 +127,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'import Foo from "ember"; let foo = computed("test", function() { Foo.set(this, "testAmount", test.length); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -171,7 +137,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'import Foo from "ember"; let foo = computed("test", function() { Foo.setProperties(this, "testAmount", test.length); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -182,7 +147,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'import EmberFoo from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { EmberFoo.set(this, "testAmount", test.length); return ""; });',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -193,7 +157,6 @@ eslintTester.run('no-side-effects', rule, {
     {
       code:
         'import EmberFoo from "ember"; import Foo from "some-other-thing"; let foo = computed("test", function() { EmberFoo.setProperties(this, "testAmount", test.length); return ""; });',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -11,15 +11,14 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('order-in-components', rule, {
   valid: [
-    {
-      code: 'export default Component.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    'export default Component.extend();',
+    `export default Component.extend({
         role: "sloth",
 
         vehicle: alias("car"),
@@ -29,10 +28,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
 
         levelOfHappiness: computed("attitude", "health", () => {
@@ -40,37 +36,25 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         levelOfHappiness: computed("attitude", "health", () => {
         }),
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend(TestMixin, {
+    `export default Component.extend(TestMixin, {
         levelOfHappiness: computed("attitude", "health", () => {
         }),
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend(TestMixin, TestMixin2, {
+    `export default Component.extend(TestMixin, TestMixin2, {
         levelOfHappiness: computed("attitude", "health", () => {
         }),
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         abc: Ember.inject.service(),
         def: inject.service(),
         ghi: service(),
@@ -80,10 +64,7 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: computed("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `
+    `
         import { inject } from '@ember/service';
         export default Component.extend({
           abc: inject(),
@@ -96,20 +77,14 @@ eslintTester.run('order-in-components', rule, {
           })
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
         abc: [],
         def: {},
 
         ghi: alias("def")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         levelOfHappiness: computed("attitude", "health", () => {
         }),
 
@@ -121,10 +96,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         abc: observer("aaaa", () => {
         }),
 
@@ -137,10 +109,7 @@ eslintTester.run('order-in-components', rule, {
           return true;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         igh: service(),
 
         abc: [],
@@ -163,10 +132,7 @@ eslintTester.run('order-in-components', rule, {
           return true;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         init() {
         },
         didReceiveAttrs() {
@@ -194,10 +160,7 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         test: service(),
 
         didReceiveAttrs() {
@@ -206,10 +169,7 @@ eslintTester.run('order-in-components', rule, {
         tSomeAction: task(function* (url) {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         test: service(),
 
         test2: computed.equal("asd", "qwe"),
@@ -220,10 +180,7 @@ eslintTester.run('order-in-components', rule, {
         tSomeAction: task(function* (url) {
         }).restartable()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         test: service(),
 
         someEmptyMethod() {},
@@ -238,10 +195,7 @@ eslintTester.run('order-in-components', rule, {
           return true;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         classNameBindings: ["filterDateSelectClass"],
         content: [],
         currentMonthEndDate: null,
@@ -251,30 +205,21 @@ eslintTester.run('order-in-components', rule, {
         typeOfDate: null,
         action: K
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
 
         levelOfHappiness: computed.or("asd", "qwe"),
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
 
         levelOfHappiness: computed(function() {}),
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
 
         levelOfHappiness: computed(function() {
@@ -282,8 +227,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
     {
       code: `export default Component.extend({
         role: "sloth",
@@ -296,7 +239,6 @@ eslintTester.run('order-in-components', rule, {
 
         foobar: Ember.inject.service(),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['property', 'multi-line-function', 'single-line-function', 'actions'],
@@ -316,15 +258,13 @@ eslintTester.run('order-in-components', rule, {
 
         foobar: Ember.inject.service(),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['property', ['single-line-function', 'multi-line-function'], 'actions'],
         },
       ],
     },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         role: "sloth",
         qwe: foo ? 'bar' : null,
         abc: [],
@@ -332,34 +272,30 @@ eslintTester.run('order-in-components', rule, {
 
         ghi: alias("def")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         template: hbs\`Hello world {{name}}\`,
         name: "Jon Snow",
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         layout,
         tabindex: -1,
 
         someComputedValue: computed.reads('count'),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         foo: computed(function() {
         }).volatile(),
         bar: computed(function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    `export default Component.extend({
+        onFoo() {},
+        onFoo: () => {},
+        foo: computed(function() {
+        }).volatile(),
+        bar() { const foo = 'bar'}
+      });`,
     {
       code: `export default Component.extend({
         onFoo() {},
@@ -368,17 +304,6 @@ eslintTester.run('order-in-components', rule, {
         }).volatile(),
         bar() { const foo = 'bar'}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component.extend({
-        onFoo() {},
-        onFoo: () => {},
-        foo: computed(function() {
-        }).volatile(),
-        bar() { const foo = 'bar'}
-      });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: [
@@ -404,7 +329,6 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: computed("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -432,7 +356,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -452,7 +375,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -477,7 +399,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -502,7 +423,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -521,7 +441,6 @@ eslintTester.run('order-in-components', rule, {
         abc: true,
         i18n: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "i18n" service injection should be above the "abc" property on line 2',
@@ -534,7 +453,6 @@ eslintTester.run('order-in-components', rule, {
         vehicle: alias("car"),
         i18n: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -551,7 +469,6 @@ eslintTester.run('order-in-components', rule, {
           i18n: inject()
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -566,7 +483,6 @@ eslintTester.run('order-in-components', rule, {
         }),
         vehicle: alias("car")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -582,7 +498,6 @@ eslintTester.run('order-in-components', rule, {
         aaa: computed("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -598,7 +513,6 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: observer("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -613,7 +527,6 @@ eslintTester.run('order-in-components', rule, {
         init() {
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "init" lifecycle hook should be above the actions hash on line 2',
@@ -628,7 +541,6 @@ eslintTester.run('order-in-components', rule, {
         },
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The actions hash should be above the "customFunc" method on line 2',
@@ -642,7 +554,6 @@ eslintTester.run('order-in-components', rule, {
         }),
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The actions hash should be above the "tAction" method on line 2',
@@ -663,7 +574,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -683,7 +593,6 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         [foo]: 'foo',
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The property should be above the actions hash on line 4',
@@ -697,7 +606,6 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -711,7 +619,6 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -725,7 +632,6 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -739,7 +645,6 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         template: hbs\`Hello world {{name}}\`,
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "template" property should be above the actions hash on line 3',
@@ -754,7 +659,6 @@ eslintTester.run('order-in-components', rule, {
 
         tabindex: -1,
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -769,7 +673,6 @@ eslintTester.run('order-in-components', rule, {
         }).volatile(),
         name: "Jon Snow",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "name" property should be above the "foo" multi-line function on line 2',
@@ -785,7 +688,6 @@ eslintTester.run('order-in-components', rule, {
         didInsertElement() {},
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -816,7 +718,6 @@ eslintTester.run('order-in-components', rule, {
         bar() { const foo = 'bar'},
         onBar: () => {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -847,7 +748,6 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -11,15 +11,14 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('order-in-controllers', rule, {
   valid: [
-    {
-      code: 'export default Controller.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller.extend({
+    'export default Controller.extend();',
+    `export default Controller.extend({
         application: controller(),
         currentUser: service(),
         queryParams: [],
@@ -29,10 +28,7 @@ eslintTester.run('order-in-controllers', rule, {
         _customAction2: function() { const foo = 'bar'; },
         tSomeTask: task(function* () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller.extend({
+    `export default Controller.extend({
         currentUser: inject(),
         queryParams: [],
         customProp: "test",
@@ -41,20 +37,14 @@ eslintTester.run('order-in-controllers', rule, {
         _customAction2: function() {},
         tSomeTask: task(function* () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller.extend({
+    `export default Controller.extend({
         queryParams: [],
         customProp: "test",
         comp: computed("test", function() {}),
         obs: observer("asd", function() {}),
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller.extend({
+    `export default Controller.extend({
         customProp: "test",
         comp: computed("test", function() {}),
         comp2: computed("test", function() {
@@ -62,8 +52,6 @@ eslintTester.run('order-in-controllers', rule, {
         actions: {},
         _customAction() { const foo = 'bar'; }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
     {
       code: `export default Controller.extend({
         actions: {},
@@ -73,7 +61,6 @@ eslintTester.run('order-in-controllers', rule, {
         }),
         _customAction() { const foo = 'bar'; }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['actions', 'single-line-function'],
@@ -85,7 +72,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service(),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['query-params', 'service'],
@@ -97,15 +83,13 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         application: controller(),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['query-params', 'controller'],
         },
       ],
     },
-    {
-      code: `
+    `
         export default Controller.extend({
           foo: service(),
           someProp: null,
@@ -117,10 +101,7 @@ eslintTester.run('order-in-controllers', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `
+    `
         export default Controller.extend({
           foo: service(),
           init() {
@@ -129,10 +110,7 @@ eslintTester.run('order-in-controllers', rule, {
           customFoo() {}
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `
+    `
         export default Controller.extend({
           foo: service(),
           init() {
@@ -140,8 +118,6 @@ eslintTester.run('order-in-controllers', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
   invalid: [
     {
@@ -149,7 +125,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -163,7 +138,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: inject()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -178,7 +152,6 @@ eslintTester.run('order-in-controllers', rule, {
         customProp: "test",
         queryParams: []
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "queryParams" property should be above the "customProp" property on line 3',
@@ -192,7 +165,6 @@ eslintTester.run('order-in-controllers', rule, {
         actions: {},
         customProp: "test"
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "customProp" property should be above the actions hash on line 3',
@@ -206,7 +178,6 @@ eslintTester.run('order-in-controllers', rule, {
         _customAction() { const foo = 'bar'; },
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The actions hash should be above the "_customAction" method on line 3',
@@ -220,7 +191,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "queryParams" property should be above the "test" property on line 2',
@@ -233,7 +203,6 @@ eslintTester.run('order-in-controllers', rule, {
         currentUser: service(),
         application: controller()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -249,7 +218,6 @@ eslintTester.run('order-in-controllers', rule, {
         comp: computed("asd", function() {}),
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "comp" single-line function should be above the "obs" observer on line 3',
@@ -263,7 +231,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -278,7 +245,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -293,7 +259,6 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -314,7 +279,6 @@ eslintTester.run('order-in-controllers', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "init" lifecycle hook should be above the actions hash on line 4',
@@ -332,7 +296,6 @@ eslintTester.run('order-in-controllers', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -350,7 +313,6 @@ eslintTester.run('order-in-controllers', rule, {
           foo: service()
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -368,7 +330,6 @@ eslintTester.run('order-in-controllers', rule, {
           someProp: null
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
@@ -387,7 +348,6 @@ eslintTester.run('order-in-controllers', rule, {
   currentUser: service(),
   queryParams: [],
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -407,7 +367,6 @@ eslintTester.run('order-in-controllers', rule, {
         test: "asd",
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "queryParams" property should be above the "test" property on line 2',

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -11,85 +11,58 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('order-in-models', rule, {
   valid: [
-    {
-      code: 'export default Model.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Model.extend({
+    'export default Model.extend();',
+    `export default Model.extend({
         shape: attr("string"),
         behaviors: hasMany("behaviour"),
         test: computed.alias("qwerty"),
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Model.extend({
+    `export default Model.extend({
         behaviors: hasMany("behaviour"),
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Model.extend({
+    `export default Model.extend({
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend({
+    `export default DS.Model.extend({
         shape: DS.attr("string"),
         behaviors: hasMany("behaviour"),
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend({
+    `export default DS.Model.extend({
         behaviors: hasMany("behaviour"),
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend({
+    `export default DS.Model.extend({
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend(TestMixin, {
+    `export default DS.Model.extend(TestMixin, {
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend(TestMixin, TestMixin2, {
+    `export default DS.Model.extend(TestMixin, TestMixin2, {
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default DS.Model.extend({
+    `export default DS.Model.extend({
         a: attr("string"),
         b: belongsTo("c", { async: false }),
         convertA(paramA) {
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
     {
       code: `export default DS.Model.extend({
         convertA(paramA) {
@@ -97,7 +70,6 @@ eslintTester.run('order-in-models', rule, {
         a: attr("string"),
         b: belongsTo("c", { async: false }),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['method'],
@@ -113,7 +85,6 @@ eslintTester.run('order-in-models', rule, {
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "shape" attribute should be above the "behaviors" relationship on line 2',
@@ -128,7 +99,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         behaviors: hasMany("behaviour")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -143,7 +113,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         shape: attr("string")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "shape" attribute should be above the "mood" multi-line function on line 2',
@@ -158,7 +127,6 @@ eslintTester.run('order-in-models', rule, {
         mood: Ember.computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "shape" attribute should be above the "behaviors" relationship on line 2',
@@ -173,7 +141,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         behaviors: hasMany("behaviour")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -188,7 +155,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         shape: attr("string")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "shape" attribute should be above the "mood" multi-line function on line 2',
@@ -202,7 +168,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -217,7 +182,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -232,7 +196,6 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -254,7 +217,6 @@ eslintTester.run('order-in-models', rule, {
         mood: computed("health", "hunger", function() {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "shape" attribute should be above the "behaviors" relationship on line 2',

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -11,15 +11,14 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('order-in-routes', rule, {
   valid: [
-    {
-      code: 'export default Route.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    'export default Route.extend();',
+    `export default Route.extend({
         currentUser: service(),
         queryParams: {},
         customProp: "test",
@@ -41,10 +40,7 @@ eslintTester.run('order-in-routes', rule, {
         _customAction2: function() { const foo = 'bar'; },
         tSomeTask: task(function* () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         currentUser: inject(),
         queryParams: {},
         customProp: "test",
@@ -59,10 +55,7 @@ eslintTester.run('order-in-routes', rule, {
         _customAction2: function() {},
         tSomeTask: task(function* () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         levelOfHappiness: computed("attitude", "health", () => {
         }),
         model() {},
@@ -71,18 +64,12 @@ eslintTester.run('order-in-routes', rule, {
         },
         _customAction() { const foo = 'bar'; }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         init() {},
         model() {},
         render() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         mergedProperties: {},
         vehicle: alias("car"),
         levelOfHappiness: computed("attitude", "health", () => {
@@ -90,24 +77,18 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         mergedProperties: {},
         test: "asd",
         vehicle: alias("car"),
         model() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
     {
       code: `export default Route.extend({
         model() {},
         beforeModel() {},
         currentUser: service(),
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['model', 'lifecycle-hook', 'service'],
@@ -121,7 +102,6 @@ eslintTester.run('order-in-routes', rule, {
         currentUser: service(),
         model() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: ['lifecycle-hook', 'service', 'model'],
@@ -136,15 +116,13 @@ eslintTester.run('order-in-routes', rule, {
         currentUser: service(),
         model() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
           order: [['deactivate', 'setupController', 'beforeModel'], 'service', 'model'],
         },
       ],
     },
-    {
-      code: `
+    `
         export default Route.extend({
           foo: service(),
           init() {
@@ -153,10 +131,7 @@ eslintTester.run('order-in-routes', rule, {
           actions: {}
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `
+    `
         export default Route.extend({
           foo: service(),
           init() {
@@ -165,8 +140,6 @@ eslintTester.run('order-in-routes', rule, {
           customFoo() {}
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
   invalid: [
     {
@@ -180,7 +153,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -205,7 +177,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -230,7 +201,6 @@ eslintTester.run('order-in-routes', rule, {
         levelOfHappiness: computed("attitude", "health", () => {
         })
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -253,7 +223,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -275,7 +244,6 @@ eslintTester.run('order-in-routes', rule, {
         _customAction() { const foo = 'bar'; },
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -294,7 +262,6 @@ eslintTester.run('order-in-routes', rule, {
         customProp: "test",
         actions: {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "customProp" property should be above the "model" hook on line 2',
@@ -308,7 +275,6 @@ eslintTester.run('order-in-routes', rule, {
         mergedProperties: {},
         model() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -340,7 +306,6 @@ eslintTester.run('order-in-routes', rule, {
         _customAction2: function() {},
         tSomeTask: task(function* () {})
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -375,7 +340,6 @@ eslintTester.run('order-in-routes', rule, {
         _test2() { const foo = 'bar'; },
         model() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "model" hook should be above the "_test2" method on line 3',
@@ -389,7 +353,6 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -403,7 +366,6 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -417,7 +379,6 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -435,7 +396,6 @@ eslintTester.run('order-in-routes', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "init" lifecycle hook should be above the actions hash on line 4',
@@ -453,7 +413,6 @@ eslintTester.run('order-in-routes', rule, {
           },
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -471,7 +430,6 @@ eslintTester.run('order-in-routes', rule, {
           foo: service()
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -489,7 +447,6 @@ eslintTester.run('order-in-routes', rule, {
           someProp: null
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
@@ -518,7 +475,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -555,7 +511,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message:
@@ -591,7 +546,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "beforeModel" lifecycle hook should be above the "model" hook on line 3',
@@ -624,7 +578,6 @@ eslintTester.run('order-in-routes', rule, {
    */
   actions: {},
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "beforeModel" lifecycle hook should be above the actions hash on line 6',
@@ -643,7 +596,6 @@ eslintTester.run('order-in-routes', rule, {
   test: "asd",
   model() {},
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -670,7 +622,6 @@ eslintTester.run('order-in-routes', rule, {
         actions: {}
 
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 3',

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -9,35 +9,21 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 eslintTester.run('require-return-from-computed', rule, {
   valid: [
-    {
-      code: 'let foo = computed("test", function() { return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'let foo = computed("test", { get() { return true; }, set() { return true; } })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'let foo = computed("test", function() { if (true) { return ""; } return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code:
-        'let foo = computed("test", { get() { data.forEach(function() { }); return true; }, set() { return true; } })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'let foo = computed("test", function() { data.forEach(function() { }); return ""; })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
+    'let foo = computed("test", function() { return ""; })',
+    'let foo = computed("test", { get() { return true; }, set() { return true; } })',
+    'let foo = computed("test", function() { if (true) { return ""; } return ""; })',
+    'let foo = computed("test", { get() { data.forEach(function() { }); return true; }, set() { return true; } })',
+    'let foo = computed("test", function() { data.forEach(function() { }); return ""; })',
   ],
   invalid: [
     {
       code: 'let foo = computed("test", function() { })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -46,7 +32,6 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed("test", function() { if (true) { return ""; } })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -55,7 +40,6 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed("test", { get() {}, set() {} })',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -67,7 +51,6 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed({ get() { return "foo"; }, set() { }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -76,7 +59,6 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed({ get() { }, set() { return "foo"; }})',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Always return a value from computed properties',

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -9,204 +9,128 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester();
+const eslintTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
 const message = 'Call this._super(...arguments) in init hook';
 
 eslintTester.run('require-super-in-init', rule, {
   valid: [
-    {
-      code: `export default Component.extend({
+    `export default Component.extend({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route.extend({
+    `export default Route.extend({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller.extend({
+    `export default Controller.extend({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Mixin.extend({
+    `export default Mixin.extend({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Service.extend({
+    `export default Service.extend({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component({
+    `export default Component({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route({
+    `export default Route({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller({
+    `export default Controller({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Mixin({
+    `export default Mixin({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Service({
+    `export default Service({
         init() {
           return this._super(...arguments);
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Component.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Route.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Controller.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Mixin.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: 'export default Service.extend();',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component({
+    'export default Component.extend();',
+    'export default Route.extend();',
+    'export default Controller.extend();',
+    'export default Mixin.extend();',
+    'export default Service.extend();',
+    `export default Component({
         init() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route({
+    `export default Route({
         init() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller({
+    `export default Controller({
         init() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Mixin({
+    `export default Mixin({
         init() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Service({
+    `export default Service({
         init() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Component({
+    `export default Component({
         init: function() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Route({
+    `export default Route({
         init: function() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Controller({
+    `export default Controller({
         init: function() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Mixin({
+    `export default Mixin({
         init: function() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Service({
+    `export default Service({
         init: function() {
           this._super(...arguments);
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
-    {
-      code: `export default Service({
+    `export default Service({
         init
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    },
   ],
   invalid: [
     {
       code: `export default Component.extend({
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -216,7 +140,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop', 'value');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -227,7 +150,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop2', 'value2');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -235,7 +157,6 @@ eslintTester.run('require-super-in-init', rule, {
       code: `export default Route.extend({
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -245,7 +166,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop', 'value');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -256,7 +176,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop2', 'value2');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -264,7 +183,6 @@ eslintTester.run('require-super-in-init', rule, {
       code: `export default Controller.extend({
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -274,7 +192,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop', 'value');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -285,7 +202,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop2', 'value2');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -293,7 +209,6 @@ eslintTester.run('require-super-in-init', rule, {
       code: `export default Mixin.extend({
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -303,7 +218,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop', 'value');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -314,7 +228,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop2', 'value2');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -322,7 +235,6 @@ eslintTester.run('require-super-in-init', rule, {
       code: `export default Service.extend({
         init() {},
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -332,7 +244,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop', 'value');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -343,7 +254,6 @@ eslintTester.run('require-super-in-init', rule, {
           this.set('prop2', 'value2');
         },
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -353,7 +263,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -363,7 +272,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -373,7 +281,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -383,7 +290,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -393,7 +299,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -403,7 +308,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -413,7 +317,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -423,7 +326,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -433,7 +335,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -443,7 +344,6 @@ eslintTester.run('require-super-in-init', rule, {
           return;
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -453,7 +353,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -463,7 +362,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -473,7 +371,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -483,7 +380,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -493,7 +389,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -503,7 +398,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -513,7 +407,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -523,7 +416,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -533,7 +425,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },
@@ -543,7 +434,6 @@ eslintTester.run('require-super-in-init', rule, {
           return 'meh';
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [{ message, line: 2 }],
     },

--- a/tests/lib/rules/routes-segments-snake-case.js
+++ b/tests/lib/rules/routes-segments-snake-case.js
@@ -30,7 +30,6 @@ eslintTester.run('routes-segments-snake-case', rule, {
   invalid: [
     {
       code: 'this.route("tree", { path: ":treeId"});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -40,7 +39,6 @@ eslintTester.run('routes-segments-snake-case', rule, {
     },
     {
       code: 'this.route("tree", { path: ":tree-id" });',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -50,7 +48,6 @@ eslintTester.run('routes-segments-snake-case', rule, {
     },
     {
       code: 'this.route("tree", { path: "/test/:treeId"});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -60,7 +57,6 @@ eslintTester.run('routes-segments-snake-case', rule, {
     },
     {
       code: 'this.route("tree", { path: "/test/treeId/:treeChildId"});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -70,7 +66,6 @@ eslintTester.run('routes-segments-snake-case', rule, {
     },
     {
       code: 'this.route("tree", { path: "/test/tree-id/:tree-child-id"});',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       output: null,
       errors: [
         {


### PR DESCRIPTION
Significantly simplifies many test files and improves readability. This allows many valid test cases to be strings instead of objects.

If all individual test cases in a file specify the same `parserOptions`, then `parserOptions` should be set globally instead.

Relevant:
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/test-case-shorthand-strings.md
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/85
