### PR TITLE
Update `no-classic-classes` rule to catch classic Ember Data model classes

### DIFF
--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -14,6 +14,19 @@ function hasObjectArgument(node) {
   return node.arguments.some(isObjectExpression);
 }
 
+function isEmberImport(classImportedFrom) {
+  if (!classImportedFrom) {
+    return false;
+  }
+
+  // Warn about classes imported from the `@ember/` and Ember Data namespaces
+  return (
+    classImportedFrom.startsWith('@ember/') ||
+    classImportedFrom.startsWith('@ember-data/') ||
+    classImportedFrom === 'ember-data'
+  );
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -48,12 +61,7 @@ module.exports = {
         // Still allows `.extend` if some other identifier is passed, like a Mixin
         if (hasNoArguments(callExpression) || hasObjectArgument(callExpression)) {
           const classImportedFrom = getSourceModuleNameForIdentifier(context, node.object);
-
-          // Only warn about classes imported from the `@ember/` namespace
-          if (
-            classImportedFrom &&
-            (classImportedFrom.startsWith('@ember/') || classImportedFrom.includes('ember-data'))
-          ) {
+          if (isEmberImport(classImportedFrom)) {
             reportNode(callExpression);
           }
         }

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -50,7 +50,10 @@ module.exports = {
           const classImportedFrom = getSourceModuleNameForIdentifier(context, node.object);
 
           // Only warn about classes imported from the `@ember/` namespace
-          if (classImportedFrom && classImportedFrom.startsWith('@ember/')) {
+          if (
+            classImportedFrom &&
+            (classImportedFrom.startsWith('@ember/') || classImportedFrom.includes('ember-data'))
+          ) {
             reportNode(callExpression);
           }
         }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -9,6 +9,7 @@ const {
   isNewExpression,
   isObjectPattern,
 } = require('../utils/types');
+const assert = require('assert');
 
 module.exports = {
   collectObjectPatternBindings,
@@ -222,12 +223,18 @@ function getSourceModuleNameForIdentifier(context, node) {
   return importDeclaration ? importDeclaration.source.value : undefined;
 }
 
+// eslint-disable-next-line consistent-return
 function getSourceModuleName(node) {
   if (isMemberExpression(node) && node.object) {
     return getSourceModuleName(node.object);
+  } else if (isIdentifier(node)) {
+    return node.name;
+  } else {
+    assert(
+      false,
+      '`getSourceModuleName` should only be called on `MemberExpression` or `Identifier`'
+    );
   }
-
-  return node.name;
 }
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -17,6 +17,7 @@ module.exports = {
   getParent,
   getPropertyValue,
   getSize,
+  getSourceModuleName,
   getSourceModuleNameForIdentifier,
   isEmptyMethod,
   isGlobalCallExpression,
@@ -222,8 +223,8 @@ function getSourceModuleNameForIdentifier(context, node) {
 }
 
 function getSourceModuleName(node) {
-  if (node.type === 'MemberExpression') {
-    return node.object.name;
+  if (isMemberExpression(node) && node.object) {
+    return getSourceModuleName(node.object);
   }
 
   return node.name;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -223,7 +223,6 @@ function getSourceModuleNameForIdentifier(context, node) {
   return importDeclaration ? importDeclaration.source.value : undefined;
 }
 
-// eslint-disable-next-line consistent-return
 function getSourceModuleName(node) {
   if (isMemberExpression(node) && node.object) {
     return getSourceModuleName(node.object);
@@ -234,6 +233,7 @@ function getSourceModuleName(node) {
       false,
       '`getSourceModuleName` should only be called on `MemberExpression` or `Identifier`'
     );
+    return undefined;
   }
 }
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -213,10 +213,20 @@ function getSourceModuleNameForIdentifier(context, node) {
   const importDeclaration = program.body
     .filter(isImportDeclaration)
     .find(importDeclaration =>
-      importDeclaration.specifiers.some(specifier => specifier.local.name === node.name)
+      importDeclaration.specifiers.some(
+        specifier => specifier.local.name === getSourceModuleName(node)
+      )
     );
 
   return importDeclaration ? importDeclaration.source.value : undefined;
+}
+
+function getSourceModuleName(node) {
+  if (node.type === 'MemberExpression') {
+    return node.object.name;
+  }
+
+  return node.name;
 }
 
 /**

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -19,18 +19,21 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-classic-classes', rule, {
   valid: [
-    // `
-    //   import Component from '@ember/component';
-    //   export default class MyComponent extends Component {}
-    // `,
-    // `
-    //   import Component from '@ember/component';
-    //   export default class MyRoute extends Route.extend(SomeMixin) {}
-    // `,
-    // `
-    //   import SomeOtherThing from 'some-other-library';
-    //   export default SomeOtherThing.extend({});
-    // `,
+    `
+      import Component from '@ember/component';
+
+      export default class MyComponent extends Component {}
+    `,
+    `
+      import Component from '@ember/component';
+
+      export default class MyRoute extends Route.extend(SomeMixin) {}
+    `,
+    `
+      import SomeOtherThing from 'some-other-library';
+
+      export default SomeOtherThing.extend({});
+    `,
   ],
 
   invalid: [

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -81,5 +81,19 @@ ruleTester.run('no-classic-classes', rule, {
       `,
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],
     },
+    {
+      code: `
+        import DS from 'ember-data';
+        export default DS.Model.extend({});
+      `,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Model from '@ember-data/model';
+        export default Model.extend({});
+      `,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
+    },
   ],
 });

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -19,21 +19,18 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-classic-classes', rule, {
   valid: [
-    `
-      import Component from '@ember/component';
-
-      export default class MyComponent extends Component {}
-    `,
-    `
-      import Component from '@ember/component';
-
-      export default class MyRoute extends Route.extend(SomeMixin) {}
-    `,
-    `
-      import SomeOtherThing from 'some-other-library';
-
-      export default SomeOtherThing.extend({});
-    `,
+    // `
+    //   import Component from '@ember/component';
+    //   export default class MyComponent extends Component {}
+    // `,
+    // `
+    //   import Component from '@ember/component';
+    //   export default class MyRoute extends Route.extend(SomeMixin) {}
+    // `,
+    // `
+    //   import SomeOtherThing from 'some-other-library';
+    //   export default SomeOtherThing.extend({});
+    // `,
   ],
 
   invalid: [

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -192,3 +192,15 @@ describe('parseCallee', () => {
     expect(parsedCallee).toEqual(['Ember', 'A']);
   });
 });
+
+describe('getSourceModuleName', () => {
+  it('gets the correct module name DS', () => {
+    const node = parse('DS.Model.extend()').callee;
+    expect(utils.getSourceModuleName(node)).toEqual('DS');
+  });
+
+  it('gets the correct module name Model', () => {
+    const node = parse('Model.extend()').callee;
+    expect(utils.getSourceModuleName(node)).toEqual('Model');
+  });
+});

--- a/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
+++ b/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
@@ -1,5 +1,6 @@
 const { getSourceModuleNameForIdentifier } = require('../../../../lib/utils/utils');
 const { FauxContext } = require('../../../helpers/faux-context');
+const babelEslint = require('babel-eslint');
 
 test('when the identifier is not imported', () => {
   const context = new FauxContext(`
@@ -46,5 +47,41 @@ describe('when the identifier is imported', () => {
     const node = { name: 'Foo' };
 
     expect(getSourceModuleNameForIdentifier(context, node)).toEqual('bar');
+  });
+
+  test('Model.extend', () => {
+    const context = new FauxContext(`
+      import Model from '@ember-data/model';
+
+      Model.extend();
+    `);
+
+    const node = babelEslint.parse('Model.extend({})').body[0].expression.callee;
+
+    expect(getSourceModuleNameForIdentifier(context, node)).toEqual('@ember-data/model');
+  });
+
+  test('DS.Model.extend', () => {
+    const context = new FauxContext(`
+      import DS from 'ember-data';
+
+      DS.Model.extend();
+    `);
+
+    const node = babelEslint.parse('DS.Model.extend({})').body[0].expression.callee;
+
+    expect(getSourceModuleNameForIdentifier(context, node)).toEqual('ember-data');
+  });
+
+  test('Some.Long.Chained.Path.extend', () => {
+    const context = new FauxContext(`
+      import Some from 'some-path';
+
+      Some.Long.Chained.Path.extend();
+    `);
+
+    const node = babelEslint.parse('Some.Long.Chained.Path.extend({})').body[0].expression.callee;
+
+    expect(getSourceModuleNameForIdentifier(context, node)).toEqual('some-path');
   });
 });

--- a/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
+++ b/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
@@ -7,7 +7,7 @@ test('when the identifier is not imported', () => {
     Foo;
   `);
 
-  const node = { name: 'Foo' };
+  const node = { name: 'Foo', type: 'Identifier' };
 
   expect(getSourceModuleNameForIdentifier(context, node)).toEqual(undefined);
 });
@@ -20,7 +20,7 @@ describe('when the identifier is imported', () => {
       Foo;
     `);
 
-    const node = { name: 'Foo' };
+    const node = { name: 'Foo', type: 'Identifier' };
 
     expect(getSourceModuleNameForIdentifier(context, node)).toEqual('bar');
   });
@@ -32,7 +32,7 @@ describe('when the identifier is imported', () => {
       Foo;
     `);
 
-    const node = { name: 'Foo' };
+    const node = { name: 'Foo', type: 'Identifier' };
 
     expect(getSourceModuleNameForIdentifier(context, node)).toEqual('bar');
   });
@@ -44,7 +44,7 @@ describe('when the identifier is imported', () => {
       Foo;
     `);
 
-    const node = { name: 'Foo' };
+    const node = { name: 'Foo', type: 'Identifier' };
 
     expect(getSourceModuleNameForIdentifier(context, node)).toEqual('bar');
   });


### PR DESCRIPTION
Currently `no-classic-classes` doesn't warn if you are using classic class syntax for Ember Data models.

Examples of code it's failing to pick up are:

``` js
import DS from 'ember-data';
export default DS.Model.extend({});
```

``` js
import Model from '@ember-data/model';
export default Model.extend({});
```

This change results in the rule correctly throwing errors