### PR TITLE
Drop Node 8, 9, and 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## ❗️Requirements
 
 - [ESLint](https://eslint.org/) `>= 5`
-- [Node.js](https://nodejs.org/) `>= 8`
+- [Node.js](https://nodejs.org/) `10.* || >= 12`
 
 ## 🚀 Usage
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rules"
   ],
   "engines": {
-    "node": ">=8.0"
+    "node": "10.* || >= 12"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Requires Node 10, 12+.

Node 8 is end-of-life as of 2019-12-31.

Planned for V8 release in #699.