### PR TITLE
Replace `this.get('property')` with `this.property` in rule examples

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -12,7 +12,7 @@ export default Foo.extend({
 
   actions: {
     addItem(item) {
-      this.get('items').pushObject(item);
+      this.items.pushObject(item);
     }
   }
 });
@@ -30,7 +30,7 @@ export default Foo.extend({
 
   actions: {
     addItem(item) {
-      this.get('items').pushObject(item);
+      this.items.pushObject(item);
     }
   }
 });

--- a/docs/rules/no-attrs-in-components.md
+++ b/docs/rules/no-attrs-in-components.md
@@ -17,10 +17,8 @@ const name = this.attrs.name;
 Examples of **correct** code for this rule:
 
 ```js
-import { get } from '@ember/object';
-
 // Prefix private properties with _
-const name = get(this, '_name');
+const name = this._name;
 ```
 
 ## Further Reading

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -52,7 +52,7 @@ import { isValidClassName } from 'my-utils';
 
 export default Component.extend({
   aComputedProperty: computed('obj', function () {
-    return isValidClassName(get(obj, 'className'));
+    return isValidClassName(obj.className);
   })
 });
 ```

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -32,7 +32,7 @@ import myMixin from 'my-mixin';
 
 export default Component.extend(myMixin, {
   aComputedProperty: computed('obj', function () {
-    return this.isValidClassName(get(obj, 'className'));
+    return this.isValidClassName(obj.className);
   })
 });
 ```
@@ -56,7 +56,7 @@ import { isValidClassName } from 'my-utils';
 
 export default Component.extend({
   aComputedProperty: computed('obj', function () {
-    return isValidClassName(get(obj, 'className'));
+    return isValidClassName(obj.className);
   })
 });
 ```

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -31,7 +31,7 @@ export default Component.extend({
   // BAD:
   fifteenAmountBad: 0,
   fifteenBad: computed('users', function () {
-    const fifteen = this.get('users').filterBy('items', 'age', 15);
+    const fifteen = this.users.filterBy('items', 'age', 15);
     this.set('fifteenAmount', fifteen.length); // SIDE EFFECT!
     return fifteen;
   })

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -107,7 +107,7 @@ export default Component.extend({
 
   // 5. Multiline Computed Property
   levelOfHappiness: computed('attitude', 'health', function () {
-    const result = this.get('attitude') * this.get('health') * Math.random();
+    const result = this.attitude * this.health * Math.random();
     return result;
   }),
 

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -66,8 +66,7 @@ You should write code grouped and ordered in this way:
 const {
   Controller,
   computed,
-  inject: { controller, service },
-  get
+  inject: { controller, service }
 } = Ember;
 
 export default Controller.extend({
@@ -91,7 +90,7 @@ export default Controller.extend({
 
   // 7. Multiline Computed Property
   levelOfHappiness: computed('attitude', 'health', function () {
-    return get(this, 'attitude') * get(this, 'health') * Math.random();
+    return this.attitude * this.health * Math.random();
   }),
 
   // 8. Observers

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -63,7 +63,7 @@ export default Model.extend({
 
   // 3. Computed Properties
   mood: computed('health', 'hunger', function () {
-    const result = this.get('health') * this.get('hunger');
+    const result = this.health * this.hunger;
     return result;
   })
 });
@@ -73,7 +73,7 @@ export default Model.extend({
 // BAD
 export default Model.extend({
   mood: computed('health', 'hunger', function () {
-    const result = this.get('health') * this.get('hunger');
+    const result = this.health * this.hunger;
     return result;
   }),
 

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -84,8 +84,7 @@ You should write code grouped and ordered in this way:
 ```javascript
 const {
   Route,
-  inject: { service },
-  get
+  inject: { service }
 } = Ember;
 
 export default Route.extend({
@@ -102,7 +101,7 @@ export default Route.extend({
 
   // 4. beforeModel hook
   beforeModel() {
-    if (!get(this, 'currentUser.isAdmin')) {
+    if (!this.currentUser.isAdmin) {
       this.transitionTo('index');
     }
   },

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -17,7 +17,7 @@ export default Component.extend({
 
   fullName: computed('firstName', 'lastName', {
     get() {
-      return `${this.get('firstName')} ${this.get('lastName')}`;
+      return `${this.firstName} ${this.lastName}`;
     },
     set(key, value) {
       const [firstName, lastName] = value.split(/\s+/);
@@ -27,8 +27,8 @@ export default Component.extend({
   }),
 
   salutation: computed('firstName', function () {
-    if (this.get('firstName')) {
-      return `Dr. ${this.get('firstName')}`;
+    if (this.firstName) {
+      return `Dr. ${this.firstName}`;
     }
   })
 });
@@ -46,7 +46,7 @@ export default Component.extend({
 
   fullName: computed('firstName', 'lastName', {
     get() {
-      return `${this.get('firstName')} ${this.get('lastName')}`;
+      return `${this.firstName} ${this.lastName}`;
     },
     set(key, value) {
       const [firstName, lastName] = value.split(/\s+/);
@@ -57,8 +57,8 @@ export default Component.extend({
   }),
 
   salutation: computed('firstName', function () {
-    if (this.get('firstName')) {
-      return `Dr. ${this.get('firstName')}`;
+    if (this.firstName) {
+      return `Dr. ${this.firstName}`;
     }
     return '';
   })


### PR DESCRIPTION
Use the more modern ES5 getter syntax, especially since `this.get()` is disallowed by the [no-get](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-get.md) rule.