### PR TITLE
Remove outdated contributors lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,25 +179,6 @@ In order to add a new rule, you should:
 
 If you have any suggestions, ideas, or problems feel free to [create an issue](https://github.com/ember-cli/eslint-plugin-ember/issues/new), but first please make sure your question does not repeat previous ones.
 
-## ⭐️ Contributors
-
-- [Adrian Zalewski](https://github.com/bardzusny)
-- [Alex LaFroscia](https://github.com/alexlafroscia)
-- [Bryan Mishkin](https://github.com/bmish)
-- [Casey Watts](https://github.com/caseywatts)
-- [Jacek Bandura](https://github.com/jbandura)
-- [Kamil Ejsymont](https://github.com/netes)
-- [Michał Sajnóg](https://github.com/michalsnik)
-- [Rafał Leszczyński](https://github.com/rafleszczynski)
-- [Robert Wagner](https://github.com/rwwagner90)
-- [Steve Gargan](https://github.com/sgargan)
-- [Tobias Bieniek](https://github.com/Turbo87)
-
-## 🙌 Credits
-
-- [DockYard team](http://github.com/DockYard) - for great inspiration with their [styleguide](https://github.com/DockYard/styleguides/blob/master/engineering/ember.md)
-- [Rob Hilgefort](https://github.com/rjhilgefort) - for making it possible to redeploy new plugin under existing `eslint-plugin-ember` package name
-
 ## 🔓 License
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).

--- a/package.json
+++ b/package.json
@@ -34,16 +34,6 @@
     "styleguide",
     "rules"
   ],
-  "author": "Michał Sajnóg <michal.sajnog@hotmail.com> (http://github.com/michalsnik)",
-  "contributors": [
-    "Rafał Leszczyński <raf.leszcz@gmail.com> (http://github.com/rafleszczynski)",
-    "Adrian Zalewski (http://github.com/bardzusny)",
-    "Kamil Ejsymont (http://github.com/netes)",
-    "Casey Watts (http://github.com/caseywatts)",
-    "Steve Gargan (http://github.com/sgargan)",
-    "Alex LaFroscia (http://github.com/alexlafroscia)",
-    "Tobias Bieniek (http://github.com/Turbo87)"
-  ],
   "engines": {
     "node": ">=8.0"
   },


### PR DESCRIPTION
These lists are a burden to maintain and are out-of-date. I'm also trying to make the README more concise by removing unnecessary or old information.
    
Anyone interested to see contributors can visit: https://github.com/ember-cli/eslint-plugin-ember/graphs/contributors