### PR TITLE
Update `ignoreNestedPaths` option default to `false` for `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -47,7 +47,7 @@ const foo = this.someProperty;
 ```
 
 ```js
-const foo = this.get('some.nested.property'); // Allowed because of nested path.
+const foo = this.get('some.nested.property'); // Allowed if `ignoreNestedPaths` option is enabled.
 ```
 
 ```js
@@ -84,7 +84,7 @@ export default EmberObject.extend({
 This rule takes an optional object containing:
 
 * `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
-* `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (default `true`) (this option is enabled by default to make it easier/safer to adopt this rule)
+* `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (default `false`)
 
 ## Related Rules
 

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -40,7 +40,7 @@ module.exports = {
           },
           ignoreNestedPaths: {
             type: 'boolean',
-            default: true,
+            default: false,
           },
         },
         additionalProperties: false,
@@ -50,7 +50,7 @@ module.exports = {
   create(context) {
     // Options:
     const ignoreGetProperties = context.options[0] && context.options[0].ignoreGetProperties;
-    const ignoreNestedPaths = !context.options[0] || context.options[0].ignoreNestedPaths;
+    const ignoreNestedPaths = context.options[0] && context.options[0].ignoreNestedPaths;
 
     let currentProxyObject = null;
     let currentClassWithUnknownPropertyMethod = null;

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -17,8 +17,8 @@ ruleTester.run('no-get', rule, {
     // **************************
 
     // Nested property path.
-    "this.get('foo.bar');",
-    "get(this, 'foo.bar');",
+    { code: "this.get('foo.bar');", options: [{ ignoreNestedPaths: true }] },
+    { code: "get(this, 'foo.bar');", options: [{ ignoreNestedPaths: true }] },
 
     // Template literals.
     {
@@ -57,10 +57,10 @@ ruleTester.run('no-get', rule, {
     // **************************
 
     // Nested property path.
-    "this.getProperties('foo', 'bar.baz');",
-    "this.getProperties(['foo', 'bar.baz']);", // With parameters in array.
-    "getProperties(this, 'foo', 'bar.baz');",
-    "getProperties(this, ['foo', 'bar.baz']);", // With parameters in array.
+    { code: "this.getProperties('foo', 'bar.baz');", options: [{ ignoreNestedPaths: true }] },
+    { code: "this.getProperties(['foo', 'bar.baz']);", options: [{ ignoreNestedPaths: true }] }, // With parameters in array.
+    { code: "getProperties(this, 'foo', 'bar.baz');", options: [{ ignoreNestedPaths: true }] },
+    { code: "getProperties(this, ['foo', 'bar.baz']);", options: [{ ignoreNestedPaths: true }] }, // With parameters in array.
 
     // Template literals.
     'this.getProperties(`prop1`, `prop2`);',
@@ -208,29 +208,25 @@ ruleTester.run('no-get', rule, {
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
 
-    // With ignoreNestedPaths: false
+    // Nested paths:
     {
       code: "this.get('foo.bar');",
       output: null,
-      options: [{ ignoreNestedPaths: false }],
       errors: [{ message: makeErrorMessageForGet('foo.bar', false), type: 'CallExpression' }],
     },
     {
       code: "get(this, 'foo.bar');",
       output: null,
-      options: [{ ignoreNestedPaths: false }],
       errors: [{ message: makeErrorMessageForGet('foo.bar', true), type: 'CallExpression' }],
     },
     {
       code: "this.getProperties('foo.bar');",
       output: null,
-      options: [{ ignoreNestedPaths: false }],
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
     {
       code: "getProperties(this, 'foo.bar');",
       output: null,
-      options: [{ ignoreNestedPaths: false }],
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
 


### PR DESCRIPTION
We should be stricter about disallowing `this.get('some.nested.path')` in the [no-get](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-get.md) rule as we encourage developers to move towards native ES5 getters and away from custom Ember APIs.

Planned for V8 release in #699.