### PR TITLE
Add many missing tests for lines without test coverage

### DIFF
--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -3,6 +3,7 @@
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 const propertyGetterUtils = require('../utils/property-getter');
+const assert = require('assert');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -30,9 +31,7 @@ const ERROR_MESSAGE_EQUAL = makeErrorMessage('equal');
  * @returns {boolean} Whether the node looks like `this.x && this.y && this.z` or `this.get('x') && this.get('y') && this.get('z')`.
  */
 function isSimpleThisExpressionsInsideLogicalExpression(node, operator) {
-  if (!types.isLogicalExpression(node)) {
-    return false;
-  }
+  assert(types.isLogicalExpression(node), 'Must call function on LogicalExpression');
 
   let current = node;
   while (current !== null) {

--- a/package.json
+++ b/package.json
@@ -88,10 +88,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 94,
+        "branches": 96,
         "functions": 99,
-        "lines": 97,
-        "statements": 97
+        "lines": 98,
+        "statements": 98
       }
     }
   }

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -18,6 +18,7 @@ const eslintTester = new RuleTester({
 eslintTester.run('avoid-using-needs-in-controllers', rule, {
   valid: [
     'export default Controller.extend();',
+    'export default Controller.extend({ random: [] });',
     'export default FooController.extend();',
     'Controller.reopen();',
     'FooController.reopen();',

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -42,6 +42,11 @@ ruleTester.run('classic-decorator-no-classic-methods', rule, {
         }
       }
     `,
+    `
+      class Foo extends Bar {
+        foo = otherClass.get('bar');
+      }
+    `,
   ],
 
   invalid: [

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -61,6 +61,9 @@ const codeWithoutGettersOrSetters = [
       foo: computed(function() {})
     }`,
   `{
+      foo: computed({ random() {} })
+    }`,
+  `{
       foo: computed(async function() {})
     }`,
   `{

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -57,6 +57,7 @@ eslintTester.run('new-module-imports', rule, {
       code: 'for (let i = 0; i < 10; i++) { }',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    'SomethingRandom.Ember.Service;',
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -34,6 +34,7 @@ ruleTester.run('no-classic-classes', rule, {
 
       export default SomeOtherThing.extend({});
     `,
+    'export default Component.extend({});', // No import
   ],
 
   invalid: [

--- a/tests/lib/rules/no-ember-testing-in-module-scope.js
+++ b/tests/lib/rules/no-ember-testing-in-module-scope.js
@@ -43,7 +43,9 @@ ruleTester.run('no-ember-testing-in-module-scope', rule, {
   invalid: [
     {
       code: `
+        import Random1 from 'random1';
         import Ember from 'ember';
+        import Random2 from 'random2';
 
         export default Ember.Component.extend({
           init() {

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -17,31 +17,37 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-restricted-resolver-tests', rule, {
   valid: [
     `
+    import { moduleFor } from 'ember-qunit';
     moduleFor('service:session', {
       integration: true
     });
     `,
     `
+    import { moduleForComponent } from 'ember-qunit';
     moduleForComponent('display-page', {
       integration: true
     });
     `,
     `
+    import { moduleForModel } from 'ember-qunit';
     moduleForModel('post', {
       integration: true
     });
     `,
     `
+    import { setupTest } from 'ember-qunit';
     setupTest('service:session', {
       integration: true
     });
     `,
     `
+    import { setupComponentTest } from 'ember-mocha';
     setupComponentTest('display-page', {
       integration: true
     });
     `,
     `
+    import { setupModelTest } from 'ember-mocha';
     setupModelTest('post', {
       integration: true
     });

--- a/tests/lib/rules/no-test-module-for.js
+++ b/tests/lib/rules/no-test-module-for.js
@@ -34,6 +34,10 @@ ruleTester.run('no-test-module-for', rule, {
       filename: 'tests/helpers/something.js',
       code: 'export default function dosomething() {}',
     },
+    {
+      filename: TEST_FILE_NAME,
+      code: 'somethingRandom.moduleFor()',
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -31,6 +31,7 @@ ruleTester.run('require-computed-macros', rule, {
     'computed(function() { return; })',
     'computed(function() { someCall(); return this.x; })', // Multiple statements in function body.
     'computed(function() { return this.x; }, SOME_OTHER_ARG)', // Function isn't last arg.
+    'computed(function() { notAReturnStatement(); })',
     'other(function() { return this.x; })',
 
     // READS
@@ -47,6 +48,8 @@ ruleTester.run('require-computed-macros', rule, {
     "and('x', 'y')",
     'computed(function() { return SOME_VAR && OTHER_VAR; })',
     'computed(function() { return this.x && this.y || this.z; })', // Mixed operators.
+    'computed(function() { return 123 && this.x; })', // With a Literal.
+    'computed(function() { return this.x && 123; })', // With a Literal.
     'computed(function() { return this.get("x") && this.get("y") || this.get("z"); })', // Mixed operators (and this.get)
 
     // OR

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -441,5 +441,14 @@ eslintTester.run('require-super-in-init', rule, {
       output: null,
       errors: [{ message, line: 2 }],
     },
+    {
+      code: `export default Service({
+        init() {
+          someRandomIdentifier;
+        },
+      });`,
+      output: null,
+      errors: [{ message, line: 2 }],
+    },
   ],
 });

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -30,6 +30,12 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
 
      const { Model } = LOL;
     `,
+    `import Model from '@ember-data/model';
+
+     export default Model.extend({
+       name: SomethingRandom.DS('string')
+     });
+    `,
   ],
 
   invalid: [

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -48,6 +48,8 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import EmberAlias from "ember"; EmberAlias.get(this, "test")',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+
+    // ignoreNonThisExpressions
     {
       code: "let a = new Map(); a.set('name', 'Tomster');",
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
@@ -57,6 +59,12 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: "let a = new Map(); a.get('myKey')",
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [{ ignoreNonThisExpressions: true }],
+    },
+
+    // ignoreThisExpressions
+    {
+      code: 'this.get("test")',
+      options: [{ ignoreThisExpressions: true }],
     },
   ],
   invalid: [
@@ -400,6 +408,8 @@ eslintTester.run('use-ember-get-and-set', rule, {
       errors: [{ message: 'Use get/set' }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+
+    // ignoreNonThisExpressions
     {
       code: "this.set('test', 'value')",
       output: null,
@@ -411,6 +421,14 @@ eslintTester.run('use-ember-get-and-set', rule, {
       output: null,
       errors: [{ message: 'Use get/set' }],
       options: [{ ignoreNonThisExpressions: true }],
+    },
+
+    // ignoreThisExpressions
+    {
+      code: "someObject.get('value')",
+      output: null,
+      errors: [{ message: 'Use get/set' }],
+      options: [{ ignoreThisExpressions: true }],
     },
   ],
 });


### PR DESCRIPTION
Used nyc/istanbul to identify lines that were missing test coverage. This addresses many but not all of them.

Improved test coverage will make future refactorings safer to perform.

Before:

```
--------------------------------------------------------|----------|----------|----------|----------|-------------------|
File                                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------------------------------|----------|----------|----------|----------|-------------------|
All files                                               |    97.77 |    95.17 |    99.24 |    97.73 |                   |
```

After:

```
--------------------------------------------------------|----------|----------|----------|----------|-------------------|
File                                                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------------------------------|----------|----------|----------|----------|-------------------|
All files                                               |    98.37 |    96.45 |    99.43 |    98.34 |                   |
```

Follow-up to: https://github.com/ember-cli/eslint-plugin-ember/pull/505