### PR TITLE
Fix invalid `no-get` rule autofix caused by invalid JS variable name

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -12,6 +12,11 @@ function makeErrorMessageForGet(property, isImportedGet) {
 const ERROR_MESSAGE_GET_PROPERTIES =
   "Use `{ prop1: this.prop1, prop2: this.prop2, ... }` instead of Ember's `getProperties` function";
 
+const VALID_JS_VARIABLE_NAME_REGEXP = RegExp('^[a-zA-Z_$][0-9a-zA-Z_$]*$');
+function isValidJSVariableName(str) {
+  return VALID_JS_VARIABLE_NAME_REGEXP.test(str);
+}
+
 module.exports = {
   makeErrorMessageForGet,
   ERROR_MESSAGE_GET_PROPERTIES,
@@ -119,6 +124,12 @@ module.exports = {
                 // Not safe to autofix nested properties because some properties in the path might be null.
                 return null;
               }
+
+              if (!isValidJSVariableName(path)) {
+                // Do not autofix since the path would not be a valid JS variable name.
+                return null;
+              }
+
               return fixer.replaceText(node, `this.${path}`);
             },
           });
@@ -142,6 +153,12 @@ module.exports = {
                 // Not safe to autofix nested properties because some properties in the path might be null.
                 return null;
               }
+
+              if (!isValidJSVariableName(path)) {
+                // Do not autofix since the path would not be a valid JS variable name.
+                return null;
+              }
+
               return fixer.replaceText(node, `this.${path}`);
             },
           });

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -170,6 +170,18 @@ ruleTester.run('no-get', rule, {
       output: 'this.foo.someFunction();',
       errors: [{ message: makeErrorMessageForGet('foo', false), type: 'CallExpression' }],
     },
+    {
+      // With invalid JS variable name:
+      code: "this.get('foo-bar');",
+      output: null,
+      errors: [{ message: makeErrorMessageForGet('foo-bar', false), type: 'CallExpression' }],
+    },
+    {
+      // With invalid JS variable name:
+      code: "get(this, 'foo-bar');",
+      output: null,
+      errors: [{ message: makeErrorMessageForGet('foo-bar', true), type: 'CallExpression' }],
+    },
 
     // **************************
     // getProperties


### PR DESCRIPTION
Fixes #609. CC: @alexlafroscia 