### PR TITLE
Update `require-computed-property-dependencies` rule to handle basic string concatenation in dependent keys

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -16,6 +16,7 @@ const Traverser = getTraverser();
 const emberUtils = require('../utils/ember');
 const types = require('../utils/types');
 const propertyGetterUtils = require('../utils/property-getter');
+const assert = require('assert');
 
 /**
  * Checks whether the node is an identifier and optionally, its name.
@@ -70,6 +71,37 @@ function isEmberComputed(node) {
 }
 
 /**
+ * Checks if a node looks like: 'part1' + 'part2'
+ *
+ * @param {ASTNode} node
+ * @returns {boolean}
+ */
+function isTwoPartStringLiteral(node) {
+  return (
+    types.isBinaryExpression(node) &&
+    types.isStringLiteral(node.left) &&
+    types.isStringLiteral(node.right)
+  );
+}
+
+/**
+ * Returns the string represented by the node.
+ *
+ * @param {ASTNode} node
+ * @returns {string}
+ */
+function nodeToStringValue(node) {
+  if (types.isStringLiteral(node)) {
+    return node.value;
+  } else if (isTwoPartStringLiteral(node)) {
+    return node.left.value + node.right.value;
+  } else {
+    assert(false);
+    return undefined;
+  }
+}
+
+/**
  * Builds an array by concatenating the results of a map.
  *
  * @template T, U
@@ -94,7 +126,7 @@ function parseComputedDependencies(args) {
   for (let i = 0; i < args.length - 1; i++) {
     const arg = args[i];
 
-    if (types.isStringLiteral(arg)) {
+    if (types.isStringLiteral(arg) || isTwoPartStringLiteral(arg)) {
       keys.push(arg);
     } else {
       dynamicKeys.push(arg);
@@ -388,9 +420,7 @@ module.exports = {
           });
           const usedKeys = [...usedKeys1, ...usedKeys2];
 
-          const expandedDeclaredKeys = expandKeys(
-            declaredDependencies.keys.map(node => node.value)
-          );
+          const expandedDeclaredKeys = expandKeys(declaredDependencies.keys.map(nodeToStringValue));
 
           const undeclaredKeysBeforeServiceCheck = removeRedundantKeys(
             usedKeys

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -34,6 +34,12 @@ ruleTester.run('require-computed-property-dependencies', rule, {
         return this.get('name');
       });
     `,
+    // String concatenation in dependent key:
+    `
+      Ember.computed('na' + 'me', function() {
+        return this.get('name');
+      });
+    `,
     // Without `Ember.`:
     `
       computed('name', function() {
@@ -725,6 +731,25 @@ ruleTester.run('require-computed-property-dependencies', rule, {
         {
           message:
             'Use of undeclared dependencies in computed property: some.very.long.multi.line.property.name',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      // String concatenation in dependent key:
+      code: `
+        Ember.computed('na' + 'me', function() {
+          return this.undeclared + this.name;
+        });
+      `,
+      output: `
+        Ember.computed('name', 'undeclared', function() {
+          return this.undeclared + this.name;
+        });
+      `,
+      errors: [
+        {
+          message: 'Use of undeclared dependencies in computed property: undeclared',
           type: 'CallExpression',
         },
       ],


### PR DESCRIPTION
Fixes #673. CC: @BlueRaja.