### PR TITLE
Update `require-computed-macros` rule to handle `this.get('property')` (in addition to `this.property`)

### DIFF
--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -24,10 +24,10 @@ const ERROR_MESSAGE_EQUAL = makeErrorMessage('equal');
 
 /**
  * Checks if a LogicalExpression looks like `this.x && this.y && this.z`
- * containing only simple `this.x` MemberExpression nodes.
+ * containing only simple `this.x` MemberExpression or `this.get('x')` CallExpression nodes.
  *
  * @param {Node} node The LogicalExpression node to check.
- * @returns {boolean} Whether the node looks like `this.x && this.y && this.z`.
+ * @returns {boolean} Whether the node looks like `this.x && this.y && this.z` or `this.get('x') && this.get('y') && this.get('z')`.
  */
 function isSimpleThisExpressionsInsideLogicalExpression(node, operator) {
   if (!types.isLogicalExpression(node)) {
@@ -54,13 +54,13 @@ function isSimpleThisExpressionsInsideLogicalExpression(node, operator) {
 }
 
 /**
- * Converts a simple LogicalExpression into an array of the MemberExpression nodes in it.
+ * Converts a simple LogicalExpression into an array of the MemberExpression/CallExpression nodes in it.
  *
  * Example Input:   A LogicalExpression node with this source: `this.x && this.y.z && this.w`
  * Example Output:  An array of these MemberExpression nodes: [this.x, this.y.z, this.w]
  *
- * @param {Node} node The LogicalExpression node containing nodes that look like `this.x`.
- * @returns {Node[]} An array of MemberExpression nodes contained in the LogicalExpression.
+ * @param {Node} node The LogicalExpression node containing nodes that look like `this.x` or `this.get('x')`.
+ * @returns {Node[]} An array of MemberExpression/CallExpression nodes contained in the LogicalExpression.
  */
 function getThisExpressions(nodeLogicalExpression) {
   const arrayOfThisExpressions = [];

--- a/lib/utils/property-getter.js
+++ b/lib/utils/property-getter.js
@@ -1,12 +1,39 @@
 const types = require('./types');
 
 /**
- * Checks if a MemberExpression node looks like `this.x` or `this.x.y`.
+ * Checks if a CallExpression node looks like `this.get('property')`.
+ *
+ * @param {Node} node The CallExpression node to check.
+ * @returns {boolean} Whether the node looks like `this.get('property')`.
+ */
+function isThisGetCall(node) {
+  if (
+    types.isCallExpression(node) &&
+    types.isMemberExpression(node.callee) &&
+    types.isThisExpression(node.callee.object) &&
+    types.isIdentifier(node.callee.property) &&
+    node.callee.property.name === 'get' &&
+    node.arguments.length === 1 &&
+    types.isStringLiteral(node.arguments[0])
+  ) {
+    // Looks like: this.get('property')
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a MemberExpression node looks like `this.x` or `this.x.y` or `this.get('x')`.
  *
  * @param {Node} node The MemberExpression node to check.
- * @returns {boolean} Whether the node looks like `this.x` or `this.x.y`.
+ * @returns {boolean} Whether the node looks like `this.x` or `this.x.y` or `this.get('x')`.
  */
 function isSimpleThisExpression(node) {
+  if (isThisGetCall(node)) {
+    return true;
+  }
+
   if (!types.isMemberExpression(node)) {
     return false;
   }
@@ -31,18 +58,24 @@ function isSimpleThisExpression(node) {
 /**
  * Converts a Node containing a ThisExpression to its dependent key.
  *
- * Example Input:   A Node with this source code: `this.x.y`
+ * Example Input:   A Node with this source code: `this.x.y` or `this.get('x')`
  * Example Output:  'x.y'
  *
- * @param {Node} node a MemberExpression node that looks like `this.x` or `this.x.y`.
+ * @param {Node} node a MemberExpression node that looks like `this.x.y` or `this.get('x')`.
  * @returns {String} The dependent key of the input node (without `this.`).
  */
 function nodeToDependentKey(nodeWithThisExpression, context) {
+  if (types.isCallExpression(nodeWithThisExpression)) {
+    // Looks like: this.get('property')
+    return nodeWithThisExpression.arguments[0].value;
+  }
+
   const sourceCode = context.getSourceCode();
   return sourceCode.getText(nodeWithThisExpression).replace(/^this\./, '');
 }
 
 module.exports = {
-  isSimpleThisExpression,
   nodeToDependentKey,
+  isSimpleThisExpression,
+  isThisGetCall,
 };

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -37,6 +37,7 @@ ruleTester.run('require-computed-macros', rule, {
     "reads('x')",
     'computed(function() { return this; })',
     'computed(function() { return SOME_VAR; })',
+    'computed(function() { return this.get(SOME_VAR); })',
     'computed(function() { return this.prop[123]; })',
     'computed(function() { return this.prop[i]; })',
     'computed(function() { return this.someFunction(); })',
@@ -46,6 +47,7 @@ ruleTester.run('require-computed-macros', rule, {
     "and('x', 'y')",
     'computed(function() { return SOME_VAR && OTHER_VAR; })',
     'computed(function() { return this.x && this.y || this.z; })', // Mixed operators.
+    'computed(function() { return this.get("x") && this.get("y") || this.get("z"); })', // Mixed operators (and this.get)
 
     // OR
     "or('x', 'y')",
@@ -76,6 +78,7 @@ ruleTester.run('require-computed-macros', rule, {
     'computed(function() { return SOME_VAR === 123; })',
     'computed(function() { return SOME_VAR === "Hello"; })',
     'computed(function() { return this.prop === MY_VAR; })',
+    "computed(function() { return this.get('prop') === MY_VAR; })",
   ],
   invalid: [
     // READS
@@ -86,6 +89,11 @@ ruleTester.run('require-computed-macros', rule, {
     },
     {
       code: 'computed(function() { return this.x.y; })', // Nested path.
+      output: "computed.reads('x.y')",
+      errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }],
+    },
+    {
+      code: "computed(function() { return this.get('x.y'); })", // this.get()
       output: "computed.reads('x.y')",
       errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }],
     },
@@ -103,6 +111,11 @@ ruleTester.run('require-computed-macros', rule, {
     },
     {
       code: 'computed(function() { return this.x && this.y.z && this.w; })', // Three parts with a nested path.
+      output: "computed.and('x', 'y.z', 'w')",
+      errors: [{ message: ERROR_MESSAGE_AND, type: 'CallExpression' }],
+    },
+    {
+      code: "computed(function() { return this.get('x') && this.get('y.z') && this.w; })", // Three parts with a nested path (and this.get).
       output: "computed.and('x', 'y.z', 'w')",
       errors: [{ message: ERROR_MESSAGE_AND, type: 'CallExpression' }],
     },
@@ -152,6 +165,11 @@ ruleTester.run('require-computed-macros', rule, {
     // EQUAL
     {
       code: 'computed(function() { return this.x === 123; })',
+      output: "computed.equal('x', 123)",
+      errors: [{ message: ERROR_MESSAGE_EQUAL, type: 'CallExpression' }],
+    },
+    {
+      code: "computed(function() { return this.get('x') === 123; })", // this.get()
       output: "computed.equal('x', 123)",
       errors: [{ message: ERROR_MESSAGE_EQUAL, type: 'CallExpression' }],
     },

--- a/tests/lib/utils/property-getter-test.js
+++ b/tests/lib/utils/property-getter-test.js
@@ -9,14 +9,40 @@ function parse(code) {
 
 describe('isSimpleThisExpression', () => {
   it('behaves correctly', () => {
-    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x'))).toBeTruthy();
-    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x.y'))).toBeTruthy();
+    // False:
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x().y'))).toBeFalsy();
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x()'))).toBeFalsy();
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x.y()'))).toBeFalsy();
-    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.get("property")'))).toBeFalsy();
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x[1]'))).toBeFalsy();
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x[i]'))).toBeFalsy();
     expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x.y[i]'))).toBeFalsy();
+
+    // True:
+    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x'))).toBeTruthy();
+    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.x.y'))).toBeTruthy();
+    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.get("property")'))).toBeTruthy();
+    expect(propertyGetterUtils.isSimpleThisExpression(parse('this.get("x.y")'))).toBeTruthy();
+  });
+});
+
+describe('isThisGetCall', () => {
+  it('behaves correctly', () => {
+    // False:
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x.y'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x().y'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x()'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x.y()'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x[1]'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x[i]'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.x.y[i]'))).toBeFalsy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.get("property").something'))).toBeFalsy();
+    expect(
+      propertyGetterUtils.isThisGetCall(parse('this.get("unexpected", "argument").something'))
+    ).toBeFalsy();
+
+    // True:
+    expect(propertyGetterUtils.isThisGetCall(parse('this.get("property")'))).toBeTruthy();
+    expect(propertyGetterUtils.isThisGetCall(parse('this.get("x.y")'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fixes #572. CC: @BlueRaja 