### PR TITLE
Add new rule `no-replace-test-comments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |:---|:--------|:------------|
 |  | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs. |
 |  | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
+|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | No 'Replace this with your real tests' comments |
 |  | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
 |  | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |:---|:--------|:------------|
 |  | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs. |
 |  | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
-|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | No 'Replace this with your real tests' comments |
+|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments |
 |  | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
 |  | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |:---|:--------|:------------|
 |  | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs. |
 |  | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
-|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments |
+|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments in test files |
 |  | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
 |  | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |

--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -34,24 +34,24 @@ Examples of **correct** code for this rule:
 
 TODO: suggest any fast/automated techniques for fixing violations in a large codebase
 
-* TODO: suggestion on how to fix violations using find-and-replace / regexp
-* TODO: suggestion on how to fix violations using a codemod
+- TODO: suggestion on how to fix violations using find-and-replace / regexp
+- TODO: suggestion on how to fix violations using a codemod
 
 ## Configuration
 
 TODO: exclude this section if the rule has no extra configuration
 
-* object -- containing the following properties:
-  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+- object -- containing the following properties:
+  - string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
+  - boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
 
 ## Related Rules
 
-* [TODO-related-rule-name1](related-rule-name1.md)
-* [TODO-related-rule-name2](related-rule-name2.md)
+- [TODO-related-rule-name1](related-rule-name1.md)
+- [TODO-related-rule-name2](related-rule-name2.md)
 
 ## References
 
-* TODO: link to relevant documentation goes here)
-* TODO: link to relevant function spec goes here
-* TODO: link to relevant guide goes here
+- TODO: link to relevant documentation goes here)
+- TODO: link to relevant function spec goes here
+- TODO: link to relevant guide goes here

--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -34,24 +34,24 @@ Examples of **correct** code for this rule:
 
 TODO: suggest any fast/automated techniques for fixing violations in a large codebase
 
-- TODO: suggestion on how to fix violations using find-and-replace / regexp
-- TODO: suggestion on how to fix violations using a codemod
+* TODO: suggestion on how to fix violations using find-and-replace / regexp
+* TODO: suggestion on how to fix violations using a codemod
 
 ## Configuration
 
 TODO: exclude this section if the rule has no extra configuration
 
-- object -- containing the following properties:
-  - string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  - boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+* object -- containing the following properties:
+  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
+  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
 
 ## Related Rules
 
-- [TODO-related-rule-name1](related-rule-name1.md)
-- [TODO-related-rule-name2](related-rule-name2.md)
+* [TODO-related-rule-name1](related-rule-name1.md)
+* [TODO-related-rule-name2](related-rule-name2.md)
 
 ## References
 
-- TODO: link to relevant documentation goes here)
-- TODO: link to relevant function spec goes here
-- TODO: link to relevant guide goes here
+* TODO: link to relevant documentation goes here)
+* TODO: link to relevant function spec goes here
+* TODO: link to relevant guide goes here

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -10,6 +10,8 @@ This rule aims to nudge developers into writing more/better tests.
 
 It aims to do this by complaining at them early about a default test file.
 
+This rule only fires for test files (ending in '-test.js' or '-test.ts')
+
 This will especially push TDD (test-driven development) on repos with githooks that enforce lint early.
 
 ## Examples

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -1,0 +1,40 @@
+# no-replace-test-comments
+
+Ember devlopers using blueprints to generate classes should write real tests.
+
+Leaving the default test comment in place is a sign of a rushed class.
+
+## Rule Details
+
+This rule aims to nudge developers into writing more/better tests.
+
+It aims to do this by complaining at them early about a default test file.
+
+This will especially push TDD on repos with githooks that enforce lint early.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+// Replace this with your real tests.
+test('it exists', function (assert) {
+  let service = this.owner.lookup('service:company');
+  assert.ok(service);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+test('it has a purpose beyond mere existence', function (assert) {
+  let service = this.owner.lookup('service:company');
+  set(service, 'company', myCompanyMock);
+  assert.equal(service.isOnboardingComplete, true, 'the computed property works as expected');
+});
+```
+
+## Migration
+
+- The [testing guides](https://guides.emberjs.com/release/testing/testing-components/) shall be your guide
+- Consider a code coverage tool like [ember-cli-code-coverage](https://github.com/kategengler/ember-cli-code-coverage) as well

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -41,4 +41,4 @@ test('it has a purpose beyond mere existence', function(assert) {
 
 ## References
 
-- TODO: link to relevant documentation goes here)
+- [Learn Test Driven Development in Ember](https://learntdd.in/ember/)

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -18,8 +18,8 @@ Examples of **incorrect** code for this rule:
 
 ```js
 // Replace this with your real tests.
-test('it exists', function (assert) {
-  let service = this.owner.lookup('service:company');
+test('it exists', function(assert) {
+  const service = this.owner.lookup('service:company');
   assert.ok(service);
 });
 ```
@@ -27,8 +27,8 @@ test('it exists', function (assert) {
 Examples of **correct** code for this rule:
 
 ```js
-test('it has a purpose beyond mere existence', function (assert) {
-  let service = this.owner.lookup('service:company');
+test('it has a purpose beyond mere existence', function(assert) {
+  const service = this.owner.lookup('service:company');
   set(service, 'company', myCompanyMock);
   assert.equal(service.isOnboardingComplete, true, 'the computed property works as expected');
 });

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -1,6 +1,6 @@
 # no-replace-test-comments
 
-Ember devlopers using blueprints to generate classes should write real tests.
+Ember developers using blueprints to generate classes should write real tests.
 
 Leaving the default test comment in place is a sign of a rushed class.
 

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -10,7 +10,7 @@ This rule aims to nudge developers into writing more/better tests.
 
 It aims to do this by complaining at them early about a default test file.
 
-This will especially push TDD on repos with githooks that enforce lint early.
+This will especially push TDD (test-driven development) on repos with githooks that enforce lint early.
 
 ## Examples
 
@@ -38,3 +38,7 @@ test('it has a purpose beyond mere existence', function(assert) {
 
 - The [testing guides](https://guides.emberjs.com/release/testing/testing-components/) shall be your guide
 - Consider a code coverage tool like [ember-cli-code-coverage](https://github.com/kategengler/ember-cli-code-coverage) as well
+
+## References
+
+- TODO: link to relevant documentation goes here)

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ module.exports = {
     'no-pause-test': require('./rules/no-pause-test'),
     'no-private-routing-service': require('./rules/no-private-routing-service'),
     'no-proxies': require('./rules/no-proxies'),
+    'no-replace-test-comments': require('./rules/no-replace-test-comments'),
     'no-restricted-resolver-tests': require('./rules/no-restricted-resolver-tests'),
     'no-side-effects': require('./rules/no-side-effects'),
     'no-test-and-then': require('./rules/no-test-and-then'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -46,6 +46,7 @@ module.exports = {
   "ember/no-pause-test": "off",
   "ember/no-private-routing-service": "off",
   "ember/no-proxies": "off",
+  "ember/no-replace-test-comments": "off",
   "ember/no-restricted-resolver-tests": "error",
   "ember/no-side-effects": "error",
   "ember/no-test-and-then": "off",

--- a/lib/rules/no-replace-test-comments.js
+++ b/lib/rules/no-replace-test-comments.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const ERROR_MESSAGE = 'No \'Replace this with your real tests\' comments. Add a substantive test.';
+const ERROR_MESSAGE = "No 'Replace this with your real tests' comments. Add a substantive test.";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "No 'Replace this with your real tests' comments",
+      description: "disallow 'Replace this with your real tests' comments",
       category: 'Testing',
       recommended: false,
       url:
@@ -32,11 +32,13 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
 
-    const checkForRealTestsComment = (node) => {
+    const checkForRealTestsComment = node => {
       const { value = '' } = node || {};
-      const regex = /Replace this with your real tests/i;
+      const regex = /replace this with your real tests/i;
       const message = ERROR_MESSAGE;
-      if (regex.test(value)) context.report({ node, message });
+      if (regex.test(value)) {
+        context.report({ node, message });
+      }
     };
 
     //----------------------------------------------------------------------

--- a/lib/rules/no-replace-test-comments.js
+++ b/lib/rules/no-replace-test-comments.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview No 'Replace this with your real tests' comments
+ * @author Jay Gruber
+ */
+
+'use strict';
+
+const ERROR_MESSAGE = 'No \'Replace this with your real tests\' comments. Add a substantive test.';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: "No 'Replace this with your real tests' comments",
+      category: 'Testing',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-replace-test-comments.md',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  ERROR_MESSAGE,
+
+  create(context) {
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    const checkForRealTestsComment = (node) => {
+      const { value = '' } = node || {};
+      const regex = /Replace this with your real tests/i;
+      const message = ERROR_MESSAGE;
+      if (regex.test(value)) context.report({ node, message });
+    };
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      Program(/* node */) {
+        const sourceCode = context.getSourceCode() || {};
+        const comments = sourceCode.getAllComments() || [];
+        comments.forEach(checkForRealTestsComment);
+      },
+    };
+  },
+};

--- a/lib/rules/no-replace-test-comments.js
+++ b/lib/rules/no-replace-test-comments.js
@@ -1,8 +1,3 @@
-/**
- * @fileoverview No 'Replace this with your real tests' comments
- * @author Jay Gruber
- */
-
 'use strict';
 
 const ERROR_MESSAGE = "No 'Replace this with your real tests' comments. Add a substantive test.";

--- a/lib/rules/no-replace-test-comments.js
+++ b/lib/rules/no-replace-test-comments.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const emberUtils = require('../utils/ember');
+
 const ERROR_MESSAGE = "No 'Replace this with your real tests' comments. Add a substantive test.";
 
 //------------------------------------------------------------------------------
@@ -10,7 +12,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "disallow 'Replace this with your real tests' comments",
+      description: "disallow 'Replace this with your real tests' comments in test files",
       category: 'Testing',
       recommended: false,
       url:
@@ -40,6 +42,9 @@ module.exports = {
     // Public
     //----------------------------------------------------------------------
 
+    if (!emberUtils.isTestFile(context.getFilename())) {
+      return {};
+    }
     return {
       Program(/* node */) {
         const sourceCode = context.getSourceCode() || {};

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -1,8 +1,3 @@
-/**
- * @fileoverview No &#39;Replace this with your real tests&#39; comments
- * @author Jay Gruber
- */
-
 'use strict';
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -21,7 +21,6 @@ ruleTester.run('no-replace-test-comments', rule, {
     {
       filename: 'app/some-app-file.js',
       code: '// Replace this with your real tests',
-      output: null,
     },
   ],
 

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview No &#39;Replace this with your real tests&#39; comments
+ * @author Jay Gruber
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/no-replace-test-comments');
+const { ERROR_MESSAGE } = rule;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-replace-test-comments', rule, {
+  valid: [
+    '// some harmless comment',
+    'const myCodeWithoutAComment = "fooBar"',
+  ],
+
+  invalid: [
+    {
+      code: '// Replace this with your real tests',
+      output: null,
+      errors: [{
+        message: ERROR_MESSAGE,
+        type: 'Line',
+      }],
+    },
+  ],
+});

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -11,8 +11,8 @@
 
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-replace-test-comments');
-const { ERROR_MESSAGE } = rule;
 
+const { ERROR_MESSAGE } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -20,19 +20,18 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester();
 ruleTester.run('no-replace-test-comments', rule, {
-  valid: [
-    '// some harmless comment',
-    'const myCodeWithoutAComment = "fooBar"',
-  ],
+  valid: ['// some harmless comment', 'const myCodeWithoutAComment = "fooBar"'],
 
   invalid: [
     {
       code: '// Replace this with your real tests',
       output: null,
-      errors: [{
-        message: ERROR_MESSAGE,
-        type: 'Line',
-      }],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'Line',
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -15,10 +15,19 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester();
 ruleTester.run('no-replace-test-comments', rule, {
-  valid: ['// some harmless comment', 'myCodeWithoutAComment = "fooBar"'],
+  valid: [
+    '// some harmless comment',
+    'myCodeWithoutAComment = "fooBar"',
+    {
+      filename: 'app/some-app-file.js',
+      code: '// Replace this with your real tests',
+      output: null,
+    },
+  ],
 
   invalid: [
     {
+      filename: 'test/some-app-file-test.js',
       code: '// Replace this with your real tests',
       output: null,
       errors: [

--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -20,7 +20,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester();
 ruleTester.run('no-replace-test-comments', rule, {
-  valid: ['// some harmless comment', 'const myCodeWithoutAComment = "fooBar"'],
+  valid: ['// some harmless comment', 'myCodeWithoutAComment = "fooBar"'],
 
   invalid: [
     {


### PR DESCRIPTION
### What
- disallow 'Replace this with your real tests' comments

### Why
- we should encourage folks to use ember-cli + generators
- for those in a rush / without strong reviews, you end up with plenty of checked in test files that only have canary tests:
```javascript
  // Replace this with your real tests.
  test('it exists', function (assert) {
    let service = this.owner.lookup('service:company');
    assert.ok(service);
  });
```
- this rule will nudge developers to start writing a meaningful test earlier in the process

Fixes #717 