### PR TITLE
Update `no-get` rule to ignore `get()` usages inside objects implementing `unknownProperty()`

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -9,7 +9,7 @@ This rule disallows:
 * `this.get('someProperty')` when `this.someProperty` can be used
 * `this.getProperties('prop1', 'prop2')` when `{ prop1: this.prop1, prop2: this.prop2 }` can be used
 
-**WARNING**: there are a number of circumstances where `get` / `getProperties` still need to be used, and you may need to manually disable the rule for these:
+**WARNING**: there are a number of circumstances where `get` / `getProperties` still need to be used, and you may need to manually disable the rule for these (although the rule will attempt to ignore them):
 
 * Ember proxy objects (`ObjectProxy`, `ArrayProxy`)
 * Objects implementing the `unknownProperty` method
@@ -60,6 +60,16 @@ import ObjectProxy from '@ember/object/proxy';
 export default ObjectProxy.extend({
   someFunction() {
     const foo = this.get('propertyInsideProxyObject'); // Allowed because inside proxy object.
+  }
+});
+```
+
+```js
+import EmberObject from '@ember/object';
+export default EmberObject.extend({
+  unknownProperty(key) {},
+  someFunction() {
+    const foo = this.get('property'); // Allowed because inside object implementing `unknownProperty()`.
   }
 });
 ```

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -45,11 +45,15 @@ module.exports = {
     const ignoreNestedPaths = !context.options[0] || context.options[0].ignoreNestedPaths;
 
     let currentProxyObject = null;
+    let currentClassWithUnknownPropertyMethod = null;
 
     return {
       'CallExpression:exit'(node) {
         if (currentProxyObject === node) {
           currentProxyObject = null;
+        }
+        if (currentClassWithUnknownPropertyMethod === node) {
+          currentClassWithUnknownPropertyMethod = null;
         }
       },
 
@@ -57,21 +61,36 @@ module.exports = {
         if (currentProxyObject === node) {
           currentProxyObject = null;
         }
+        if (currentClassWithUnknownPropertyMethod === node) {
+          currentClassWithUnknownPropertyMethod = null;
+        }
       },
 
       ClassDeclaration(node) {
         if (emberUtils.isEmberProxy(context, node)) {
           currentProxyObject = node; // Keep track of being inside a proxy object.
         }
+        if (emberUtils.isEmberObjectImplementingUnknownProperty(node)) {
+          currentClassWithUnknownPropertyMethod = node; // Keep track of being inside an object implementing `unknownProperty`.
+        }
       },
 
       // eslint-disable-next-line complexity
       CallExpression(node) {
+        // **************************
+        // Check for situations which the rule should ignore.
+        // **************************
+
         if (emberUtils.isEmberProxy(context, node)) {
           currentProxyObject = node; // Keep track of being inside a proxy object.
         }
-        if (currentProxyObject) {
-          return; // Proxy objects still require using `get()` so ignore any code inside them.
+        if (emberUtils.isEmberObjectImplementingUnknownProperty(node)) {
+          currentClassWithUnknownPropertyMethod = node;
+        }
+        if (currentProxyObject || currentClassWithUnknownPropertyMethod) {
+          // Proxy objects and objects implementing `unknownProperty()`
+          // still require using `get()`, so ignore any code inside them.
+          return;
         }
 
         // **************************

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -53,6 +53,8 @@ module.exports = {
 
   isReopenObject,
   isReopenClassObject,
+
+  isEmberObjectImplementingUnknownProperty,
 };
 
 // Private
@@ -500,4 +502,28 @@ function unwrapBraceExpressions(dependentKeys) {
   });
 
   return unwrappedExpressions.reduce((acc, cur) => acc.concat(cur), []);
+}
+
+function isEmberObjectImplementingUnknownProperty(node) {
+  if (types.isCallExpression(node)) {
+    if (!isEmberObject(node) && !isReopenObject(node)) {
+      return false;
+    }
+    // Classic class.
+    const properties = getModuleProperties(node);
+    return properties.some(
+      property => types.isIdentifier(property.key) && property.key.name === 'unknownProperty'
+    );
+  } else if (types.isClassDeclaration(node)) {
+    // Native class.
+    return node.body.body.some(
+      n =>
+        types.isMethodDefinition(n) && types.isIdentifier(n.key) && n.key.name === 'unknownProperty'
+    );
+  } else {
+    assert(
+      'Function should only be called on a `CallExpression` (classic class) or `ClassDeclaration` (native class)'
+    );
+  }
+  return false;
 }

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -1134,3 +1134,29 @@ describe('getEmberImportAliasName', () => {
     expect(emberUtils.getEmberImportAliasName(node)).toEqual('foo');
   });
 });
+
+describe('isEmberObjectImplementingUnknownProperty', () => {
+  it('should be true for a classic class EmberObject with `unknownProperty`', () => {
+    const node = babelEslint.parse('EmberObject.extend({ unknownProperty() {} });').body[0]
+      .expression;
+    expect(emberUtils.isEmberObjectImplementingUnknownProperty(node)).toBeTruthy();
+  });
+
+  it('should be false for a classic class EmberObject without `unknownProperty`', () => {
+    const node = babelEslint.parse('EmberObject.extend({ somethingElse() {} });').body[0]
+      .expression;
+    expect(emberUtils.isEmberObjectImplementingUnknownProperty(node)).toBeFalsy();
+  });
+
+  it('should be true for a native class EmberObject with `unknownProperty`', () => {
+    const node = babelEslint.parse('class MyClass extends EmberObject { unknownProperty() {} }')
+      .body[0];
+    expect(emberUtils.isEmberObjectImplementingUnknownProperty(node)).toBeTruthy();
+  });
+
+  it('should be false for a native class EmberObject without `unknownProperty`', () => {
+    const node = babelEslint.parse('class MyClass extends EmberObject { somethingElse() {} }')
+      .body[0];
+    expect(emberUtils.isEmberObjectImplementingUnknownProperty(node)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
`get()` is still needed inside objects implementing `unknownProperty()`.

This fix will help avoid false positives and enable future autofixing (#577).

More info: https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md