### PR TITLE
Fix typo in example in `no-side-effects` rule doc

### DIFF
--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -28,7 +28,7 @@ export default Component.extend({
   fifteenAmountBad: 0,
   fifteenBad: computed('users', function () {
     const fifteen = this.users.filterBy('items', 'age', 15);
-    this.set('fifteenAmount', fifteen.length); // SIDE EFFECT!
+    this.set('fifteenAmountBad', fifteen.length); // SIDE EFFECT!
     return fifteen;
   })
 });


### PR DESCRIPTION
`fifteenAmount` is not a defined variable in the example. I believe it meant to be `fifteenAmountBad` and this PR is just fixing that.