### PR TITLE
Recategorize rules into new groups in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,35 +59,54 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 
 <!--RULES_TABLE_START-->
 
-### Best Practices
+### Components
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+| :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components |
+| :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks |
+| :car: | [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components |
+| :car: | [no-component-lifecycle-hooks](./docs/rules/no-component-lifecycle-hooks.md) | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. |
+| :white_check_mark: | [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components |
+| :car: | [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component |
+
+### Computed Properties
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |
+| :white_check_mark: | [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties |
+| :car: | [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes |
+| :white_check_mark: | [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` |
+| :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys |
+| :wrench: | [no-incorrect-computed-macros](./docs/rules/no-incorrect-computed-macros.md) | disallow incorrect usage of computed property macros |
+|  | [no-invalid-dependent-keys](./docs/rules/no-invalid-dependent-keys.md) | disallow invalid dependent keys in computed properties |
+| :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties |
+| :white_check_mark: | [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties |
+| :wrench: | [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible |
+| :wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties |
+| :white_check_mark: | [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties |
+| :white_check_mark: | [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys |
+
+### Controllers
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 |  | [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | enforce aliasing model in controllers |
 | :white_check_mark: | [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers |
-| :white_check_mark: | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions |
-|  | [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |
-| :white_check_mark: | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 |
 |  | [no-controllers](./docs/rules/no-controllers.md) | disallow non-essential controllers |
+
+### Deprecations
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+| :white_check_mark: | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions |
+| :white_check_mark: | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 |
 | :white_check_mark: | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions |
-| :car: | [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function |
-| :car::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
-| :white_check_mark: | [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object |
-| :car: | [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery |
 |  | [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins |
 | :white_check_mark: | [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins |
 | :white_check_mark: | [no-observers](./docs/rules/no-observers.md) | disallow usage of observers |
 | :white_check_mark::wrench: | [no-old-shims](./docs/rules/no-old-shims.md) | disallow usage of old shims for modules |
-| :white_check_mark: | [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components |
-|  | [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service |
-| :white_check_mark: | [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests |
-|  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |
-| :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option |
-| :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |
-| :white_check_mark: | [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties |
-| :wrench: | [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible |
-|  | [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |
-| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
 
 ### Ember Data
 
@@ -101,62 +120,68 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | disallow state leakage |
-| :car: | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes |
-| :car: | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` |
-|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |
+| :car: | [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function |
+| :car::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
 |  | [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |
+| :white_check_mark: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require `this._super` to be called in `init` hooks |
+| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
 
 ### Ember Octane
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
+| :car: | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes |
+| :car: | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` |
 | :car: | [no-actions-hash](./docs/rules/no-actions-hash.md) | disallow the actions hash in components, controllers, and routes |
 | :car: | [no-classic-classes](./docs/rules/no-classic-classes.md) | disallow "classic" classes in favor of native JS classes |
-| :car: | [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components |
-| :car: | [no-component-lifecycle-hooks](./docs/rules/no-component-lifecycle-hooks.md) | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. |
-| :car: | [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes |
-| :car: | [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component |
+| :white_check_mark::wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods |
 
-### Possible Errors
+### jQuery
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [jquery-ember-run](./docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop |
-| :white_check_mark: | [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties |
-| :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components |
-| :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks |
-| :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js |
-| :white_check_mark: | [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` |
-| :white_check_mark: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys |
-| :white_check_mark::wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods |
-| :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope |
+| :white_check_mark: | [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object |
+| :car: | [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery |
+
+### Miscellaneous
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+|  | [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |
 | :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
-| :wrench: | [no-incorrect-computed-macros](./docs/rules/no-incorrect-computed-macros.md) | disallow incorrect usage of computed property macros |
 | :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
-|  | [no-invalid-dependent-keys](./docs/rules/no-invalid-dependent-keys.md) | disallow invalid dependent keys in computed properties |
-| :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties |
-| :wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties |
-| :white_check_mark: | [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties |
-| :white_check_mark: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require `this._super` to be called in `init` hooks |
+
+### Routes
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+| :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js |
+|  | [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service |
+|  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |
+| :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option |
+|  | [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |
 | :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | enforce usage of snake_cased dynamic segments in routes |
 
 ### Stylistic Issues
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
+| :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |
 | :wrench: | [order-in-components](./docs/rules/order-in-components.md) | enforce proper order of properties in components |
 | :wrench: | [order-in-controllers](./docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |
 | :wrench: | [order-in-models](./docs/rules/order-in-models.md) | enforce proper order of properties in models |
 | :wrench: | [order-in-routes](./docs/rules/order-in-routes.md) | enforce proper order of properties in routes |
-| :white_check_mark: | [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys |
 
 ### Testing
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
+| :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope |
 |  | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs |
 |  | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
 |  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments in test files |
+| :white_check_mark: | [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests |
 |  | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
 |  | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
 |  | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |

--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce aliasing model in controllers',
-      category: 'Best Practices',
+      category: 'Controllers',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/alias-model-in-controller.md',

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -11,7 +11,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow using `needs` in controllers',
-      category: 'Best Practices',
+      category: 'Controllers',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/avoid-using-needs-in-controllers.md',

--- a/lib/rules/classic-decorator-hooks.js
+++ b/lib/rules/classic-decorator-hooks.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'enforce using correct hooks for both classic and non-classic classes',
-      category: 'Ember Object',
+      category: 'Ember Octane',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/classic-decorator-no-classic-methods.js
+++ b/lib/rules/classic-decorator-no-classic-methods.js
@@ -26,7 +26,7 @@ module.exports = {
     docs: {
       description:
         "disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic`",
-      category: 'Ember Object',
+      category: 'Ember Octane',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/closure-actions.js
+++ b/lib/rules/closure-actions.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce usage of closure actions',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/closure-actions.md',

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -17,7 +17,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce the consistent use of getters in computed properties',
-      category: 'Ember Object',
+      category: 'Computed Properties',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/computed-property-getters.md',

--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow usage of jQuery without an Ember run loop',
-      category: 'Possible Errors',
+      category: 'jQuery',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/jquery-ember-run.md',

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -11,7 +11,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce usage of named functions in promises',
-      category: 'Best Practices',
+      category: 'Miscellaneous',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/named-functions-in-promises.md',

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -27,7 +27,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'enforce using "New Module Imports" from Ember RFC #176',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/new-module-imports.md',

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow arrow functions in computed properties',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-arrow-function-computed-properties.md',

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow usage of `this.attrs` in components',
-      category: 'Possible Errors',
+      category: 'Components',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-in-components.md',

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -16,7 +16,7 @@ module.exports = {
     docs: {
       description:
         'disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks',
-      category: 'Possible Errors',
+      category: 'Components',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-attrs-snapshot.md',

--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow routes with uppercased letters in router.js',
-      category: 'Possible Errors',
+      category: 'Routes',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-capital-letters-in-routes.md',

--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -11,7 +11,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce using Glimmer components',
-      category: 'Ember Octane',
+      category: 'Components',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/no-component-lifecycle-hooks.js
+++ b/lib/rules/no-component-lifecycle-hooks.js
@@ -18,7 +18,7 @@ module.exports = {
     docs: {
       description:
         'disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead.',
-      category: 'Ember Octane',
+      category: 'Components',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -30,7 +30,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow using computed properties in native classes',
-      category: 'Ember Octane',
+      category: 'Computed Properties',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/no-controllers.js
+++ b/lib/rules/no-controllers.js
@@ -10,7 +10,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow non-essential controllers',
-      category: 'Best Practices',
+      category: 'Controllers',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-controllers.md',

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow usage of deeply-nested computed property dependent keys with `@each`',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-deeply-nested-dependent-keys-with-each.md',

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow repeating computed property dependent keys',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-duplicate-dependent-keys.md',

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -5,7 +5,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow use of `this._super` in ES class methods',
-      category: 'Possible Errors',
+      category: 'Ember Octane',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-ember-super-in-es-classes.md',

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow use of `Ember.testing` in module scope',
-      category: 'Possible Errors',
+      category: 'Testing',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-ember-testing-in-module-scope.md',

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -11,7 +11,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: "disallow usage of Ember's `function` prototype extensions",
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-function-prototype-extensions.md',

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -10,7 +10,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: "disallow usage of the Ember's `getWithDefault` function",
-      category: 'Best Practices',
+      category: 'Ember Object',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -24,7 +24,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: "require using ES5 getters instead of Ember's `get` / `getProperties` functions",
-      category: 'Best Practices',
+      category: 'Ember Object',
       recommended: false,
       octane: true,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-get.md',

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -16,7 +16,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow usage of global jQuery object',
-      category: 'Best Practices',
+      category: 'jQuery',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-global-jquery.md',

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -25,7 +25,7 @@ module.exports = {
     docs: {
       description:
         'disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`',
-      category: 'Possible Errors',
+      category: 'Miscellaneous',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md',

--- a/lib/rules/no-incorrect-computed-macros.js
+++ b/lib/rules/no-incorrect-computed-macros.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow incorrect usage of computed property macros',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-incorrect-computed-macros.md',

--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -18,7 +18,7 @@ module.exports = {
     docs: {
       description:
         "disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.",
-      category: 'Possible Errors',
+      category: 'Miscellaneous',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-invalid-debug-function-arguments.md',

--- a/lib/rules/no-invalid-dependent-keys.js
+++ b/lib/rules/no-invalid-dependent-keys.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow invalid dependent keys in computed properties',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-invalid-dependent-keys.md',

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -16,7 +16,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow any usage of jQuery',
-      category: 'Best Practices',
+      category: 'jQuery',
       recommended: false,
       octane: true,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-jquery.md',

--- a/lib/rules/no-mixins.js
+++ b/lib/rules/no-mixins.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow the usage of mixins',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-mixins.md',
     },

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow the creation of new mixins',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-new-mixins.md',

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow usage of observers',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-observers.md',

--- a/lib/rules/no-old-shims.js
+++ b/lib/rules/no-old-shims.js
@@ -253,7 +253,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow usage of old shims for modules',
-      category: 'Best Practices',
+      category: 'Deprecations',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-old-shims.md',

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow usage of `on` to call lifecycle hooks in components',
-      category: 'Best Practices',
+      category: 'Components',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-on-calls-in-components.md',

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -15,7 +15,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow injecting the private routing service',
-      category: 'Best Practices',
+      category: 'Routes',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-private-routing-service.md',

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -65,7 +65,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow the use of patterns that use the restricted resolver in tests',
-      category: 'Best Practices',
+      category: 'Testing',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-restricted-resolver-tests.md',

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -16,7 +16,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow unexpected side effects in computed properties',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-side-effects.md',

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow unnecessary `index` route definition',
-      category: 'Best Practices',
+      category: 'Routes',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-index-route.md',

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow unnecessary usage of the route `path` option',
-      category: 'Best Practices',
+      category: 'Routes',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-route-path-option.md',

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -15,7 +15,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow unnecessary argument when injecting services',
-      category: 'Best Practices',
+      category: 'Stylistic Issues',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-unnecessary-service-injection-argument.md',

--- a/lib/rules/no-volatile-computed-properties.js
+++ b/lib/rules/no-volatile-computed-properties.js
@@ -12,7 +12,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow volatile computed properties',
-      category: 'Best Practices',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-volatile-computed-properties.md',

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -81,7 +81,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'require using computed property macros when possible',
-      category: 'Best Practices',
+      category: 'Computed Properties',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-computed-macros.md',

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -355,7 +355,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'require dependencies to be declared statically in computed properties',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-computed-property-dependencies.md',

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -15,7 +15,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'disallow missing return statements in computed properties',
-      category: 'Possible Errors',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-return-from-computed.md',

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -71,7 +71,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'require `this._super` to be called in `init` hooks',
-      category: 'Possible Errors',
+      category: 'Ember Object',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-init.md',

--- a/lib/rules/require-tagless-components.js
+++ b/lib/rules/require-tagless-components.js
@@ -91,7 +91,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow using the wrapper element of a component',
-      category: 'Ember Octane',
+      category: 'Components',
       recommended: false,
       octane: true,
       url:

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -15,7 +15,7 @@ module.exports = {
     docs: {
       description:
         'enforce usage of kebab-case (instead of snake_case or camelCase) in route paths',
-      category: 'Best Practices',
+      category: 'Routes',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/route-path-style.md',

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -13,7 +13,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce usage of snake_cased dynamic segments in routes',
-      category: 'Possible Errors',
+      category: 'Routes',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/routes-segments-snake-case.md',

--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -14,7 +14,7 @@ module.exports = {
     type: 'layout',
     docs: {
       description: 'enforce usage of brace expansion in computed property dependent keys',
-      category: 'Stylistic Issues',
+      category: 'Computed Properties',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-brace-expansion.md',

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -18,7 +18,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce usage of `Ember.get` and `Ember.set`',
-      category: 'Best Practices',
+      category: 'Ember Object',
       recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/use-ember-get-and-set.md',

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -43,7 +43,9 @@ const categories = rules
     }
     return arr;
   }, [])
-  .sort();
+  .sort(function(a, b) {
+    return a.toLowerCase().localeCompare(b.toLowerCase()); // Case-insensitive sort function.
+  });
 
 let rulesTableContent = categories
   .map(


### PR DESCRIPTION
Rebalances rule categories into new groups:
* Components
* Computed Properties
* Controllers
* Deprecations
* Ember Data
* Ember Object
* Ember Octane
* jQuery
* Miscellaneous
* Routes
* Stylistic Issues
* Testing

Old groups (some of these groups were getting too large):
* Best Practices
* Ember Data
* Ember Object
* Ember Octane
* Possible Errors
* Stylistic Issues
* Testing