### PR TITLE
Update `no-observers` rule to catch `addObserver` and observer imports

### DIFF
--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -27,11 +27,57 @@ export default Controller.extend({
 ```
 
 ```js
+import { observer } from '@ember/object';
+
+export default Controller.extend({
+  change: observer('text', function() {
+    console.log(`change detected: ${this.text}`);
+  },
+});
+```
+
+```js
 import { observes } from '@ember-decorators/object';
 class FooComponent extends Component {
   @observes('text')
   change() {
     console.log(`change detected: ${this.text}`);
+  }
+}
+``` 
+
+```js
+import { addObserver, removeObserver } from '@ember/object/observers';
+
+class FooComponent extends Component {
+  constructor() {
+    super(...arguments);
+    addObserver(this, 'text', this.change)
+  }
+  
+  change() {
+    console.log(`change detected: ${this.text}`);
+  }
+
+  willDestroy() {
+    removeObserver(this, 'text', this.change);
+    super.willDestroy(...arguments);
+  }
+}
+``` 
+
+```js
+import { inject as service } from '@ember/service'; 
+
+class FooComponent extends Component {
+  time: service(),
+  constructor() {
+    super(...arguments);
+    this.time.addObserver('currentTime.seconds', this.update)
+  }
+  
+  update() {
+    console.log(`The time is ${this.time.currentTime}`);
   }
 }
 ```

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -57,8 +57,8 @@ module.exports = {
       'CallExpression > MemberExpression[property.name="extend"]'(node) {
         const callExpression = node.parent;
 
-        // Invalid if there are no arguments because that is equivalent to nnot called `extend` at all
-        // Invalid with an object as an argument because that logic needsconversion to a native class
+        // Invalid if there are no arguments because that is equivalent to not called `extend` at all
+        // Invalid with an object as an argument because that logic needs conversion to a native class
         // Still allows `.extend` if some other identifier is passed, like a Mixin
         if (hasNoArguments(callExpression) || hasObjectArgument(callExpression)) {
           const classImportedFrom = getSourceModuleNameForIdentifier(context, node.object);

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ember = require('../utils/ember');
+const types = require('../utils/types');
 
 //------------------------------------------------------------------------------
 // General rule - Don't use observers
@@ -34,10 +35,32 @@ module.exports = {
         if (ember.isModule(node, 'observer')) {
           report(node);
         }
+
+        const { callee } = node;
+
+        if (
+          (types.isThisExpression(callee.object) || types.isMemberExpression(callee)) &&
+          types.isIdentifier(callee.property) &&
+          callee.property.name === 'addObserver'
+        ) {
+          report(node);
+        }
       },
 
       Decorator(node) {
         if (ember.isObserverDecorator(node)) {
+          report(node);
+        }
+      },
+
+      ImportDeclaration(node) {
+        const importSource = node.source.value;
+
+        if (
+          (importSource === '@ember/object' &&
+            node.specifiers.some(s => s.imported.name === 'observer')) ||
+          importSource === '@ember/object/observers'
+        ) {
           report(node);
         }
       },

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -35,6 +35,104 @@ eslintTester.run('no-observers', rule, {
   ],
   invalid: [
     {
+      code: "import { observer, computed } from '@ember/object';",
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: "import { observer as foo } from '@ember/object';",
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: "import { addObserver } from '@ember/object/observers';",
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: "import { removeObserver } from '@ember/object/observers';",
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: `
+        export default Component.extend({
+          fooBar() {
+            this.foo.addObserver("bar", this, "rerun");
+          }
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        export default Component.extend({
+          fooBar() {
+            this.addObserver("bar", this, "rerun");
+          }
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        export default Component.extend({
+          fooBar(baz) {
+            baz.addObserver("bar", this, "rerun");
+          }
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'Ember.addObserver("foo", this, "rerun");',
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
       code: 'Ember.observer("text", function() {});',
       output: null,
       errors: [


### PR DESCRIPTION
Should fix #527 

I did this mostly by cargo-culting from other files and poking around on astexplorer, so it may warrant a closer-look.