### PR TITLE
Add missing test case output assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
     'eslint-comments/no-unused-disable': 'error',
 
     // eslint-plugin rules:
+    'eslint-plugin/consistent-output': ['error', 'always'],
     'eslint-plugin/no-deprecated-report-api': 'off',
     'eslint-plugin/require-meta-docs-url': ['error', {
       pattern: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/{{name}}.md',

--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -50,6 +50,7 @@ ruleTester.run('classic-decorator-hooks', rule, {
           init() {}
         }
       `,
+      output: null,
       errors: [
         {
           message: ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
@@ -62,6 +63,7 @@ ruleTester.run('classic-decorator-hooks', rule, {
           destroy() {}
         }
       `,
+      output: null,
       errors: [
         {
           message: ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,
@@ -75,6 +77,7 @@ ruleTester.run('classic-decorator-hooks', rule, {
           constructor() {}
         }
       `,
+      output: null,
       errors: [
         {
           message: ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC,

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -58,6 +58,7 @@ ruleTester.run('classic-decorator-no-classic-methods', rule, {
           }
         }
       `,
+      output: null,
       errors: [
         {
           message: disallowedMethodErrorMessage('get'),
@@ -71,6 +72,7 @@ ruleTester.run('classic-decorator-no-classic-methods', rule, {
           foo = this.get('bar');
         }
       `,
+      output: null,
       errors: [
         {
           message: disallowedMethodErrorMessage('get'),

--- a/tests/lib/rules/no-actions-hash.js
+++ b/tests/lib/rules/no-actions-hash.js
@@ -74,6 +74,7 @@ ruleTester.run('no-actions-hash', rule, {
           },
         });
       `,
+      output: null,
       errors: [{ type: 'Property', message: ERROR_MESSAGE }],
     },
     {
@@ -86,6 +87,7 @@ ruleTester.run('no-actions-hash', rule, {
           }
         }
       `,
+      output: null,
       errors: [{ type: 'ClassProperty', message: ERROR_MESSAGE }],
     },
     {
@@ -95,6 +97,7 @@ ruleTester.run('no-actions-hash', rule, {
           },
         });
       `,
+      output: null,
       errors: [{ type: 'Property', message: ERROR_MESSAGE }],
     },
     {
@@ -107,6 +110,7 @@ ruleTester.run('no-actions-hash', rule, {
           }
         }
       `,
+      output: null,
       errors: [{ type: 'ClassProperty', message: ERROR_MESSAGE }],
     },
     {
@@ -116,6 +120,7 @@ ruleTester.run('no-actions-hash', rule, {
           },
         });
       `,
+      output: null,
       errors: [{ type: 'Property', message: ERROR_MESSAGE }],
     },
     {
@@ -128,6 +133,7 @@ ruleTester.run('no-actions-hash', rule, {
           }
         }
       `,
+      output: null,
       errors: [{ type: 'ClassProperty', message: ERROR_MESSAGE }],
     },
   ],

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -54,33 +54,40 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
   invalid: [
     {
       code: 'computed(() => { return 123; })',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
       code: "computed('prop', () => { return this.prop; })",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
 
     {
       code: "computed('prop', () => { return this.prop; }).volatile()",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
       code: "computed.map('products', product => { return someFunction(product); })",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
       code: 'computed(() => { return 123; })',
+      output: null,
       errors: [],
       options: [{ onlyThisContexts: true }],
     },
     {
       code: "computed('prop', () => { return this.prop; })",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
       options: [{ onlyThisContexts: true }],
     },
     {
       code: "computed('prop', () => { return this.prop; }).volatile()",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
       options: [{ onlyThisContexts: true }],
     },

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -43,6 +43,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Component from '@ember/component';
         export default Component.extend();
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
     {
@@ -50,6 +51,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Component from '@ember/component';
         export default Component.extend({});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
     {
@@ -58,6 +60,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Evented from '@ember/object/Evented';
         export default Component.extend(Evented, {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],
     },
     {
@@ -65,6 +68,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Component from '@ember/component';
         export default class MyComponent extends Component.extend() {};
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
     {
@@ -72,6 +76,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Component from '@ember/component';
         export default class MyComponent extends Component.extend({}) {};
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
     {
@@ -80,6 +85,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Evented from '@ember/object/evented';
         export default class MyComponent extends Component.extend(Evented, {}) {};
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],
     },
     {
@@ -87,6 +93,7 @@ ruleTester.run('no-classic-classes', rule, {
         import DS from 'ember-data';
         export default DS.Model.extend({});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
     {
@@ -94,6 +101,7 @@ ruleTester.run('no-classic-classes', rule, {
         import Model from '@ember-data/model';
         export default Model.extend({});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
   ],

--- a/tests/lib/rules/no-classic-components.js
+++ b/tests/lib/rules/no-classic-components.js
@@ -24,6 +24,7 @@ ruleTester.run('no-classic-components', rule, {
   invalid: [
     {
       code: "import Component from '@ember/component';",
+      output: null,
       errors: [
         {
           message: ERROR_MESSAGE,

--- a/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -147,6 +147,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once } from '@ember/runloop';
         once(function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -154,6 +155,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once } from '@ember/runloop';
         once(this, function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -161,6 +163,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once, scheduleOnce } from '@ember/runloop';
         once(function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -168,6 +171,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { scheduleOnce } from '@ember/runloop';
         scheduleOnce('afterRender', function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -175,6 +179,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { scheduleOnce } from '@ember/runloop';
         scheduleOnce('afterRender', this, function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -182,6 +187,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once, scheduleOnce } from '@ember/runloop';
         scheduleOnce('afterRender', this, function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -189,6 +195,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { debounce } from '@ember/runloop';
         debounce(this, function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -196,6 +203,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { run } from '@ember/runloop';
         run.once(function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -203,6 +211,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { run } from '@ember/runloop';
         run.once(this, function() {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -210,6 +219,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { run } from '@ember/runloop';
         run.scheduleOnce('afterRender', function() {})
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -217,6 +227,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { run } from '@ember/runloop';
         run.scheduleOnce('afterRender', this, function() {})
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -224,6 +235,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once, scheduleOnce, run } from '@ember/runloop';
         run.scheduleOnce('afterRender', this, function() {})
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'FunctionExpression' }],
     },
     {
@@ -231,6 +243,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { run } from '@ember/runloop';
         run.scheduleOnce('afterRender', this, () => {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
@@ -238,6 +251,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { scheduleOnce } from '@ember/runloop';
         scheduleOnce('afterRender', this, () => {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
@@ -245,6 +259,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { once } from '@ember/runloop';
         once(this, () => {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
@@ -252,6 +267,7 @@ ruleTester.run('no-anonymous-functions-to-single-scheduler-methods', rule, {
         import { debounce } from '@ember/runloop';
         debounce(this, () => {});
       `,
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
   ],

--- a/tests/lib/rules/no-unnecessary-index-route.js
+++ b/tests/lib/rules/no-unnecessary-index-route.js
@@ -39,22 +39,27 @@ ruleTester.run('no-unnecessary-index-route', rule, {
   invalid: [
     {
       code: 'this.route("index");',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: 'this.route("index", { path: "" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: 'this.route("index", { path: "/" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: 'this.route("index", { path: "/index" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: 'this.route("index", { path: "/" }, function() {});',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
   ],

--- a/tests/lib/rules/no-volatile-computed-properties.js
+++ b/tests/lib/rules/no-volatile-computed-properties.js
@@ -24,11 +24,13 @@ ruleTester.run('no-volatile-computed-properties', rule, {
   invalid: [
     {
       code: 'computed().volatile()',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
     },
 
     {
       code: "computed('prop', function() { return this.prop; }).volatile()",
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
     },
   ],

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -24,6 +24,7 @@ eslintTester.run('require-return-from-computed', rule, {
   invalid: [
     {
       code: 'let foo = computed("test", function() { })',
+      output: null,
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -32,6 +33,7 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed("test", function() { if (true) { return ""; } })',
+      output: null,
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -40,6 +42,7 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed("test", { get() {}, set() {} })',
+      output: null,
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -51,6 +54,7 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed({ get() { return "foo"; }, set() { }})',
+      output: null,
       errors: [
         {
           message: 'Always return a value from computed properties',
@@ -59,6 +63,7 @@ eslintTester.run('require-return-from-computed', rule, {
     },
     {
       code: 'let foo = computed({ get() { }, set() { return "foo"; }})',
+      output: null,
       errors: [
         {
           message: 'Always return a value from computed properties',

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -82,38 +82,47 @@ ruleTester.run('route-path-style', rule, {
   invalid: [
     {
       code: 'this.route("blog_posts");',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blogPosts");',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blogPosts", function() {});',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blog_posts" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blogPosts" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blogPosts/:blog_id" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blog-posts/:blog_id/otherPart" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blogPosts/*path" });',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.route("blog-posts", { path: "/blogPosts" }, function() {});',
+      output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
   ],

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -45,6 +45,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
         export default DS.Model.extend({
         });
       `,
+      output: null,
       errors: [
         {
           message,
@@ -63,6 +64,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
           name: DS.attr('string')
         });
       `,
+      output: null,
       errors: [
         {
           message,
@@ -82,6 +84,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
           name: attr('string')
         });
       `,
+      output: null,
       errors: [
         {
           message,
@@ -104,6 +107,11 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
         export default Model.extend({
         });
       `,
+      output: `import Model from '@ember-data/model';
+
+        export default Model.extend({
+        });
+      `,
       errors: [
         {
           message,
@@ -114,6 +122,13 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
     {
       code: `import Model from 'ember-data/model';
         import attr  from 'ember-data/attr';
+
+        export default Model.extend({
+          name: attr('string')
+        });
+      `,
+      output: `import Model from '@ember-data/model';
+        import { attr } from '@ember-data/model';
 
         export default Model.extend({
           name: attr('string')
@@ -138,6 +153,13 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
           name: attr('string')
         });
       `,
+      output: `import Model from '@ember-data/model';
+        import { attr } from '@ember-data/model';
+
+        export default Model.extend({
+          name: attr('string')
+        });
+      `,
       errors: [
         {
           message,
@@ -148,6 +170,13 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
     {
       code: `import Model from '@ember-data/model';
         import namedAttr from 'ember-data/attr';
+
+        export default Model.extend({
+          name: namedAttr('string')
+        });
+      `,
+      output: `import Model from '@ember-data/model';
+        import { attr as namedAttr } from '@ember-data/model';
 
         export default Model.extend({
           name: namedAttr('string')
@@ -166,6 +195,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
         export default Model.extend({
         });
       `,
+      output: null,
       errors: [
         {
           message,
@@ -178,6 +208,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
 
         const { Model } = ED;
       `,
+      output: null,
       errors: [
         {
           message,


### PR DESCRIPTION
And enforce this with the `always` setting of the [eslint-plugin/consistent-output](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/consistent-output.md) lint rule.