### PR TITLE
Update `order-in-*` rules to consider template literals as properties

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -278,6 +278,7 @@ function isCustomProp(property) {
 
   return (
     types.isLiteral(value) ||
+    types.isTemplateLiteral(value) ||
     types.isIdentifier(value) ||
     types.isArrayExpression(value) ||
     types.isUnaryExpression(value) ||

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -29,6 +29,16 @@ eslintTester.run('order-in-components', rule, {
         actions: {}
       });`,
     `export default Component.extend({
+        role: ${`${'sloth'}`},
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
+    `export default Component.extend({
         role: "sloth",
 
         levelOfHappiness: computed("attitude", "health", () => {
@@ -323,6 +333,33 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
 
         role: "sloth",
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
+      errors: [
+        {
+          message: 'The "role" property should be above the actions hash on line 2',
+          line: 4,
+        },
+        {
+          message: 'The "vehicle" single-line function should be above the actions hash on line 2',
+          line: 6,
+        },
+        {
+          message:
+            'The "levelOfHappiness" multi-line function should be above the actions hash on line 2',
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: `export default Component.extend({
+        actions: {},
+
+        role: ${`${'sloth'}`},
 
         vehicle: alias("car"),
 

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -834,6 +834,9 @@ describe('isCustomProp', () => {
     node = getProperty("test = { test: 'someLiteral' }");
     expect(emberUtils.isCustomProp(node)).toBeTruthy();
 
+    node = getProperty("test = { test: `foo${'bar'}` }");
+    expect(emberUtils.isCustomProp(node)).toBeTruthy();
+
     node = getProperty('test = { test: someIdentifier }');
     expect(emberUtils.isCustomProp(node)).toBeTruthy();
 

--- a/tests/lib/utils/property-order-test.js
+++ b/tests/lib/utils/property-order-test.js
@@ -188,6 +188,16 @@ describe('determinePropertyType', () => {
       expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('property');
     });
 
+    it('should determine template literals as properties', () => {
+      const context = new FauxContext(
+        `export default Component.extend({
+          foo: ${`foo${"bar"}`}
+        });`
+      );
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(propertyOrder.determinePropertyType(node, 'component')).toStrictEqual('property');
+    });
+
     it('should determine empty methods', () => {
       const context = new FauxContext(
         `export default Component.extend({


### PR DESCRIPTION
Fixes #304 