### PR TITLE
Switch to new module imports in rule examples

### DIFF
--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -20,8 +20,10 @@ String option:
 ### always-with-setter
 
 ```javascript
+import EmberObject, { computed } from '@ember/object';
+
 // BAD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', {
     get() {
       // ...
@@ -30,14 +32,14 @@ Ember.Object.extend({
 });
 
 // GOOD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', function () {
     // ...
   })
 });
 
 // GOOD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', {
     set() {
       // ...
@@ -52,8 +54,10 @@ Ember.Object.extend({
 ### always
 
 ```javascript
+import EmberObject, { computed } from '@ember/object';
+
 // GOOD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', {
     get() {
       // ...
@@ -62,7 +66,7 @@ Ember.Object.extend({
 });
 
 // BAD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', function () {
     // ...
   })
@@ -72,15 +76,17 @@ Ember.Object.extend({
 ### never
 
 ```javascript
+import EmberObject, { computed } from '@ember/object';
+
 // GOOD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', function () {
     // ...
   })
 });
 
 // BAD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', {
     get() {
       // ...
@@ -89,7 +95,7 @@ Ember.Object.extend({
 });
 
 // BAD
-Ember.Object.extend({
+EmberObject.extend({
   fullName: computed('firstName', 'lastName', {
     get() {
       // ...

--- a/docs/rules/jquery-ember-run.md
+++ b/docs/rules/jquery-ember-run.md
@@ -9,7 +9,9 @@ Using plain jQuery invokes actions out of the Ember Run Loop. In order to have a
 Examples of **incorrect** code for this rule:
 
 ```js
-Ember.$('#something-rendered-by-jquery-plugin').on('click', () => {
+import $ from 'jquery';
+
+$('#something-rendered-by-jquery-plugin').on('click', () => {
   this._handlerActionFromController();
 });
 ```
@@ -17,8 +19,11 @@ Ember.$('#something-rendered-by-jquery-plugin').on('click', () => {
 Examples of **correct** code for this rule:
 
 ```javascript
-Ember.$('#something-rendered-by-jquery-plugin').on(
+import $ from 'jquery';
+import { bind } from '@ember/runloop';
+
+$('#something-rendered-by-jquery-plugin').on(
   'click',
-  Ember.run.bind(this, this._handlerActionFromController)
+  bind(this, this._handlerActionFromController)
 );
 ```

--- a/docs/rules/no-attrs-snapshot.md
+++ b/docs/rules/no-attrs-snapshot.md
@@ -15,8 +15,9 @@ If for some reason you need to do a comparison of arguments we suggest that you 
 Examples of **incorrect** code for this rule:
 
 ```js
+import Component from '@ember/component';
 
-export default Ember.Component({
+export default Component({
   init(...args) {
     this._super(...args);
     this.updated = false;
@@ -36,8 +37,9 @@ export default Ember.Component({
 Examples of **correct** code for this rule:
 
 ```js
+import Component from '@ember/component';
 
-export default Ember.Component({
+export default Component({
   init(...args) {
     this._super(...args);
     this._valueCache = this.value;

--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -11,6 +11,7 @@ This rule disallows using computed properties with native classes.
 Examples of **incorrect** code for this rule:
 
 ```js
+import Component from '@ember/component';
 import { and, or, alias } from '@ember/object/computed';
 
 export default class MyComponent extends Component {
@@ -19,6 +20,7 @@ export default class MyComponent extends Component {
 ```
 
 ```js
+import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default class MyComponent extends Component {
@@ -32,14 +34,14 @@ Examples of **correct** code for this rule:
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 
-export default Ember.Component.extend({});
+export default Component.extend({});
 ```
 
 ```js
 import { alias, or, and } from '@ember/object/computed';
 import Component from '@ember/component';
 
-export default Ember.Component.extend({});
+export default Component.extend({});
 ```
 
 ```js

--- a/docs/rules/no-ember-testing-in-module-scope.md
+++ b/docs/rules/no-ember-testing-in-module-scope.md
@@ -14,6 +14,8 @@ of destructuring.
 Examples of **incorrect** code for this rule:
 
 ```js
+import Component from '@ember/component';
+
 export default Component.extend({
   init() {
     this.isTesting = Ember.testing;
@@ -23,8 +25,9 @@ export default Component.extend({
 
 ```js
 import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   isTesting: Ember.testing
 });
 ```
@@ -45,6 +48,7 @@ Examples of **correct** code for this rule:
 
 ```javascript
 import Ember from 'ember';
+import Component from '@ember/component';
 
 export default Component.extend({
   someMethod() {
@@ -59,6 +63,7 @@ export default Component.extend({
 
 ```js
 import Ember from 'ember';
+import Service from '@ember/service';
 
 export default Service.extend({
   foo() {

--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -18,8 +18,10 @@ Observers do have some limited uses. They let you reflect state from your applic
 Examples of **incorrect** code for this rule:
 
 ```js
+import { observer } from '@ember/object';
+
 export default Controller.extend({
-  change: Ember.observer('text', function () {
+  change: observer('text', function () {
     console.log(`change detected: ${this.text}`);
   })
 });

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -7,12 +7,8 @@ When using computed properties do not introduce side effects. It will make reaso
 ## Examples
 
 ```javascript
-import Ember from 'ember';
-
-const {
-  Component,
-  computed: { filterBy, alias }
-} = Ember;
+import Component from '@ember/component';
+import { alias, filterBy } from '@ember/object/computed';
 
 export default Component.extend({
   init(...args) {

--- a/docs/rules/require-super-in-init.md
+++ b/docs/rules/require-super-in-init.md
@@ -9,7 +9,9 @@ When overriding the `init` lifecycle hook inside Ember Components, Controllers, 
 Examples of **incorrect** code for this rule:
 
 ```javascript
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   init() {
     this.set('items', []);
   }
@@ -19,7 +21,9 @@ export default Ember.Component.extend({
 Examples of **correct** code for this rule:
 
 ```javascript
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   init(...args) {
     this._super(...args);
     this.set('items', []);


### PR DESCRIPTION
I ran the [new-module-imports](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/new-module-imports.md) lint rule on the markdown examples using eslint-plugin-markdown to help with this.