### PR TITLE
Update `no-new-mixins` rule documentation

### DIFF
--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -2,7 +2,9 @@
 
 ### Rule name: `no-new-mixins`
 
-Using mixins makes sharing code simple at first, but add significant complexity as a project developes and grows larger.
+Using mixins to share code appears easy at first. But they add significant complexity as a project grows. Furthermore, the [Octane programming model](https://guides.emberjs.com/release/upgrading/current-edition/) eliminates the need to use them in favor of native class semantics and other primitives.
+
+For practical strategies on removing mixins see [this discourse thread](https://discuss.emberjs.com/t/best-way-to-replace-mixins/17395/2).
 
 For more details and examples of how mixins create problems down-the-line, see these excellent blog posts:
 * [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)


### PR DESCRIPTION
I think we should consider removing code examples from this rule in favor of linking to community curated examples. In the linked discourse thread I'm plugging using Ember Atlas because it fills this void nicely.
The examples showcase a functional style of programming that may not be relevant in various applications.