### PR TITLE
Update `order-in-*` rules to support custom ordering of properties

### DIFF
--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -54,7 +54,20 @@ order: [
 ]
 ```
 
-You can find full list of properties that you can use to configure this rule [here](/lib/utils/property-order.js#L10).
+### Custom Properties
+
+If you would like to specify ordering for a property type that is not listed, you can use the custom property syntax
+in the order list to specify where the property should go:
+
+```
+custom:myPropertyName
+```
+
+These must be prefixed with `custom:`
+
+### Additional Properties
+
+You can find the full list of properties [here](/lib/utils/property-order.js#L10).
 
 ## Description
 
@@ -121,30 +134,5 @@ export default Component.extend({
   _secretMethod() {
     // custom secret method logic
   }
-});
-```
-
-#### Custom Prop Ordering
-
-If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
-
-```
-ember/order-in-components: [2, {
-  order: [
-    'property',
-    'method',
-    ...
-    'custom:customOrderedPropName'
-  ]
-}]
-```
-
-Now this accepted by the linter:
-
-```
-export default Component.extend({
-  regularProp: 1,
-  aMethod: function() {},
-  customOrderedPropName: 2
 });
 ```

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -123,3 +123,28 @@ export default Component.extend({
   }
 });
 ```
+
+#### Custom Prop Ordering
+
+If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
+
+```
+ember/order-in-components: [2, {
+  order: [
+    'property',
+    'method',
+    ...
+    'custom:customOrderedPropName'
+  ]
+}]
+```
+
+Now this accepted by the linter:
+
+```
+export default Component.extend({
+  regularProp: 1,
+  aMethod: function() {},
+  customOrderedPropName: 2
+});
+```

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -30,7 +30,20 @@ order: [
 ]
 ```
 
-You can find full list of properties that you can use to configure this rule [here](/lib/utils/property-order.js#L10).
+### Custom Properties
+
+If you would like to specify ordering for a property type that is not listed, you can use the custom property syntax
+in the order list to specify where the property should go:
+
+```
+custom:myPropertyName
+```
+
+These must be prefixed with `custom:`
+
+### Additional Properties
+
+You can find the full list of properties [here](/lib/utils/property-order.js#L10).
 
 ## Description
 
@@ -90,30 +103,5 @@ export default Controller.extend({
   _secretMethod() {
     // custom secret method logic
   },
-});
-```
-
-#### Custom Prop Ordering
-
-If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
-
-```
-ember/order-in-components: [2, {
-  order: [
-    'property',
-    'method',
-    ...
-    'custom:customOrderedPropName'
-  ]
-}]
-```
-
-Now this accepted by the linter:
-
-```
-export default Controller.extend({
-  regularProp: 1,
-  aMethod: function() {},
-  customOrderedPropName: 2
 });
 ```

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -92,3 +92,28 @@ export default Controller.extend({
   },
 });
 ```
+
+#### Custom Prop Ordering
+
+If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
+
+```
+ember/order-in-components: [2, {
+  order: [
+    'property',
+    'method',
+    ...
+    'custom:customOrderedPropName'
+  ]
+}]
+```
+
+Now this accepted by the linter:
+
+```
+export default Controller.extend({
+  regularProp: 1,
+  aMethod: function() {},
+  customOrderedPropName: 2
+});
+```

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -23,7 +23,20 @@ order: [
 ]
 ```
 
-You can find full list of properties that you can use to configure this rule [here](/lib/utils/property-order.js#L10).
+### Custom Properties
+
+If you would like to specify ordering for a property type that is not listed, you can use the custom property syntax
+in the order list to specify where the property should go:
+
+```
+custom:myPropertyName
+```
+
+These must be prefixed with `custom:`
+
+### Additional Properties
+
+You can find the full list of properties [here](/lib/utils/property-order.js#L10).
 
 ## Description
 
@@ -63,30 +76,5 @@ export default Model.extend({
   behaviors: hasMany('behaviour'),
 
   shape: attr('string')
-});
-```
-
-#### Custom Prop Ordering
-
-If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
-
-```
-ember/order-in-components: [2, {
-  order: [
-    'property',
-    'method',
-    ...
-    'custom:customOrderedPropName'
-  ]
-}]
-```
-
-Now this accepted by the linter:
-
-```
-export default DS.Model.extend({
-  regularProp: 1,
-  aMethod: function() {},
-  customOrderedPropName: 2
 });
 ```

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -65,3 +65,28 @@ export default Model.extend({
   shape: attr('string')
 });
 ```
+
+#### Custom Prop Ordering
+
+If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
+
+```
+ember/order-in-components: [2, {
+  order: [
+    'property',
+    'method',
+    ...
+    'custom:customOrderedPropName'
+  ]
+}]
+```
+
+Now this accepted by the linter:
+
+```
+export default DS.Model.extend({
+  regularProp: 1,
+  aMethod: function() {},
+  customOrderedPropName: 2
+});
+```

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -118,3 +118,28 @@ export default Route.extend({
   },
 });
 ```
+
+#### Custom Prop Ordering
+
+If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
+
+```
+ember/order-in-components: [2, {
+  order: [
+    'property',
+    'method',
+    ...
+    'custom:customOrderedPropName'
+  ]
+}]
+```
+
+Now this accepted by the linter:
+
+```
+export default Route.extend({
+  regularProp: 1,
+  aMethod: function() {},
+  customOrderedPropName: 2
+});
+```

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -50,7 +50,20 @@ order: [
 ]
 ```
 
-You can find full list of properties that you can use to configure this rule [here](/lib/utils/property-order.js#L10).
+### Custom Properties
+
+If you would like to specify ordering for a property type that is not listed, you can use the custom property syntax
+in the order list to specify where the property should go:
+
+```
+custom:myPropertyName
+```
+
+These must be prefixed with `custom:`
+
+### Additional Properties
+
+You can find the full list of properties [here](/lib/utils/property-order.js#L10).
 
 ## Description
 
@@ -116,30 +129,5 @@ export default Route.extend({
   _secretMethod() {
     // custom secret method logic
   },
-});
-```
-
-#### Custom Prop Ordering
-
-If you have certain properties that you like to keep in a particular order, then you can pass the `custom:$PROPERTY_NAME` syntax to the configuration:
-
-```
-ember/order-in-components: [2, {
-  order: [
-    'property',
-    'method',
-    ...
-    'custom:customOrderedPropName'
-  ]
-}]
-```
-
-Now this accepted by the linter:
-
-```
-export default Route.extend({
-  regularProp: 1,
-  aMethod: function() {},
-  customOrderedPropName: 2
 });
 ```

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -83,7 +83,6 @@ module.exports = {
         if (!ember.isEmberRoute(context, node)) {
           return;
         }
-
         reportUnorderedProperties(node, context, 'route', order);
       },
     };

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -49,9 +49,8 @@ const NAMES = {
   willUpdate: 'lifecycle hook',
 };
 
-// eslint-disable-next-line complexity
-function determinePropertyType(node, parentType) {
-  if (ember.isInjectedServiceProp(node)) {
+function determinePropertyType(node, parentType, ORDER) {
+  if (ember.isInjectedServiceProp(node.value)) {
     return 'service';
   }
 
@@ -112,6 +111,12 @@ function determinePropertyType(node, parentType) {
     return 'multi-line-function';
   }
 
+  const propName = getNodeKeyName(node);
+  const possibleOrderName = `custom:${propName}`;
+  if (ORDER.includes(possibleOrderName)) {
+    return possibleOrderName;
+  }
+
   if (ember.isCustomProp(node)) {
     return 'property';
   }
@@ -145,20 +150,34 @@ function getOrder(ORDER, type) {
   return ORDER.length;
 }
 
+function getNodeKeyName(node) {
+  if (node.key) {
+    if (node.key.type === 'Identifier') {
+      return node.key.name;
+    } else if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+      return node.key.value;
+    }
+  }
+
+  return 'unknown';
+}
+
 function getName(type, node) {
   let prefix;
-  if (!node.computed && type !== 'actions' && type !== 'model') {
-    if (node.key.type === 'Identifier') {
-      prefix = node.key.name;
-    } else if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
-      prefix = node.key.value;
-    }
+  if (!node.computed &&
+    type !== 'actions' &&
+    type !== 'model') {
+    prefix = getNodeKeyName(node);
   }
 
   const typeDescription = NAMES[type];
 
   if (type === 'inherited-property') {
     return prefix ? `inherited "${prefix}" property` : 'inherited property';
+  }
+
+  if (type.startsWith('custom:')) {
+    return prefix ? `"${prefix}" custom property` : 'custom property';
   }
 
   return prefix ? `"${prefix}" ${typeDescription}` : typeDescription;
@@ -169,12 +188,8 @@ function reportUnorderedProperties(node, context, parentType, ORDER) {
   const firstPropertyOfType = {};
   let firstPropertyOfNextType;
 
-  const properties = types.isClassDeclaration(node)
-    ? node.body.body
-    : ember.getModuleProperties(node);
-
-  properties.forEach(property => {
-    const type = determinePropertyType(property, parentType);
+  ember.getModuleProperties(node).forEach((property) => {
+    const type = determinePropertyType(property, parentType, ORDER);
     const order = getOrder(ORDER, type);
 
     const info = {

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -49,8 +49,9 @@ const NAMES = {
   willUpdate: 'lifecycle hook',
 };
 
+// eslint-disable-next-line complexity
 function determinePropertyType(node, parentType, ORDER) {
-  if (ember.isInjectedServiceProp(node.value)) {
+  if (ember.isInjectedServiceProp(node)) {
     return 'service';
   }
 
@@ -164,9 +165,7 @@ function getNodeKeyName(node) {
 
 function getName(type, node) {
   let prefix;
-  if (!node.computed &&
-    type !== 'actions' &&
-    type !== 'model') {
+  if (!node.computed && type !== 'actions' && type !== 'model') {
     prefix = getNodeKeyName(node);
   }
 
@@ -188,7 +187,11 @@ function reportUnorderedProperties(node, context, parentType, ORDER) {
   const firstPropertyOfType = {};
   let firstPropertyOfNextType;
 
-  ember.getModuleProperties(node).forEach((property) => {
+  const properties = types.isClassDeclaration(node)
+    ? node.body.body
+    : ember.getModuleProperties(node);
+
+  properties.forEach(property => {
     const type = determinePropertyType(property, parentType, ORDER);
     const order = getOrder(ORDER, type);
 

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -305,15 +305,17 @@ eslintTester.run('order-in-components', rule, {
         bar() { const foo = 'bar'}
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'property',
-          'empty-method',
-          'single-line-function',
-          'multi-line-function',
-          'method'
-        ]
-      }]
+      options: [
+        {
+          order: [
+            'property',
+            'empty-method',
+            'single-line-function',
+            'multi-line-function',
+            'method',
+          ],
+        },
+      ],
     },
     {
       code: `export default Component.extend({
@@ -324,15 +326,12 @@ eslintTester.run('order-in-components', rule, {
         customProp: { a: 1 }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'property',
-          'actions',
-          'custom:customProp',
-          'method'
-        ]
-      }]
-    }
+      options: [
+        {
+          order: ['property', 'actions', 'custom:customProp', 'method'],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -736,13 +735,43 @@ eslintTester.run('order-in-components', rule, {
         onBar: () => {}
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'The "onFoo" empty method should be above the "foo" multi-line function on line 2',
-        line: 4
-      }, {
-        message: 'The "onBar" empty method should be above the "foo" multi-line function on line 2',
-        line: 6
-      }]
+      errors: [
+        {
+          message:
+            'The "onFoo" empty method should be above the "foo" multi-line function on line 2',
+          line: 4,
+        },
+        {
+          message:
+            'The "onBar" empty method should be above the "foo" multi-line function on line 2',
+          line: 6,
+        },
+      ],
+    },
+    {
+      code: `export default Component.extend({
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        vehicle: alias("car"),
+
+        actions: {}
+      });`,
+      output: `export default Component.extend({
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
+      errors: [
+        {
+          message:
+            'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 2',
+          line: 5,
+        },
+      ],
     },
     {
       code: `export default Component.extend({
@@ -751,18 +780,17 @@ eslintTester.run('order-in-components', rule, {
         customProp: { a: 1 }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'property',
-          'custom:customProp',
-          'actions',
-          'method'
-        ]
-      }],
-      errors: [{
-        message: 'The "customProp" custom property should be above the actions hash on line 3',
-        line: 4
-      }]
+      options: [
+        {
+          order: ['property', 'custom:customProp', 'actions', 'method'],
+        },
+      ],
+      errors: [
+        {
+          message: 'The "customProp" custom property should be above the actions hash on line 3',
+          line: 4,
+        },
+      ],
     },
     {
       code: `export default Component.extend({
@@ -772,16 +800,18 @@ eslintTester.run('order-in-components', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'method',
-          'custom:customProp'
-        ]
-      }],
-      errors: [{
-        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
-        line: 3
-      }]
-    }
-  ]
+      options: [
+        {
+          order: ['method', 'custom:customProp'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'The "aMethod" method should be above the "customProp" custom property on line 2',
+          line: 3,
+        },
+      ],
+    },
+  ],
 });

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -304,18 +304,35 @@ eslintTester.run('order-in-components', rule, {
         }).volatile(),
         bar() { const foo = 'bar'}
       });`,
-      options: [
-        {
-          order: [
-            'property',
-            'empty-method',
-            'single-line-function',
-            'multi-line-function',
-            'method',
-          ],
-        },
-      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'property',
+          'empty-method',
+          'single-line-function',
+          'multi-line-function',
+          'method'
+        ]
+      }]
     },
+    {
+      code: `export default Component.extend({
+        prop: null,
+        actions: {
+          action: () => {}
+        },
+        customProp: { a: 1 }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'property',
+          'actions',
+          'custom:customProp',
+          'method'
+        ]
+      }]
+    }
   ],
   invalid: [
     {
@@ -718,43 +735,53 @@ eslintTester.run('order-in-components', rule, {
         bar() { const foo = 'bar'},
         onBar: () => {}
       });`,
-      errors: [
-        {
-          message:
-            'The "onFoo" empty method should be above the "foo" multi-line function on line 2',
-          line: 4,
-        },
-        {
-          message:
-            'The "onBar" empty method should be above the "foo" multi-line function on line 2',
-          line: 6,
-        },
-      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "onFoo" empty method should be above the "foo" multi-line function on line 2',
+        line: 4
+      }, {
+        message: 'The "onBar" empty method should be above the "foo" multi-line function on line 2',
+        line: 6
+      }]
     },
     {
       code: `export default Component.extend({
-        levelOfHappiness: computed("attitude", "health", () => {
-        }),
-
-        vehicle: alias("car"),
-
-        actions: {}
+        prop: null,
+        actions: {},
+        customProp: { a: 1 }
       });`,
-      output: `export default Component.extend({
-        vehicle: alias("car"),
-
-        levelOfHappiness: computed("attitude", "health", () => {
-        }),
-
-        actions: {}
-      });`,
-      errors: [
-        {
-          message:
-            'The "vehicle" single-line function should be above the "levelOfHappiness" multi-line function on line 2',
-          line: 5,
-        },
-      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'property',
+          'custom:customProp',
+          'actions',
+          'method'
+        ]
+      }],
+      errors: [{
+        message: 'The "customProp" custom property should be above the actions hash on line 3',
+        line: 4
+      }]
     },
-  ],
+    {
+      code: `export default Component.extend({
+        customProp: { a: 1 },
+        aMethod() {
+          console.log('not empty');
+        }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'method',
+          'custom:customProp'
+        ]
+      }],
+      errors: [{
+        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
+        line: 3
+      }]
+    }
+  ]
 });

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -117,7 +117,24 @@ eslintTester.run('order-in-controllers', rule, {
             this._super(...arguments);
           }
         });
-      `,
+    `,
+    {
+      code: `export default Controller.extend({
+        prop: null,
+        actions: {
+          action: () => {}
+        },
+        customProp: { a: 1 }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'property',
+          'actions',
+          'custom:customProp'
+        ]
+      }]
+    }
   ],
   invalid: [
     {
@@ -313,66 +330,30 @@ eslintTester.run('order-in-controllers', rule, {
           foo: service()
         });
       `,
-      errors: [
-        {
-          message:
-            'The "foo" service injection should be above the "init" lifecycle hook on line 3',
-          line: 6,
-        },
-      ],
-    },
-    {
-      code: `
-        export default Controller.extend({
-          init() {
-            this._super(...arguments);
-          },
-          someProp: null
-        });
-      `,
-      errors: [
-        {
-          message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
-          line: 6,
-        },
-      ],
-    },
-    {
-      code:
-        // whitespace is preserved inside `` and it's breaking the test
-        `export default Controller.extend({
-  queryParams: [],
-  currentUser: service(),
-});`,
-      output: `export default Controller.extend({
-  currentUser: service(),
-  queryParams: [],
-});`,
-      errors: [
-        {
-          message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
-        },
-      ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
+        line: 6
+      }]
     },
     {
       code: `export default Controller.extend({
-        test: "asd",
-        queryParams: [],
-        actions: {}
+        customProp: { a: 1 },
+        aMethod() {
+          console.log('not empty');
+        }
       });`,
-      output: `export default Controller.extend({
-        queryParams: [],
-        test: "asd",
-        actions: {}
-      });`,
-      errors: [
-        {
-          message: 'The "queryParams" property should be above the "test" property on line 2',
-          line: 3,
-        },
-      ],
-    },
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'method',
+          'custom:customProp'
+        ]
+      }],
+      errors: [{
+        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
+        line: 3
+      }]
+    }
   ],
 });

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -127,14 +127,12 @@ eslintTester.run('order-in-controllers', rule, {
         customProp: { a: 1 }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'property',
-          'actions',
-          'custom:customProp'
-        ]
-      }]
-    }
+      options: [
+        {
+          order: ['property', 'actions', 'custom:customProp'],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -331,10 +329,66 @@ eslintTester.run('order-in-controllers', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      errors: [{
-        message: 'The "foo" service injection should be above the inherited "init" property on line 3',
-        line: 6
-      }]
+      errors: [
+        {
+          message:
+            'The "foo" service injection should be above the "init" lifecycle hook on line 3',
+          line: 6,
+        },
+      ],
+    },
+    {
+      code: `
+        export default Controller.extend({
+          init() {
+            this._super(...arguments);
+          },
+          someProp: null
+        });
+      `,
+      errors: [
+        {
+          message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
+          line: 6,
+        },
+      ],
+    },
+    {
+      code:
+        // whitespace is preserved inside `` and it's breaking the test
+        `export default Controller.extend({
+  queryParams: [],
+  currentUser: service(),
+});`,
+      output: `export default Controller.extend({
+  currentUser: service(),
+  queryParams: [],
+});`,
+      errors: [
+        {
+          message:
+            'The "currentUser" service injection should be above the "queryParams" property on line 2',
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `export default Controller.extend({
+        test: "asd",
+        queryParams: [],
+        actions: {}
+      });`,
+      output: `export default Controller.extend({
+        queryParams: [],
+        test: "asd",
+        actions: {}
+      });`,
+      errors: [
+        {
+          message: 'The "queryParams" property should be above the "test" property on line 2',
+          line: 3,
+        },
+      ],
     },
     {
       code: `export default Controller.extend({
@@ -344,16 +398,18 @@ eslintTester.run('order-in-controllers', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'method',
-          'custom:customProp'
-        ]
-      }],
-      errors: [{
-        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
-        line: 3
-      }]
-    }
+      options: [
+        {
+          order: ['method', 'custom:customProp'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'The "aMethod" method should be above the "customProp" custom property on line 2',
+          line: 3,
+        },
+      ],
+    },
   ],
 });

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -84,14 +84,12 @@ eslintTester.run('order-in-models', rule, {
         customProp: { a: 1 }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'attribute',
-          'method',
-          'custom:customProp'
-        ]
-      }]
-    }
+      options: [
+        {
+          order: ['attribute', 'method', 'custom:customProp'],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -248,16 +246,18 @@ eslintTester.run('order-in-models', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'method',
-          'custom:customProp'
-        ]
-      }],
-      errors: [{
-        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
-        line: 3
-      }]
+      options: [
+        {
+          order: ['method', 'custom:customProp'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'The "aMethod" method should be above the "customProp" custom property on line 2',
+          line: 3,
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -76,6 +76,22 @@ eslintTester.run('order-in-models', rule, {
         },
       ],
     },
+    {
+      code: `export default DS.Model.extend({
+        a: attr('string'),
+        convertA(paramA) {
+        },
+        customProp: { a: 1 }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'attribute',
+          'method',
+          'custom:customProp'
+        ]
+      }]
+    }
   ],
   invalid: [
     {
@@ -223,6 +239,25 @@ eslintTester.run('order-in-models', rule, {
           line: 3,
         },
       ],
+    },
+    {
+      code: `export default DS.Model.extend({
+        customProp: { a: 1 },
+        aMethod() {
+          console.log('not empty');
+        }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'method',
+          'custom:customProp'
+        ]
+      }],
+      errors: [{
+        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
+        line: 3
+      }]
     },
   ],
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -139,7 +139,24 @@ eslintTester.run('order-in-routes', rule, {
           },
           customFoo() {}
         });
-      `,
+    `,
+    {
+      code: `export default Route.extend({
+        prop: null,
+        actions: {
+          action: () => {}
+        },
+        customProp: { a: 1 }
+      });`,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'property',
+          'actions',
+          'custom:customProp'
+        ]
+      }]
+    }
   ],
   invalid: [
     {
@@ -554,80 +571,23 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     {
-      code:
-        // whitespace is preserved inside `` and it's breaking the test
-        `export default Route.extend({
-  customProp: "test",
-  /**
-   * actions block comment
-   */
-  actions: {},
-  /**
-   * beforeModel block comment
-   */
-  beforeModel() {}
-});`,
-      output: `export default Route.extend({
-  customProp: "test",
-  /**
-   * beforeModel block comment
-   */
-  beforeModel() {},
-  /**
-   * actions block comment
-   */
-  actions: {},
-});`,
-      errors: [
-        {
-          message: 'The "beforeModel" lifecycle hook should be above the actions hash on line 6',
-          line: 10,
-        },
-      ],
-    },
-    {
-      code:
-        // whitespace is preserved inside `` and it's breaking the test
-        `export default Route.extend({
-  model() {},
-  test: "asd"
-});`,
-      output: `export default Route.extend({
-  test: "asd",
-  model() {},
-});`,
-      errors: [
-        {
-          message: 'The "test" property should be above the "model" hook on line 2',
-          line: 3,
-        },
-      ],
-    },
-    {
       code: `export default Route.extend({
-
-        model() {},
-
-        test: "asd",
-
-        actions: {}
-
+        customProp: { a: 1 },
+        aMethod() {
+          console.log('not empty');
+        }
       });`,
-      output: `export default Route.extend({
-
-        test: "asd",
-
-        model() {},
-
-        actions: {}
-
-      });`,
-      errors: [
-        {
-          message: 'The "test" property should be above the "model" hook on line 3',
-          line: 5,
-        },
-      ],
-    },
-  ],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      options: [{
+        order: [
+          'method',
+          'custom:customProp'
+        ]
+      }],
+      errors: [{
+        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
+        line: 3
+      }]
+    }
+  ]
 });

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -149,14 +149,12 @@ eslintTester.run('order-in-routes', rule, {
         customProp: { a: 1 }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'property',
-          'actions',
-          'custom:customProp'
-        ]
-      }]
-    }
+      options: [
+        {
+          order: ['property', 'actions', 'custom:customProp'],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -571,6 +569,82 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     {
+      code:
+        // whitespace is preserved inside `` and it's breaking the test
+        `export default Route.extend({
+  customProp: "test",
+  /**
+   * actions block comment
+   */
+  actions: {},
+  /**
+   * beforeModel block comment
+   */
+  beforeModel() {}
+});`,
+      output: `export default Route.extend({
+  customProp: "test",
+  /**
+   * beforeModel block comment
+   */
+  beforeModel() {},
+  /**
+   * actions block comment
+   */
+  actions: {},
+});`,
+      errors: [
+        {
+          message: 'The "beforeModel" lifecycle hook should be above the actions hash on line 6',
+          line: 10,
+        },
+      ],
+    },
+    {
+      code:
+        // whitespace is preserved inside `` and it's breaking the test
+        `export default Route.extend({
+  model() {},
+  test: "asd"
+});`,
+      output: `export default Route.extend({
+  test: "asd",
+  model() {},
+});`,
+      errors: [
+        {
+          message: 'The "test" property should be above the "model" hook on line 2',
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `export default Route.extend({
+
+        model() {},
+
+        test: "asd",
+
+        actions: {}
+
+      });`,
+      output: `export default Route.extend({
+
+        test: "asd",
+
+        model() {},
+
+        actions: {}
+
+      });`,
+      errors: [
+        {
+          message: 'The "test" property should be above the "model" hook on line 3',
+          line: 5,
+        },
+      ],
+    },
+    {
       code: `export default Route.extend({
         customProp: { a: 1 },
         aMethod() {
@@ -578,16 +652,18 @@ eslintTester.run('order-in-routes', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      options: [{
-        order: [
-          'method',
-          'custom:customProp'
-        ]
-      }],
-      errors: [{
-        message: 'The "aMethod" method should be above the "customProp" custom property on line 2',
-        line: 3
-      }]
-    }
-  ]
+      options: [
+        {
+          order: ['method', 'custom:customProp'],
+        },
+      ],
+      errors: [
+        {
+          message:
+            'The "aMethod" method should be above the "customProp" custom property on line 2',
+          line: 3,
+        },
+      ],
+    },
+  ],
 });

--- a/tests/lib/utils/property-order-test.js
+++ b/tests/lib/utils/property-order-test.js
@@ -185,7 +185,7 @@ describe('determinePropertyType', () => {
         });`
       );
       const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('property');
+      expect(propertyOrder.determinePropertyType(node, 'component', [])).toStrictEqual('property');
     });
 
     it('should determine empty methods', () => {
@@ -195,7 +195,9 @@ describe('determinePropertyType', () => {
         });`
       );
       const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('empty-method');
+      expect(propertyOrder.determinePropertyType(node, 'component', [])).toStrictEqual(
+        'empty-method'
+      );
     });
 
     it('should determine methods', () => {
@@ -205,7 +207,34 @@ describe('determinePropertyType', () => {
         });`
       );
       const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('method');
+      expect(propertyOrder.determinePropertyType(node, 'component', [])).toStrictEqual('method');
+    });
+
+    it('should determine custom properties when given order with custom property', () => {
+      const context = new FauxContext(
+        `export default Component.extend({
+          myFooProperty: null
+        });`
+      );
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(
+        propertyOrder.determinePropertyType(node, 'component', [
+          'custom:myBarProperty',
+          'custom:myFooProperty',
+        ])
+      ).toStrictEqual('custom:myFooProperty');
+    });
+
+    it('should determine custom properties as normal properties when given order without custom property', () => {
+      const context = new FauxContext(
+        `export default Component.extend({
+          myFooProperty: null
+        });`
+      );
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(
+        propertyOrder.determinePropertyType(node, 'component', ['custom:myBarProperty'])
+      ).toStrictEqual('property');
     });
   });
 
@@ -301,7 +330,7 @@ describe('determinePropertyType', () => {
         }`
       );
       const node = context.ast.body[0].body.body[0];
-      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual(
+      expect(propertyOrder.determinePropertyType(node, 'component', [])).toStrictEqual(
         'multi-line-function'
       );
     });
@@ -313,7 +342,7 @@ describe('determinePropertyType', () => {
         }`
       );
       const node = context.ast.body[0].body.body[0];
-      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('property');
+      expect(propertyOrder.determinePropertyType(node, 'component', [])).toStrictEqual('property');
     });
   });
 });


### PR DESCRIPTION
Taking over PR #191.

We have a use-case for this where we want properties named "layout" ordered before all else.