### PR TITLE
Fix handling of multi-line property keys by `require-computed-property-dependencies` rule

### DIFF
--- a/lib/utils/property-getter.js
+++ b/lib/utils/property-getter.js
@@ -55,6 +55,11 @@ function isSimpleThisExpression(node) {
   return false;
 }
 
+function removeWhitespace(str) {
+  // Removes whitespace anywhere inside string.
+  return str.replace(/\s/g, '');
+}
+
 /**
  * Converts a Node containing a ThisExpression to its dependent key.
  *
@@ -71,7 +76,7 @@ function nodeToDependentKey(nodeWithThisExpression, context) {
   }
 
   const sourceCode = context.getSourceCode();
-  return sourceCode.getText(nodeWithThisExpression).replace(/^this\./, '');
+  return removeWhitespace(sourceCode.getText(nodeWithThisExpression).replace(/^this\./, ''));
 }
 
 module.exports = {

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -708,5 +708,26 @@ ruleTester.run('require-computed-property-dependencies', rule, {
         },
       ],
     },
+    {
+      code: `
+        Ember.computed(function() {
+          return this.some.very.long.
+            multi.line.property.name;
+        });
+      `,
+      output: `
+        Ember.computed('some.very.long.multi.line.property.name', function() {
+          return this.some.very.long.
+            multi.line.property.name;
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Use of undeclared dependencies in computed property: some.very.long.multi.line.property.name',
+          type: 'CallExpression',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Previously, the newline character in a multi-line property key would be erroneously kept in the autofixed computed property dependency keys, typically leading to a syntax error.