### PR TITLE
Remove `no-empty-attrs` from `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-| :white_check_mark: | [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |
+|  | [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |
 | :white_check_mark::wrench: | [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | enforce usage of `@ember-data/` package imports instead `ember-data` |
 
 ### Ember Object

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -18,7 +18,6 @@ module.exports = {
   "ember/no-duplicate-dependent-keys": "error",
   "ember/no-ember-super-in-es-classes": "error",
   "ember/no-ember-testing-in-module-scope": "error",
-  "ember/no-empty-attrs": "error",
   "ember/no-function-prototype-extensions": "error",
   "ember/no-get-with-default": "error",
   "ember/no-get": "error",

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -12,7 +12,7 @@ module.exports = {
     docs: {
       description: 'disallow usage of empty attributes in Ember Data models',
       category: 'Ember Data',
-      recommended: true,
+      recommended: false,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-empty-attrs.md',
     },

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -15,7 +15,6 @@ Array [
   "no-duplicate-dependent-keys",
   "no-ember-super-in-es-classes",
   "no-ember-testing-in-module-scope",
-  "no-empty-attrs",
   "no-function-prototype-extensions",
   "no-get-with-default",
   "no-get",


### PR DESCRIPTION
Removes [no-empty-attrs](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-empty-attrs.md) rule from `recommended` config based on feedback here: https://github.com/ember-cli/eslint-plugin-ember/issues/699#issuecomment-606088129

CC: @runspired