### PR TITLE
Add missing init hook super calls in rule examples

### DIFF
--- a/docs/rules/no-ember-testing-in-module-scope.md
+++ b/docs/rules/no-ember-testing-in-module-scope.md
@@ -15,7 +15,8 @@ Examples of **incorrect** code for this rule:
 
 ```js
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     this.isTesting = Ember.testing;
   }
 });

--- a/docs/rules/no-global-jquery.md
+++ b/docs/rules/no-global-jquery.md
@@ -12,7 +12,8 @@ Examples of **incorrect** code for this rule:
 
 ```js
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     $('.foo').addClass('bar'); // global usage
   }
 });
@@ -25,7 +26,8 @@ import Ember from 'ember';
 
 const { $ } = Ember;
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     Ember.$('.foo').addClass('bar'); // usage from Ember object
     // or even better
     $('.foo').addClass('bar'); // deconstruction from Ember object

--- a/docs/rules/no-legacy-test-waiters.md
+++ b/docs/rules/no-legacy-test-waiters.md
@@ -24,7 +24,8 @@ if (DEBUG) {
 }
 
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     counter++;
     someAsync()
       .then(() => console.log('hi'))
@@ -47,7 +48,8 @@ if (DEBUG) {
 }
 
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     counter++;
     someAsync()
       .then(() => console.log('hi'))
@@ -69,9 +71,9 @@ import { buildWaiter } from 'ember-test-waiters';
 const waiter = buildWaiter('my-waiter');
 
 export default Component.extend({
-  init() {
+  init(...args) {
+    this._super(...args);
     const token = waiter.beginAsync();
-
     someAsync()
       .then(() => console.log('hi'))
       .finally(() => waiter.endAsync(token));


### PR DESCRIPTION
Caught by running the Ember lint rules on the markdown rule examples with eslint-plugin-markdown.