### PR TITLE
Fix issue causing assert to fire in `getSourceModuleName` util function

### DIFF
--- a/lib/utils/import.js
+++ b/lib/utils/import.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const assert = require('assert');
-const { isIdentifier, isImportDeclaration, isMemberExpression } = require('../utils/types');
+const {
+  isCallExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isMemberExpression,
+} = require('../utils/types');
 
 module.exports = {
   getSourceModuleNameForIdentifier,
@@ -30,14 +35,16 @@ function getSourceModuleNameForIdentifier(context, node) {
 }
 
 function getSourceModuleName(node) {
-  if (isMemberExpression(node) && node.object) {
+  if (isCallExpression(node) && node.callee) {
+    return getSourceModuleName(node.callee);
+  } else if (isMemberExpression(node) && node.object) {
     return getSourceModuleName(node.object);
   } else if (isIdentifier(node)) {
     return node.name;
   } else {
     assert(
       false,
-      '`getSourceModuleName` should only be called on `MemberExpression` or `Identifier`'
+      '`getSourceModuleName` should only be called on a `CallExpression`, `MemberExpression` or `Identifier`'
     );
     return undefined;
   }

--- a/tests/lib/utils/import-test.js
+++ b/tests/lib/utils/import-test.js
@@ -6,13 +6,18 @@ function parse(code) {
 }
 
 describe('getSourceModuleName', () => {
-  it('gets the correct module name DS', () => {
+  it('gets the correct module name with MemberExpression', () => {
     const node = parse('DS.Model.extend()').callee;
     expect(importUtils.getSourceModuleName(node)).toEqual('DS');
   });
 
-  it('gets the correct module name Model', () => {
+  it('gets the correct module name with Identifier', () => {
     const node = parse('Model.extend()').callee;
+    expect(importUtils.getSourceModuleName(node)).toEqual('Model');
+  });
+
+  it('gets the correct module name with CallExpression', () => {
+    const node = parse('Model.extend()');
     expect(importUtils.getSourceModuleName(node)).toEqual('Model');
   });
 });

--- a/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
+++ b/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
@@ -84,4 +84,17 @@ describe('when the identifier is imported', () => {
 
     expect(getSourceModuleNameForIdentifier(context, node)).toEqual('some-path');
   });
+
+  test('Model.extend(Mixin)', () => {
+    const context = new FauxContext(`
+      import Mixin from './my-mixin';
+      import Model from '@ember-data/model';
+
+      export default class SomeClass extends Model.extend(Mixin) {}
+    `);
+
+    const node = babelEslint.parse('Model.extend(Mixin)').body[0].expression;
+
+    expect(getSourceModuleNameForIdentifier(context, node)).toEqual('@ember-data/model');
+  });
 });


### PR DESCRIPTION
Fixes #614.

@bmish I just tried out 7.7.0 in our app and I started seeing the following assertion `'getSourceModuleName' should only be called on 'MemberExpression' or 'Identifier'` firing on the following code:

```js
export default class MyModel extends Model.extend(SomeMixin) {
  ...
}
```

I've put together a patch for that here