### PR TITLE
Use consistent prefixes for rule descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,101 +85,101 @@ The `--fix` option on the command line automatically fixes problems reported by 
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-|  | [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | Enforces aliasing model in controller |
-| :white_check_mark: | [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | Avoids using needs in controllers |
-| :white_check_mark: | [closure-actions](./docs/rules/closure-actions.md) | Enforces usage of closure actions |
-|  | [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | Enforces usage of named functions in promises |
-| :white_check_mark: | [new-module-imports](./docs/rules/new-module-imports.md) |  Use "New Module Imports" from Ember RFC #176 |
-| :white_check_mark: | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | Prevents usage of Ember's `function` prototype extensions |
-| :car: | [no-get-with-default](./docs/rules/no-get-with-default.md) | Disallows use of the Ember's `getWithDefault` function |
-| :car::wrench: | [no-get](./docs/rules/no-get.md) | Require ES5 getters instead of Ember's `get` / `getProperties` functions |
-| :white_check_mark: | [no-global-jquery](./docs/rules/no-global-jquery.md) | Prevents usage of global jQuery object |
-| :car: | [no-jquery](./docs/rules/no-jquery.md) | Disallow any usage of jQuery |
-| :white_check_mark: | [no-new-mixins](./docs/rules/no-new-mixins.md) | Prevents creation of new mixins |
-| :white_check_mark: | [no-observers](./docs/rules/no-observers.md) | Prevents usage of observers |
-| :white_check_mark::wrench: | [no-old-shims](./docs/rules/no-old-shims.md) | Prevents usage of old shims for modules |
-| :white_check_mark: | [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | Prevents usage of `on` to call lifecycle hooks in components |
-| :white_check_mark: | [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | Prevents the use of patterns that use the restricted resolver in tests. |
-|  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | Disallow unnecessary `index` route definition |
-| :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | Disallow unnecessary route `path` option |
-| :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | Disallow unnecessary argument when injecting service |
-| :white_check_mark: | [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | Disallows volatile computed properties |
-| :wrench: | [require-computed-macros](./docs/rules/require-computed-macros.md) | Requires using computed property macros when possible |
-|  | [route-path-style](./docs/rules/route-path-style.md) | Enforces usage of kebab-case (instead of snake_case or camelCase) in route paths |
-| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | Enforces usage of Ember.get and Ember.set |
+|  | [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | enforce aliasing model in controllers |
+| :white_check_mark: | [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers |
+| :white_check_mark: | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions |
+|  | [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |
+| :white_check_mark: | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 |
+| :white_check_mark: | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions |
+| :car: | [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function |
+| :car::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
+| :white_check_mark: | [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object |
+| :car: | [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery |
+| :white_check_mark: | [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins |
+| :white_check_mark: | [no-observers](./docs/rules/no-observers.md) | disallow usage of observers |
+| :white_check_mark::wrench: | [no-old-shims](./docs/rules/no-old-shims.md) | disallow usage of old shims for modules |
+| :white_check_mark: | [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components |
+| :white_check_mark: | [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests |
+|  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |
+| :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option |
+| :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |
+| :white_check_mark: | [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties |
+| :wrench: | [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible |
+|  | [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |
+| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
 
 
 ### Ember Object
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | Avoids state leakage |
-| :car: | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | Ensure correct hooks are used for both classic and non-classic classes |
-| :car: | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | Prevent usage of classic APIs such as get/set in classes that aren't explicitly decorated with @classic |
-|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | Enforce the consistent use of getters in computed properties |
-|  | [no-proxies](./docs/rules/no-proxies.md) | Disallows using array or object proxies |
+| :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | disallow state leakage |
+| :car: | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes |
+| :car: | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` |
+|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |
+|  | [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |
 
 
 ### Possible Errors
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :white_check_mark: | [jquery-ember-run](./docs/rules/jquery-ember-run.md) | Prevents usage of jQuery without Ember Run Loop |
-| :white_check_mark: | [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | Disallows arrow functions in computed properties |
-| :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | Disallow usage of this.attrs in components |
-| :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs` |
-| :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | Raise an error when there is a route with uppercased letters in router.js |
-| :white_check_mark: | [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | Disallows usage of deeply-nested computed property dependent keys with `@each`. |
-| :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | Disallow repeating dependent keys |
-| :white_check_mark::wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | Prevents use of `this._super` in ES class methods |
-| :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | Prevents use of Ember.testing in module scope |
-| :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | Disallows inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
-| :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | Catch usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
-| :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | Warns about unexpected side effects in computed properties |
-| :wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | Requires dependencies to be declared statically in computed properties |
-| :white_check_mark: | [require-return-from-computed](./docs/rules/require-return-from-computed.md) | Warns about missing return statements in computed properties |
-| :white_check_mark: | [require-super-in-init](./docs/rules/require-super-in-init.md) | Enforces super calls in init hooks |
-| :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | Enforces usage of snake_cased dynamic segments in routes |
+| :white_check_mark: | [jquery-ember-run](./docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop |
+| :white_check_mark: | [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties |
+| :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components |
+| :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` hooks |
+| :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js |
+| :white_check_mark: | [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` |
+| :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys |
+| :white_check_mark::wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods |
+| :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope |
+| :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
+| :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
+| :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties |
+| :wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties |
+| :white_check_mark: | [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties |
+| :white_check_mark: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require `this._super` to be called in `init` hooks |
+| :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | enforce usage of snake_cased dynamic segments in routes |
 
 
 ### Ember Octane
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :car: | [no-actions-hash](./docs/rules/no-actions-hash.md) | Disallows the actions hash in components, controllers and routes |
-| :car: | [no-classic-classes](./docs/rules/no-classic-classes.md) | Disallow "classic" classes in favor of native JS classes |
-| :car: | [no-classic-components](./docs/rules/no-classic-components.md) | Enforces Glimmer components |
-| :car: | [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | Disallows using computed properties in native classes |
-| :car: | [require-tagless-components](./docs/rules/require-tagless-components.md) | Disallows using the wrapper element of a Component |
+| :car: | [no-actions-hash](./docs/rules/no-actions-hash.md) | disallow the actions hash in components, controllers, and routes |
+| :car: | [no-classic-classes](./docs/rules/no-classic-classes.md) | disallow "classic" classes in favor of native JS classes |
+| :car: | [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components |
+| :car: | [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes |
+| :car: | [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component |
 
 
 ### Ember Data
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-|  | [no-empty-attrs](./docs/rules/no-empty-attrs.md) | Prevents usage of empty attributes in ember data models |
-| :wrench: | [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | Use "Ember Data Packages" from Ember RFC #395 |
+|  | [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |
+| :wrench: | [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | enforce usage of `@ember-data/` packages instead `ember-data` |
 
 
 ### Testing
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-|  | [no-pause-test](./docs/rules/no-pause-test.md) | Disallow use of `pauseTest` helper in tests. |
-|  | [no-test-and-then](./docs/rules/no-test-and-then.md) | Disallow use of `andThen` test wait helper. |
-|  | [no-test-import-export](./docs/rules/no-test-import-export.md) | Disallow importing of "-test.js" in a test file and exporting from a test file. |
-|  | [no-test-module-for](./docs/rules/no-test-module-for.md) | Disallow use of moduleFor, moduleForComponent, etc |
+|  | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
+|  | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
+|  | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
+|  | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |
 
 
 ### Stylistic Issues
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :wrench: | [order-in-components](./docs/rules/order-in-components.md) | Enforces proper order of properties in components |
-| :wrench: | [order-in-controllers](./docs/rules/order-in-controllers.md) | Enforces proper order of properties in controllers |
-| :wrench: | [order-in-models](./docs/rules/order-in-models.md) | Enforces proper order of properties in models |
-| :wrench: | [order-in-routes](./docs/rules/order-in-routes.md) | Enforces proper order of properties in routes |
-| :white_check_mark: | [use-brace-expansion](./docs/rules/use-brace-expansion.md) | Enforces usage of brace expansion |
+| :wrench: | [order-in-components](./docs/rules/order-in-components.md) | enforce proper order of properties in components |
+| :wrench: | [order-in-controllers](./docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |
+| :wrench: | [order-in-models](./docs/rules/order-in-models.md) | enforce proper order of properties in models |
+| :wrench: | [order-in-routes](./docs/rules/order-in-routes.md) | enforce proper order of properties in routes |
+| :white_check_mark: | [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys |
 
 <!--RULES_TABLE_END-->
 

--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces aliasing model in controller',
+      description: 'enforce aliasing model in controllers',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -52,7 +52,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Avoids state leakage',
+      description: 'disallow state leakage',
       category: 'Ember Object',
       recommended: true,
       url:

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Avoids using needs in controllers',
+      description: 'disallow using `needs` in controllers',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/classic-decorator-hooks.js
+++ b/lib/rules/classic-decorator-hooks.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Ensure correct hooks are used for both classic and non-classic classes',
+      description: 'enforce using correct hooks for both classic and non-classic classes',
       category: 'Ember Object',
       recommended: false,
       octane: true,

--- a/lib/rules/classic-decorator-no-classic-methods.js
+++ b/lib/rules/classic-decorator-no-classic-methods.js
@@ -25,7 +25,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        "Prevent usage of classic APIs such as get/set in classes that aren't explicitly decorated with @classic",
+        "disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic`",
       category: 'Ember Object',
       recommended: false,
       octane: true,

--- a/lib/rules/closure-actions.js
+++ b/lib/rules/closure-actions.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces usage of closure actions',
+      description: 'enforce usage of closure actions',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -16,7 +16,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforce the consistent use of getters in computed properties',
+      description: 'enforce the consistent use of getters in computed properties',
       category: 'Ember Object',
       recommended: false,
       url:

--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevents usage of jQuery without Ember Run Loop',
+      description: 'disallow usage of jQuery without an Ember run loop',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces usage of named functions in promises',
+      description: 'enforce usage of named functions in promises',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -26,7 +26,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: ' Use "New Module Imports" from Ember RFC #176',
+      description: 'enforce using "New Module Imports" from Ember RFC #176',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-actions-hash.js
+++ b/lib/rules/no-actions-hash.js
@@ -8,7 +8,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows the actions hash in components, controllers and routes',
+      description: 'disallow the actions hash in components, controllers, and routes',
       category: 'Ember Octane',
       recommended: false,
       octane: true,

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallows arrow functions in computed properties',
+      description: 'disallow arrow functions in computed properties',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow usage of this.attrs in components',
+      description: 'disallow usage of `this.attrs` in components',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -14,7 +14,8 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs`',
+      description:
+        'disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` hooks',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Raise an error when there is a route with uppercased letters in router.js',
+      description: 'disallow routes with uppercased letters in router.js',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -37,7 +37,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow "classic" classes in favor of native JS classes',
+      description: 'disallow "classic" classes in favor of native JS classes',
       category: 'Ember Octane',
       recommended: false,
       octane: true,

--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -7,7 +7,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces Glimmer components',
+      description: 'enforce using Glimmer components',
       category: 'Ember Octane',
       recommended: false,
       octane: true,

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -29,7 +29,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows using computed properties in native classes',
+      description: 'disallow using computed properties in native classes',
       category: 'Ember Octane',
       recommended: false,
       octane: true,

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -13,8 +13,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description:
-        'Disallows usage of deeply-nested computed property dependent keys with `@each`.',
+      description: 'disallow usage of deeply-nested computed property dependent keys with `@each`',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow repeating dependent keys',
+      description: 'disallow repeating computed property dependent keys',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevents use of `this._super` in ES class methods',
+      description: 'disallow use of `this._super` in ES class methods',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevents use of Ember.testing in module scope',
+      description: 'disallow use of `Ember.testing` in module scope',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents usage of empty attributes in ember data models',
+      description: 'disallow usage of empty attributes in Ember Data models',
       category: 'Ember Data',
       recommended: false,
       url:

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "Prevents usage of Ember's `function` prototype extensions",
+      description: "disallow usage of Ember's `function` prototype extensions",
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -9,7 +9,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "Disallows use of the Ember's `getWithDefault` function",
+      description: "disallow usage of the Ember's `getWithDefault` function",
       category: 'Best Practices',
       recommended: false,
       octane: true,

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -23,7 +23,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "Require ES5 getters instead of Ember's `get` / `getProperties` functions",
+      description: "require using ES5 getters instead of Ember's `get` / `getProperties` functions",
       category: 'Best Practices',
       recommended: false,
       octane: true,

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents usage of global jQuery object',
+      description: 'disallow usage of global jQuery object',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -24,7 +24,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        'Disallows inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`',
+        'disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -18,7 +18,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        "Catch usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.",
+        "disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.",
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow any usage of jQuery',
+      description: 'disallow any usage of jQuery',
       category: 'Best Practices',
       recommended: false,
       octane: true,

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents creation of new mixins',
+      description: 'disallow the creation of new mixins',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents usage of observers',
+      description: 'disallow usage of observers',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-old-shims.js
+++ b/lib/rules/no-old-shims.js
@@ -252,7 +252,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents usage of old shims for modules',
+      description: 'disallow usage of old shims for modules',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Prevents usage of `on` to call lifecycle hooks in components',
+      description: 'disallow usage of `on` to call lifecycle hooks in components',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-pause-test.js
+++ b/lib/rules/no-pause-test.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow use of `pauseTest` helper in tests.',
+      description: 'disallow usage of the `pauseTest` helper in tests',
       category: 'Testing',
       recommended: false,
       url:

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows using array or object proxies',
+      description: 'disallow using array or object proxies',
       category: 'Ember Object',
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-proxies.md',

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -64,7 +64,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevents the use of patterns that use the restricted resolver in tests.',
+      description: 'disallow the use of patterns that use the restricted resolver in tests',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Warns about unexpected side effects in computed properties',
+      description: 'disallow unexpected side effects in computed properties',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow use of `andThen` test wait helper.',
+      description: 'disallow usage of the `andThen` test wait helper',
       category: 'Testing',
       recommended: false,
       url:

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -15,8 +15,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description:
-        'Disallow importing of "-test.js" in a test file and exporting from a test file.',
+      description: 'disallow importing of "-test.js" in a test file and exporting from a test file',
       category: 'Testing',
       recommended: false,
       url:

--- a/lib/rules/no-test-module-for.js
+++ b/lib/rules/no-test-module-for.js
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow use of moduleFor, moduleForComponent, etc',
+      description: 'disallow usage of `moduleFor`, `moduleForComponent`, etc',
       category: 'Testing',
       recommended: false,
       url:

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow unnecessary `index` route definition',
+      description: 'disallow unnecessary `index` route definition',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow unnecessary route `path` option',
+      description: 'disallow unnecessary usage of the route `path` option',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -14,7 +14,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow unnecessary argument when injecting service',
+      description: 'disallow unnecessary argument when injecting services',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/no-volatile-computed-properties.js
+++ b/lib/rules/no-volatile-computed-properties.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows volatile computed properties',
+      description: 'disallow volatile computed properties',
       category: 'Best Practices',
       recommended: true,
       url:

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -37,7 +37,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'Enforces proper order of properties in components',
+      description: 'enforce proper order of properties in components',
       category: 'Stylistic Issues',
       recommended: false,
       url:

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -28,7 +28,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'Enforces proper order of properties in controllers',
+      description: 'enforce proper order of properties in controllers',
       category: 'Stylistic Issues',
       recommended: false,
       url:

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -17,7 +17,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'Enforces proper order of properties in models',
+      description: 'enforce proper order of properties in models',
       category: 'Stylistic Issues',
       recommended: false,
       url:

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -35,7 +35,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'Enforces proper order of properties in routes',
+      description: 'enforce proper order of properties in routes',
       category: 'Stylistic Issues',
       recommended: false,
       url:

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -80,7 +80,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Requires using computed property macros when possible',
+      description: 'require using computed property macros when possible',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -322,7 +322,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Requires dependencies to be declared statically in computed properties',
+      description: 'require dependencies to be declared statically in computed properties',
       category: 'Possible Errors',
       recommended: false,
       url:

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -14,7 +14,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Warns about missing return statements in computed properties',
+      description: 'disallow missing return statements in computed properties',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -70,7 +70,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Enforces super calls in init hooks',
+      description: 'require `this._super` to be called in `init` hooks',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/require-tagless-components.js
+++ b/lib/rules/require-tagless-components.js
@@ -90,7 +90,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallows using the wrapper element of a Component',
+      description: 'disallow using the wrapper element of a component',
       category: 'Ember Octane',
       recommended: false,
       octane: true,

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description:
-        'Enforces usage of kebab-case (instead of snake_case or camelCase) in route paths',
+        'enforce usage of kebab-case (instead of snake_case or camelCase) in route paths',
       category: 'Best Practices',
       recommended: false,
       url:

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -12,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces usage of snake_cased dynamic segments in routes',
+      description: 'enforce usage of snake_cased dynamic segments in routes',
       category: 'Possible Errors',
       recommended: true,
       url:

--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'Enforces usage of brace expansion',
+      description: 'enforce usage of brace expansion in computed property dependent keys',
       category: 'Stylistic Issues',
       recommended: true,
       url:

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -64,7 +64,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Use "Ember Data Packages" from Ember RFC #395',
+      description: 'enforce usage of `@ember-data/` packages instead `ember-data`',
       category: 'Ember Data',
       recommended: false,
       url:

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -17,7 +17,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforces usage of Ember.get and Ember.set',
+      description: 'enforce usage of `Ember.get` and `Ember.set`',
       category: 'Best Practices',
       recommended: false,
       url:


### PR DESCRIPTION
Updates all rule descriptions to start with 'enforce', 'require', 'disallow' prefixes to match eslint conventions.

Includes tweaks to clarity and consistency.

I plan to enforce this with a new lint rule: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/89