### PR TITLE
Update `no-classic-components` rule to only disallow the specific component import

### DIFF
--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const types = require('../utils/types');
+const assert = require('assert');
+
 const ERROR_MESSAGE =
   'Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)';
 
@@ -27,12 +30,18 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        const importSource = node.source.value;
-
-        if (importSource === '@ember/component') {
-          report(node);
+        if (node.source.value === '@ember/component') {
+          const importDefaultSpecifier = getImportDefaultSpecifier(node);
+          if (importDefaultSpecifier) {
+            report(importDefaultSpecifier);
+          }
         }
       },
     };
   },
 };
+
+function getImportDefaultSpecifier(node) {
+  assert(types.isImportDeclaration(node));
+  return node.specifiers.find(specifier => types.isImportDefaultSpecifier(specifier));
+}

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -18,6 +18,7 @@ module.exports = {
   isFunctionExpression,
   isIdentifier,
   isImportDeclaration,
+  isImportDefaultSpecifier,
   isLiteral,
   isLogicalExpression,
   isMemberExpression,
@@ -223,6 +224,16 @@ function isIdentifier(node) {
  */
 function isImportDeclaration(node) {
   return node !== undefined && node.type === 'ImportDeclaration';
+}
+
+/**
+ * Check whether or not a node is an ImportDefaultSpecifier.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an ImportDefaultSpecifier.
+ */
+function isImportDefaultSpecifier(node) {
+  return node !== undefined && node.type === 'ImportDefaultSpecifier';
 }
 
 /**

--- a/tests/lib/rules/no-classic-components.js
+++ b/tests/lib/rules/no-classic-components.js
@@ -19,7 +19,11 @@ const parserOptions = {
 const ruleTester = new RuleTester({ parserOptions });
 
 ruleTester.run('no-classic-components', rule, {
-  valid: ["import Component from '@glimmer/component';"],
+  valid: [
+    "import Component from '@glimmer/component';",
+    "import { setComponentTemplate } from '@ember/component';",
+    "import { helper } from '@ember/component/helper';",
+  ],
 
   invalid: [
     {
@@ -28,7 +32,7 @@ ruleTester.run('no-classic-components', rule, {
       errors: [
         {
           message: ERROR_MESSAGE,
-          type: 'ImportDeclaration',
+          type: 'ImportDefaultSpecifier',
         },
       ],
     },


### PR DESCRIPTION
Only this default import should be disallowed:

```
import Component from '@ember/component';
```

Other named imports from `@ember/component` should be allowed.

Fixes #653. CC: @mehulkar.