### PR TITLE
Add CI check to ensure `yarn update` is run to update docs/autogenerated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 script:
   - yarn lint
   - yarn test:coverage --runInBand
+  - yarn update && git diff --exit-code
   - yarn add --dev eslint@5 && yarn test --runInBand
 
 before_deploy:


### PR DESCRIPTION
I verified that the build will fail with the following output if someone forgets to run `yarn update`:

```
The command "yarn update && git diff --exit-code" exited with 1.
```