### PR TITLE
Add "Help Wanted" section to documentation for rules that are missing native JavaScript class support

### DIFF
--- a/docs/rules/alias-model-in-controller.md
+++ b/docs/rules/alias-model-in-controller.md
@@ -36,3 +36,9 @@ export default Controller.extend({
   pets: reads('model.pets')
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/avoid-using-needs-in-controllers.md
+++ b/docs/rules/avoid-using-needs-in-controllers.md
@@ -25,3 +25,9 @@ export default Component.extend({
   newComments: alias('comments.newest')
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -100,3 +100,9 @@ Ember.Object.extend({
     })
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -42,3 +42,9 @@ This rule takes an optional object containing:
 
 * [Arrow function spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
 * [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-capital-letters-in-routes.md
+++ b/docs/rules/no-capital-letters-in-routes.md
@@ -29,3 +29,9 @@ this.route('sign-up');
 * [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
 * [route-path-style](route-path-style.md)
 * [routes-segments-snake-case](routes-segments-snake-case.md)
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-deeply-nested-dependent-keys-with-each.md
+++ b/docs/rules/no-deeply-nested-dependent-keys-with-each.md
@@ -31,3 +31,9 @@ owners: computed('todos.@each.owner', function() {
 ## Further Reading
 
 * See the [documentation](https://guides.emberjs.com/release/object-model/computed-properties-and-aggregate-data/) for Ember computed properties with `@each`
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-duplicate-dependent-keys.md
+++ b/docs/rules/no-duplicate-dependent-keys.md
@@ -31,3 +31,9 @@ computed('foo.{bar,baz,qux}', 'bar.foo', function() {
   //...
 })
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-empty-attrs.md
+++ b/docs/rules/no-empty-attrs.md
@@ -31,3 +31,9 @@ export default Model.extend({
 ```
 
 In case you need a custom behavior, it's good to write your own [transform](http://emberjs.com/api/data/classes/DS.Transform.html).
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -38,3 +38,9 @@ export default Component.extend({
   })
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-unnecessary-service-injection-argument.md
+++ b/docs/rules/no-unnecessary-service-injection-argument.md
@@ -41,3 +41,9 @@ export default Component.extend({
 
 * Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
 * Ember [inject](https://emberjs.com/api/ember/release/functions/@ember%2Fservice/inject) function spec
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/no-volatile-computed-properties.md
+++ b/docs/rules/no-volatile-computed-properties.md
@@ -35,3 +35,9 @@ const Person = EmberObject.extend({
 * [Deprecation list](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile)
 * [Volatile spec](https://api.emberjs.com/ember/release/classes/ComputedProperty/methods/volatile?anchor=volatile)
 * [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -129,3 +129,9 @@ export default Component.extend({
   }
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -98,3 +98,9 @@ export default Controller.extend({
   },
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -71,3 +71,9 @@ export default Model.extend({
   shape: attr('string')
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -124,3 +124,9 @@ export default Route.extend({
   },
 });
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -89,3 +89,9 @@ export default Component.extend({
 
 * [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
 * [Spec](http://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -49,3 +49,9 @@ This rule takes an optional object containing:
 ## References
 
 * [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -73,3 +73,9 @@ To avoid false positives from relying on implicit returns in some code branches,
 * [consistent-return] from eslint
 
 [consistent-return]: https://eslint.org/docs/rules/consistent-return
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/docs/rules/use-brace-expansion.md
+++ b/docs/rules/use-brace-expansion.md
@@ -21,3 +21,9 @@ fullName: computed('user.{firstName,lastName}', {
   // Code
 })
 ```
+
+## Help Wanted
+
+| Issue | Link |
+| :-- | :-- |
+| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |


### PR DESCRIPTION
For rules that are missing native ES6 class / decorator support, add a "Help Wanted" section to their docs, along with a link to the #560 issue.