### PR TITLE
Fix crashes in `no-invalid-test-waiters` rule

### DIFF
--- a/lib/rules/no-invalid-test-waiters.js
+++ b/lib/rules/no-invalid-test-waiters.js
@@ -46,7 +46,7 @@ module.exports = {
       },
 
       CallExpression(node) {
-        if (node.callee.name !== buildWaiter) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== buildWaiter) {
           return;
         }
 
@@ -55,9 +55,7 @@ module.exports = {
             node,
             message: DIRECT_ASSIGNMENT_ERROR_MESSAGE,
           });
-        }
-
-        if (!isInModuleScope(node)) {
+        } else if (!isInModuleScope(node)) {
           context.report({
             node,
             message: MODULE_SCOPE_ERROR_MESSAGE,

--- a/tests/lib/rules/no-invalid-test-waiters.js
+++ b/tests/lib/rules/no-invalid-test-waiters.js
@@ -40,6 +40,12 @@ ruleTester.run('no-invalid-test-waiters', rule, {
       let myWaiter = buildWaiter.somethingElse('waiterName');
     }
   `,
+    `
+    import { buildWaiter } from 'ember-test-waiters';
+
+    buildWaiter.somethingElse('waiterName');
+    somethingElse.buildWaiter('waiterName');
+  `,
   ],
 
   invalid: [
@@ -72,6 +78,15 @@ ruleTester.run('no-invalid-test-waiters', rule, {
       const someFunction = () => {
         buildWaiter('waiterName');
       };
+      `,
+      output: null,
+      errors: [{ message: DIRECT_ASSIGNMENT_ERROR_MESSAGE }],
+    },
+    {
+      code: `
+      import { buildWaiter } from 'ember-test-waiters';
+
+      buildWaiter('waiterName');
       `,
       output: null,
       errors: [{ message: DIRECT_ASSIGNMENT_ERROR_MESSAGE }],


### PR DESCRIPTION
Discovered multiple situations that can crash the rule or result in false positives by running this on a newly-generated ember-cli app as well as my own application.

One example crash:
```
TypeError: Cannot read property 'parent' of null
```

Follow-up to #702.