### PR TITLE
Mention if a rule is fixable in its documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ module.exports = {
 
 ## 🍟 Rules
 
-Rules are grouped by category to help you understand their purpose.
+Rules are grouped by category to help you understand their purpose. Each rule has emojis denoting:
 
-Each rule has emojis denoting what configuration it belongs to and/or a :wrench: if the rule is fixable via the `--fix` command line option.
+- What configuration it belongs to
+- :wrench: if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
 
 <!--RULES_TABLE_START-->
 

--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -1,5 +1,7 @@
 # TODO: rule-name-goes-here
 
+(TODO: only include this line if the rule is fixable) :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 TODO: context about the problem goes here
 
 ## Rule Details

--- a/docs/rules/no-ember-super-in-es-classes.md
+++ b/docs/rules/no-ember-super-in-es-classes.md
@@ -1,5 +1,7 @@
 # no-ember-super-in-es-classes
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 `this._super` is not allowed in ES class methods.
 
 While `this._super()` is the only way to invoke an overridden method in an `EmberObject.extend`-style class, the `_super` method doesn't work properly when using native class syntax. Fortunately, native classes come with their own mechanism for invoking methods from a parent.

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -1,5 +1,7 @@
 # no-get
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Starting in Ember 3.1, native ES5 getters are available, which eliminates much of the need to use `get` / `getProperties` on Ember objects.
 
 ## Rule Details

--- a/docs/rules/no-old-shims.md
+++ b/docs/rules/no-old-shims.md
@@ -1,5 +1,7 @@
 # no-old-shims
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Don't use import paths from `ember-cli-shims`.
 
 The import paths in `ember-cli-shims` were never considered public API and

--- a/docs/rules/no-unnecessary-route-path-option.md
+++ b/docs/rules/no-unnecessary-route-path-option.md
@@ -1,5 +1,7 @@
 # no-unnecessary-route-path-option
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Disallow unnecessary route `path` option.
 
 When defining a route, it's not necessary to specify the `path` option if it matches the route name.

--- a/docs/rules/no-unnecessary-service-injection-argument.md
+++ b/docs/rules/no-unnecessary-service-injection-argument.md
@@ -1,5 +1,7 @@
 # no-unnecessary-service-injection-argument
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Disallow unnecessary argument when injecting service.
 
 It's not necessary to specify an injected service's name as an argument when the property name matches the service name.

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -1,5 +1,7 @@
 # order-in-components
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## Configuration
 
 ```js

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -1,5 +1,7 @@
 # order-in-controllers
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## Configuration
 
 ```js

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -1,5 +1,7 @@
 # order-in-models
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## Configuration
 
 ```js

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -1,5 +1,7 @@
 # order-in-routes
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## Configuration
 
 ```js

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -1,5 +1,7 @@
 # require-computed-macros
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 It is preferred to use Ember's computed property macros as opposed to manually writing out logic in a computed property function. Reasons include:
 
 * Conciseness

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -1,5 +1,7 @@
 # require-computed-property-dependencies
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Computed properties should have their property dependencies listed out so that they can recompute upon changes.
 
 ## Rule Details

--- a/docs/rules/use-ember-data-rfc-395-imports.md
+++ b/docs/rules/use-ember-data-rfc-395-imports.md
@@ -1,5 +1,7 @@
 # use-ember-data-rfc-395-imports
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Use &#34;Ember Data Packages&#34; from Ember RFC #395.
 
 The goal of this rule is to ease the migration to the new @ember-data packages.

--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -1,5 +1,7 @@
 # use-ember-get-and-set
 
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 Use `Ember.get` and `Ember.set`.
 
 This way you don't have to worry whether the object that you're trying to access is an `Ember.Object` or not. It also solves the problem of trying to wrap every object in `Ember.Object` in order to be able to use things like `getWithDefault`.

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -55,13 +55,23 @@ describe('rules setup is correct', function() {
     );
   });
 
-  it('should have the right title and an "Examples" section for each rule documentation file', function() {
+  it('should have the right contents (title, examples, fixable notice) for each rule documentation file', function() {
+    const FIXABLE_MSG =
+      ':wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.';
+
     RULE_NAMES.forEach(ruleName => {
+      const rule = rules[ruleName];
       const path = join(__dirname, '..', 'docs', 'rules', `${ruleName}.md`);
       const file = readFileSync(path, 'utf8');
 
       expect(file).toContain(`# ${ruleName}`); // Title header.
       expect(file).toContain('## Examples'); // Examples section header.
+
+      if (rule.meta.fixable === 'code') {
+        expect(file).toContain(FIXABLE_MSG);
+      } else {
+        expect(file).not.toContain(FIXABLE_MSG);
+      }
     });
   });
 


### PR DESCRIPTION
Before this change, we only indicated which rules are fixable in the top-level README, but not in individual rule docs.

This change adds a message to individual rule docs that matches the convention of [eslint](https://eslint.org/docs/rules/eol-last) core:
> :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.

Also adds a test to ensure that the correct rule docs include this notice.

Fixes #684.