### PR TITLE
Update `avoid-leaking-state-in-ember-objects` rule to handle logical expressions

### DIFF
--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -23,6 +23,10 @@ function isAllowedTernary(value) {
   );
 }
 
+function isAllowedLogicalExpression(value) {
+  return types.isLogicalExpression(value) && isAllowed(value.left) && isAllowed(value.right);
+}
+
 function isAllowed(value) {
   return (
     ember.isFunctionExpression(value) ||
@@ -34,7 +38,8 @@ function isAllowed(value) {
     types.isTaggedTemplateExpression(value) ||
     types.isMemberExpression(value) ||
     types.isUnaryExpression(value) ||
-    isAllowedTernary(value)
+    isAllowedTernary(value) ||
+    isAllowedLogicalExpression(value)
   );
 }
 

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -64,6 +64,8 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     'export default Foo.extend({ foo: !true });',
     'export default Foo.extend({ ...props });',
     'export default Foo.extend({ foo: condition ? "foo" : "bar" });',
+    'export default Foo.extend({ foo: "foo" && "bar" });',
+    'export default Foo.extend({ foo: "foo" || "bar" });',
   ],
   invalid: [
     {
@@ -179,6 +181,46 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     },
     {
       code: 'export default Foo.extend({ foo: condition ? false : {} });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Foo.extend({ foo: false && {} });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Foo.extend({ foo: {} && false });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Foo.extend({ foo: false || {} });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Foo.extend({ foo: {} || false });',
       output: null,
       errors: [
         {


### PR DESCRIPTION
Very similar to #571 

Much like a ternary expression should be valid if either option are valid, a logical expression (`&&` or `||`) should be valid if both options are valid.