### PR TITLE
Fix false positive with `ignoreNonThisExpressions` option in `use-ember-get-and-set` rule

### DIFF
--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -128,17 +128,17 @@ module.exports = {
         ) {
           return;
         }
+
         // Skip calls made on this
         if (options.ignoreThisExpressions && isThisExpression(callee.object)) {
           return;
         }
-        // Only lint calls made on this
-        if (options.ignoreNonThisExpressions && isThisExpression(callee.object)) {
-          report(node);
-          return;
-        } else if (options.ignoreNonThisExpressions) {
+
+        // Skip calls made on non this expression
+        if (options.ignoreNonThisExpressions && !isThisExpression(callee.object)) {
           return;
         }
+
         // Skip calls made on Ember methods
         if (isIdentifier(callee.object) && callee.object.name === emberImportAliasName) {
           return;

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -60,6 +60,11 @@ eslintTester.run('use-ember-get-and-set', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [{ ignoreNonThisExpressions: true }],
     },
+    {
+      code: 'this.test("ok")',
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{ ignoreNonThisExpressions: true }]
+    },
 
     // ignoreThisExpressions
     {

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -63,7 +63,7 @@ eslintTester.run('use-ember-get-and-set', rule, {
     {
       code: 'this.test("ok")',
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{ ignoreNonThisExpressions: true }]
+      options: [{ ignoreNonThisExpressions: true }],
     },
 
     // ignoreThisExpressions


### PR DESCRIPTION
Currently, every expression using `this.{method}()` will raise an error `Use get/seteslint(ember/use-ember-get-and-set)`

Here is a fix + test.