### PR TITLE
Fix crash with default imports in `no-observers` and `no-computed-properties-in-native-classes` rules

### DIFF
--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -16,7 +16,7 @@ function findComputedNodes(nodeBody) {
     return (
       node.source.value === '@ember/object/computed' ||
       (node.source.value === '@ember/object' &&
-        node.specifiers.some(s => s.imported.name === 'computed'))
+        node.specifiers.some(s => (s.imported ? s.imported.name : s.local.name) === 'computed'))
     );
   });
 }

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -58,7 +58,9 @@ module.exports = {
 
         if (
           (importSource === '@ember/object' &&
-            node.specifiers.some(s => s.imported.name === 'observer')) ||
+            node.specifiers.some(
+              s => (s.imported ? s.imported.name : s.local.name) === 'observer'
+            )) ||
           importSource === '@ember/object/observers'
         ) {
           report(node);

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -37,14 +37,19 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
 
       export default class MyComponent extends Component {}
     `,
+
+    // Unrelated import statements:
+    "import EmberObject from '@ember/object';",
+    "import { run } from '@ember/runloop';",
+    "import { run as renamedRun } from '@ember/runloop';",
   ],
   invalid: [
     {
       code: `
       import { computed } from '@ember/object';
-      
+
       export default class MyComponent extends Component {
-      
+
       }
       `,
       output: null,
@@ -53,9 +58,9 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
     {
       code: `
       import { computed as thinking } from '@ember/object';
-      
+
       export default class MyComponent extends Component {
-      
+
       }
       `,
       output: null,
@@ -64,9 +69,9 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
     {
       code: `
       import { and, or, alias } from '@ember/object/computed';
-      
+
       export default class MyComponent extends Component {
-      
+
       }
       `,
       output: null,

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -26,6 +26,12 @@ eslintTester.run('no-observers', rule, {
   valid: [
     'export default Controller.extend();',
     'export default Controller.extend({actions: {},});',
+
+    // Unrelated import statements:
+    "import EmberObject from '@ember/object';",
+    "import { run } from '@ember/runloop';",
+    "import { run as renamedRun } from '@ember/runloop';",
+
     `
     import { action } from '@ember/object';
     class FooComponent extends Component {


### PR DESCRIPTION
Fix to ensure that this example does not crash:

```
import EmberObject from '@ember/object';
```

with this error:

```
TypeError: Cannot read property 'name' of undefined
```

Follow-up to #639 and #640.