### PR TITLE
Simplify tests for `no-restricted-resolver-tests` rule by using global `parserOptions`

### DIFF
--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -5,84 +5,60 @@
 const rule = require('../../../lib/rules/no-restricted-resolver-tests');
 const RuleTester = require('eslint').RuleTester;
 
-const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
 const { ERROR_MESSAGES } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
 ruleTester.run('no-restricted-resolver-tests', rule, {
   valid: [
-    {
-      code: `
-              moduleFor('service:session', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              moduleForComponent('display-page', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              moduleForModel('post', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              setupTest('service:session', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              setupComponentTest('display-page', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              setupModelTest('post', {
-                integration: true
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: `
-              module('foo', function(hooks) {
-                setupTest(hooks);
-              });
-            `,
-      parserOptions,
-    },
-    {
-      code: "import { setupTest } from 'ember-qunit';",
-      parserOptions,
-    },
-    {
-      code: `const setupTest = require('ember-fastboot-addon-tests').setupTest;
+    `
+    moduleFor('service:session', {
+      integration: true
+    });
+    `,
+    `
+    moduleForComponent('display-page', {
+      integration: true
+    });
+    `,
+    `
+    moduleForModel('post', {
+      integration: true
+    });
+    `,
+    `
+    setupTest('service:session', {
+      integration: true
+    });
+    `,
+    `
+    setupComponentTest('display-page', {
+      integration: true
+    });
+    `,
+    `
+    setupModelTest('post', {
+      integration: true
+    });
+    `,
+    `
+    module('foo', function(hooks) {
+      setupTest(hooks);
+    });
+    `,
+    "import { setupTest } from 'ember-qunit';",
+    `
+    const setupTest = require('ember-fastboot-addon-tests').setupTest;
 
-            describe('Integration tests', function() {
-              setupTest('fastboot-ready-app');
-            });`,
-      parserOptions,
-    },
+    describe('Integration tests', function() {
+      setupTest('fastboot-ready-app');
+    });
+    `,
   ],
   invalid: [
     {
@@ -90,7 +66,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleFor('service:session');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -105,7 +80,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -120,7 +94,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -133,7 +106,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleFor('service:session', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -146,7 +118,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleForComponent('display-page');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -161,7 +132,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -176,7 +146,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -189,7 +158,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleForComponent('display-page', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -202,7 +170,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleForModel('post');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -217,7 +184,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -232,7 +198,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -245,7 +210,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               moduleForModel('post', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -258,7 +222,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupTest('service:session');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -273,7 +236,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -288,7 +250,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -301,7 +262,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupTest('service:session', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -314,7 +274,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupComponentTest('display-page');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -329,7 +288,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -344,7 +302,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -357,7 +314,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupComponentTest('display-page', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -370,7 +326,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupModelTest('post');
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -385,7 +340,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 unit: true
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -400,7 +354,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
                 needs: ['type:thing']
               });
             `,
-      parserOptions,
       output: null,
       errors: [
         {
@@ -413,7 +366,6 @@ ruleTester.run('no-restricted-resolver-tests', rule, {
 
               setupModelTest('post', arg2, {});
             `,
-      parserOptions,
       output: null,
       errors: [
         {


### PR DESCRIPTION
Follow-up to: https://github.com/ember-cli/eslint-plugin-ember/pull/570