### PR TITLE
Fix some invalid test case properties

### DIFF
--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -61,7 +61,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -84,7 +84,7 @@ eslintTester.run('no-attrs-snapshot', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -58,8 +58,6 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          ruleId: 'no-invalid-dependent-keys',
-          severity: 1,
           message: ERROR_MESSAGE_UNBALANCED_BRACES,
           line: 1,
           column: 18,
@@ -68,8 +66,6 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
           endColumn: 35,
         },
         {
-          ruleId: 'no-invalid-dependent-keys',
-          severity: 1,
           message: ERROR_MESSAGE_UNBALANCED_BRACES,
           line: 1,
           column: 37,
@@ -84,8 +80,6 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          ruleId: 'no-invalid-dependent-keys',
-          severity: 1,
           message: ERROR_MESSAGE_UNBALANCED_BRACES,
           line: 1,
           column: 18,
@@ -101,8 +95,6 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          ruleId: 'no-invalid-dependent-keys',
-          severity: 1,
           message: ERROR_MESSAGE_UNBALANCED_BRACES,
           line: 1,
           column: 19,
@@ -118,8 +110,6 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
       output: null,
       errors: [
         {
-          ruleId: 'no-invalid-dependent-keys',
-          severity: 1,
           message: ERROR_MESSAGE_UNBALANCED_BRACES,
           line: 1,
           column: 19,

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -41,7 +41,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -57,7 +57,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -73,7 +73,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -90,7 +90,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -105,7 +105,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -120,7 +120,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -136,7 +136,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -152,7 +152,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -168,7 +168,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -183,7 +183,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -203,7 +203,7 @@ eslintTester.run('no-jquery', rule, {
       output: null,
       errors: [
         {
-          ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },


### PR DESCRIPTION
Caught by running tests under eslint 7 alpha.

```
Invalid error property name 'severity'. Expected one of ['message', 'messageId', 'data', 'type', 'line', 'column', 'endLine', 'endColumn', 'suggestions'].
```