### PR TITLE
And missing rule documentation URLs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,8 +93,10 @@ module.exports = {
 
     // eslint-plugin rules:
     'eslint-plugin/no-deprecated-report-api': 'off',
+    'eslint-plugin/require-meta-docs-url': ['error', {
+      pattern: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/{{name}}.md',
+    }],
     'eslint-plugin/require-meta-type': 'off',
-    'eslint-plugin/require-meta-docs-url': 'off',
     'eslint-plugin/test-case-property-ordering': 'off',
 
     // Filenames:

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -12,6 +12,8 @@ module.exports = {
       description: 'Avoids using needs in controllers',
       category: 'Best Practices',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/avoid-using-needs-in-controllers.md',
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-actions-hash.js
+++ b/lib/rules/no-actions-hash.js
@@ -11,10 +11,10 @@ module.exports = {
       category: 'Ember Octane',
       recommended: false,
       octane: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-actions-hash.md',
     },
     fixable: null, // or "code" or "whitespace"
-    url:
-      'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-actions-hash.md',
   },
 
   create: context => {

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -13,6 +13,8 @@ module.exports = {
       description: 'Disallows arrow functions in computed properties',
       category: 'Possible Errors',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-arrow-function-computed-properties.md',
     },
   },
 

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -27,6 +27,8 @@ module.exports = {
       category: 'Ember Octane',
       recommended: false,
       octane: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-classic-classes.md',
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -16,6 +16,8 @@ module.exports = {
         'Disallows usage of deeply-nested computed property dependent keys with `@each`.',
       category: 'Possible Errors',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-deeply-nested-dependent-keys-with-each.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -21,6 +21,7 @@ module.exports = {
       category: 'Best Practices',
       recommended: false,
       octane: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-get.md',
     },
     schema: [
       {

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -26,6 +26,8 @@ module.exports = {
         'Disallows inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`',
       category: 'Possible Errors',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md',
     },
   },
 

--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -20,6 +20,8 @@ module.exports = {
         "Catch usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.",
       category: 'Possible Errors',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-invalid-debug-function-arguments.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -14,6 +14,8 @@ module.exports = {
       description: 'Prevents creation of new mixins',
       category: 'Best Practices',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-new-mixins.md',
     },
     fixable: null, // or "code" or "whitespace"
   },

--- a/lib/rules/no-pause-test.js
+++ b/lib/rules/no-pause-test.js
@@ -15,6 +15,8 @@ module.exports = {
       description: 'Disallow use of `pauseTest` helper in tests.',
       category: 'Testing',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-pause-test.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -12,6 +12,7 @@ module.exports = {
       description: 'Disallows using array or object proxies',
       category: 'Ember Object',
       recommended: false,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-proxies.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -66,6 +66,8 @@ module.exports = {
       description: 'Prevents the use of patterns that use the restricted resolver in tests.',
       category: 'Best Practices',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-restricted-resolver-tests.md',
     },
     fixable: null, // or "code" or "whitespace",
   },

--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -15,6 +15,8 @@ module.exports = {
       description: 'Disallow use of `andThen` test wait helper.',
       category: 'Testing',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-and-then.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -18,6 +18,8 @@ module.exports = {
         'Disallow importing of "-test.js" in a test file and exporting from a test file.',
       category: 'Testing',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-import-export.md',
     },
     importMessage: NO_IMPORT_MESSAGE,
     exportMessage: NO_EXPORT_MESSAGE,

--- a/lib/rules/no-test-module-for.js
+++ b/lib/rules/no-test-module-for.js
@@ -17,6 +17,8 @@ module.exports = {
       description: 'Disallow use of moduleFor, moduleForComponent, etc',
       category: 'Testing',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-module-for.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -15,6 +15,8 @@ module.exports = {
       description: 'Disallow unnecessary `index` route definition',
       category: 'Best Practices',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-index-route.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -15,6 +15,8 @@ module.exports = {
       description: 'Disallow unnecessary route `path` option',
       category: 'Best Practices',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-route-path-option.md',
     },
     fixable: 'code',
   },

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -16,6 +16,8 @@ module.exports = {
       description: 'Disallow unnecessary argument when injecting service',
       category: 'Best Practices',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-service-injection-argument.md',
     },
     fixable: 'code',
   },

--- a/lib/rules/no-volatile-computed-properties.js
+++ b/lib/rules/no-volatile-computed-properties.js
@@ -13,6 +13,8 @@ module.exports = {
       description: 'Disallows volatile computed properties',
       category: 'Best Practices',
       recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-volatile-computed-properties.md',
     },
   },
 

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -83,6 +83,8 @@ module.exports = {
       description: 'Requires using computed property macros when possible',
       category: 'Best Practices',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-computed-macros.md',
     },
     fixable: 'code',
   },

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -324,6 +324,8 @@ module.exports = {
       description: 'Requires dependencies to be declared statically in computed properties',
       category: 'Possible Errors',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-computed-property-dependencies.md',
     },
 
     fixable: 'code',

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -16,6 +16,8 @@ module.exports = {
         'Enforces usage of kebab-case (instead of snake_case or camelCase) in route paths',
       category: 'Best Practices',
       recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/route-path-style.md',
     },
     fixable: null,
   },


### PR DESCRIPTION
Also lints that these documentation URLs are present and correct.

Some IDEs will use this information to provide a link to the rule documentation next to a violation.

https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-docs-url.md