### PR TITLE
Add missing schema validation for options on many rules

### DIFF
--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -18,6 +18,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/alias-model-in-controller.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -17,6 +17,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/avoid-using-needs-in-controllers.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/closure-actions.js
+++ b/lib/rules/closure-actions.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/closure-actions.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/jquery-ember-run.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -17,6 +17,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/named-functions-in-promises.md',
     },
     fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowSimpleArrowFunction: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -32,6 +32,7 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/new-module-imports.md',
     },
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-actions-hash.js
+++ b/lib/rules/no-actions-hash.js
@@ -16,6 +16,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-actions-hash.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create: context => {

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -17,6 +17,18 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-arrow-function-computed-properties.md',
     },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          onlyThisContexts: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-in-components.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -21,6 +21,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-snapshot.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -45,6 +45,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-classic-classes.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -15,6 +15,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-classic-components.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -37,6 +37,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-computed-properties-in-native-classes.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -21,6 +21,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-deeply-nested-dependent-keys-with-each.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -18,6 +18,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-duplicate-dependent-keys.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -11,6 +11,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-ember-super-in-es-classes.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-ember-testing-in-module-scope.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGES,

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -17,6 +17,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-empty-attrs.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -17,6 +17,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-function-prototype-extensions.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -16,6 +16,7 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-get-with-default.md',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -22,6 +22,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-global-jquery.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -30,6 +30,7 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md',
     },
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -25,6 +25,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-invalid-debug-function-arguments.md',
     },
     fixable: null,
+    schema: [],
   },
 
   getErrorMessage,

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -22,6 +22,7 @@ module.exports = {
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-jquery.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-new-mixins.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-observers.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-old-shims.js
+++ b/lib/rules/no-old-shims.js
@@ -259,6 +259,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-old-shims.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-on-calls-in-components.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-pause-test.js
+++ b/lib/rules/no-pause-test.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-pause-test.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -16,6 +16,7 @@ module.exports = {
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-proxies.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -71,6 +71,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-restricted-resolver-tests.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGES: {

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -22,6 +22,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-side-effects.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-and-then.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -22,6 +22,7 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-import-export.md',
     },
+    schema: [],
     importMessage: NO_IMPORT_MESSAGE,
     exportMessage: NO_EXPORT_MESSAGE,
   },

--- a/lib/rules/no-test-module-for.js
+++ b/lib/rules/no-test-module-for.js
@@ -22,6 +22,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-test-module-for.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-index-route.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-route-path-option.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -21,6 +21,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-service-injection-argument.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/no-volatile-computed-properties.js
+++ b/lib/rules/no-volatile-computed-properties.js
@@ -17,6 +17,7 @@ module.exports = {
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-volatile-computed-properties.md',
     },
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -44,6 +44,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-components.md',
     },
     fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -35,6 +35,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-controllers.md',
     },
     fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -24,6 +24,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-models.md',
     },
     fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -42,6 +42,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/order-in-routes.md',
     },
     fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array',
+            minItems: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -88,6 +88,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-computed-macros.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   ERROR_MESSAGE_READS,

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -21,6 +21,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-return-from-computed.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -77,6 +77,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-init.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/require-tagless-components.js
+++ b/lib/rules/require-tagless-components.js
@@ -98,6 +98,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-tagless-components.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -21,6 +21,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/route-path-style.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -19,6 +19,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/routes-segments-snake-case.md',
     },
     fixable: null,
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -20,6 +20,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-brace-expansion.md',
     },
     fixable: null,
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -71,6 +71,7 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-ember-data-rfc-395-imports.md',
     },
     fixable: 'code',
+    schema: [],
   },
 
   ERROR_MESSAGE,

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -24,6 +24,22 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-ember-get-and-set.md',
     },
     fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreThisExpressions: {
+            type: 'boolean',
+            default: false,
+          },
+          ignoreNonThisExpressions: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {


### PR DESCRIPTION
This will ensure that no one accidentally passes non-existent options to rules. Even rules that have no options should specify that they have an empty schema so that validation can take place.

https://eslint.org/docs/developer-guide/working-with-rules#options-schemas

I intend to enforce this with an upcoming rule `eslint-plugin/require-meta-schema` in https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/87.