### PR TITLE
Fix false positive reported in `require-tagless-components` 

### DIFF
--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -56,6 +56,14 @@ ruleTester.run('require-tagless-components', rule, {
         tagName = 'some-non-empty-value';
       }
     `,
+    `
+      import Service from '@ember/service';
+      export default Service.extend({});
+    `,
+    `
+      import Service from '@ember/service';
+      export default class MyService extends Service {}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Trying to fix #601 with this.

I added tests that should trigger the false positive that was reported, but the tests don't actually fail.