### PR TITLE
Update each rule doc to mention what config enables the rule

### DIFF
--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -1,5 +1,7 @@
 # TODO: rule-name-goes-here
 
+(TODO: only include this line if the rule is recommended) :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 (TODO: only include this line if the rule is fixable) :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 TODO: context about the problem goes here

--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -1,5 +1,7 @@
 # avoid-leaking-state-in-ember-objects
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Don't use arrays and objects as default properties. More info here: <https://dockyard.com/blog/2015/09/18/ember-best-practices-avoid-leaking-state-into-factories>
 
 ## Examples

--- a/docs/rules/avoid-using-needs-in-controllers.md
+++ b/docs/rules/avoid-using-needs-in-controllers.md
@@ -1,5 +1,7 @@
 # avoid-using-needs-in-controllers
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Avoid using `needs` to load other controllers. Inject the required controller instead. `needs` was deprecated in ember 1.x and removed in 2.0.
 
 ## Examples

--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -1,5 +1,7 @@
 # classic-decorator-hooks
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Use the correct lifecycle hooks in classic and non-classic classes. Classic
 classes should use `init`, and non-classic classes should use `constructor`.
 Additionally, non-classic classes may not use `destroy`.

--- a/docs/rules/classic-decorator-no-classic-methods.md
+++ b/docs/rules/classic-decorator-no-classic-methods.md
@@ -1,5 +1,7 @@
 # classic-decorator-no-classic-methods
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Disallows the use of the following classic API methods within a class:
 
 - `get`

--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -1,5 +1,7 @@
 # closure-actions
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Always use closure actions (according to DDAU convention). Exception: only when you need bubbling.
 
 ## Examples

--- a/docs/rules/jquery-ember-run.md
+++ b/docs/rules/jquery-ember-run.md
@@ -1,5 +1,7 @@
 # jquery-ember-run
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Don’t use jQuery without the Ember Run Loop.
 
 Using plain jQuery invokes actions out of the Ember Run Loop. In order to have a control on all operations in Ember, it's good practice to trigger actions in run loop.

--- a/docs/rules/new-module-imports.md
+++ b/docs/rules/new-module-imports.md
@@ -1,5 +1,7 @@
 # new-module-imports
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Use "New Module Imports" from Ember RFC #176.
 
 [RFC #176](https://github.com/emberjs/rfcs/pull/176) introduced as new public

--- a/docs/rules/no-actions-hash.md
+++ b/docs/rules/no-actions-hash.md
@@ -1,5 +1,7 @@
 # no-actions-hash
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Disallows the actions hash in components and controllers.
 
 Ember Octane includes a rethink of event handling in Ember. The `actions` hash and `{{action}}` modifier and helper are no longer needed. To provide the correct context to functions (binding), you should now use the `@action` decorator. In templates, the `{{on}}` modifier can be used to set up event handlers and the `{{fn}}` helper can be used for partial application.

--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -1,5 +1,7 @@
 # no-arrow-function-computed-properties
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Arrow functions should not be used in computed properties because they are unable to access other properties (using `this.property`) of the same object. Accidental usage can thus lead to bugs.
 
 ## Rule Details

--- a/docs/rules/no-attrs-in-components.md
+++ b/docs/rules/no-attrs-in-components.md
@@ -1,5 +1,7 @@
 # no-attrs-in-components
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Do not use `this.attrs`.
 
 In the run-up to Ember 2.0, several blog articles were written about using `this.attrs` but this feature has never been documented as a public API. Typically people use `attrs` to denote properties and methods as having been "passed" in to a component and bare names as properties local to the component. This is useful and some iteration of Ember will have this built into the programming model, but for now we should not use `attrs`.

--- a/docs/rules/no-attrs-snapshot.md
+++ b/docs/rules/no-attrs-snapshot.md
@@ -1,5 +1,7 @@
 # no-attrs-snapshot
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs`.
 
 Do not use the arguments (attrs) that are passed in `didReceiveAttrs` and `didUpdateAttrs`. Using the arguments (attrs) in these hooks can result in performance degradation in your application.

--- a/docs/rules/no-capital-letters-in-routes.md
+++ b/docs/rules/no-capital-letters-in-routes.md
@@ -1,5 +1,7 @@
 # no-capital-letters-in-routes
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Raise an error when there is a route with upper-cased letters in router.js.
 
 When you accidentally uppercase any of your routes or create upper-cased route using ember-cli the application will crash without any clear information what's wrong. This rule makes it more obvious, so you don't have to think about it any more.

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -1,5 +1,7 @@
 # no-classic-classes
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Disallow "classic" classes in favor of native JS classes.
 
 Ember now allows you to use native JS classes to extend the built-in classes provided by Ember. This pattern is preferred in favor of using the "classic" style of classes that Ember has provided since before JS classes were available to use.

--- a/docs/rules/no-classic-components.md
+++ b/docs/rules/no-classic-components.md
@@ -1,5 +1,7 @@
 # no-classic-components
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 This rule aims to enforce Glimmer components instead of classic ones. We should migrate to Glimmer components because
 they have few advantages:
 

--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -1,5 +1,7 @@
 # no-component-lifecycle-hooks
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Disallow usage of "classic" ember component lifecycle hooks.
 
 ## Rule Details

--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -1,5 +1,7 @@
 # no-computed-properties-in-native-classes
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Since the beginning of Ember's existence, Computed Properties (CPs) have been used to accomplish reactivity in the framework. With Ember Octane, new features were introduced including Glimmer components, native JavaScript classes and Tracked Properties. With Ember Octane's new programming model, CPs are no longer needed. If using native JavaScript classes, Tracked Properties should be used instead as they give us the same benefit of CPs but with less boilerplate and more flexibility.
 
 ## Rule Details

--- a/docs/rules/no-deeply-nested-dependent-keys-with-each.md
+++ b/docs/rules/no-deeply-nested-dependent-keys-with-each.md
@@ -1,5 +1,7 @@
 # no-deeply-nested-dependent-keys-with-each
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Disallows usage of deeply-nested computed property dependent keys with `@each`.
 
 For performance / complexity reasons, Ember does not allow deeply-nested computed property dependent keys with `@each`. At runtime, it will show a warning about this:

--- a/docs/rules/no-duplicate-dependent-keys.md
+++ b/docs/rules/no-duplicate-dependent-keys.md
@@ -1,5 +1,7 @@
 # no-duplicate-dependent-keys
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Disallow repeating dependent keys.
 
 ## Rule Details

--- a/docs/rules/no-ember-super-in-es-classes.md
+++ b/docs/rules/no-ember-super-in-es-classes.md
@@ -1,5 +1,7 @@
 # no-ember-super-in-es-classes
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 `this._super` is not allowed in ES class methods.

--- a/docs/rules/no-ember-testing-in-module-scope.md
+++ b/docs/rules/no-ember-testing-in-module-scope.md
@@ -1,5 +1,7 @@
 # no-ember-testing-in-module-scope
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 `Ember.testing` is not allowed in modules scope.
 
 Since ember-cli-qunit@4.1.0 / ember-qunit@3.0.0, `Ember.testing` is only set to

--- a/docs/rules/no-function-prototype-extensions.md
+++ b/docs/rules/no-function-prototype-extensions.md
@@ -1,5 +1,7 @@
 # no-function-prototype-extensions
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Do not use Ember's `function` prototype extensions.
 
 Use computed property syntax, observer syntax or module hooks instead of `.property()`, `.observes()` or `.on()` in Ember modules.

--- a/docs/rules/no-get-with-default.md
+++ b/docs/rules/no-get-with-default.md
@@ -1,5 +1,7 @@
 # no-get-with-default
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 This rule attempts to catch and prevent the use of `getWithDefault`.

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -1,5 +1,7 @@
 # no-get
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Starting in Ember 3.1, native ES5 getters are available, which eliminates much of the need to use `get` / `getProperties` on Ember objects.

--- a/docs/rules/no-global-jquery.md
+++ b/docs/rules/no-global-jquery.md
@@ -1,5 +1,7 @@
 # no-global-jquery
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Do not use global `$` or `jQuery`.
 
 ## Rule Details

--- a/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
+++ b/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
@@ -1,5 +1,7 @@
 # no-incorrect-calls-with-inline-anonymous-functions
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 The following functions keep track of the function references they have been passed:
 
 - `debounce`

--- a/docs/rules/no-incorrect-computed-macros.md
+++ b/docs/rules/no-incorrect-computed-macros.md
@@ -1,5 +1,7 @@
 # no-incorrect-computed-macros
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 This rule attempts to find incorrect usages of computed property macros, such as calling them with the incorrect number of arguments.

--- a/docs/rules/no-invalid-debug-function-arguments.md
+++ b/docs/rules/no-invalid-debug-function-arguments.md
@@ -1,5 +1,7 @@
 # no-invalid-debug-function-arguments
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Catch usages of Ember&#39;s `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.
 
 This rule aims to catch a common mistake when using Ember's debug functions:

--- a/docs/rules/no-invalid-dependent-keys.md
+++ b/docs/rules/no-invalid-dependent-keys.md
@@ -1,5 +1,7 @@
 # no-invalid-dependent-keys
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Dependent keys used for computed properties have to be valid.

--- a/docs/rules/no-jquery.md
+++ b/docs/rules/no-jquery.md
@@ -1,5 +1,7 @@
 # no-jquery
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 This rule attempts to catch and prevent any usage of jQuery.
 
 ## Rule Details

--- a/docs/rules/no-legacy-test-waiters.md
+++ b/docs/rules/no-legacy-test-waiters.md
@@ -1,5 +1,7 @@
 # no-legacy-test-waiters
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Prevents the use of the legacy test waiter APIs.
 
 ## Rule Details

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -1,5 +1,7 @@
 # no-mixins
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Using mixins to share code appears easy at first. But they add significant complexity as a project grows. Furthermore, the [Octane programming model](https://guides.emberjs.com/release/upgrading/current-edition/) eliminates the need to use them in favor of native class semantics and other primitives.
 
 For practical strategies on removing mixins see [this discourse thread](https://discuss.emberjs.com/t/best-way-to-replace-mixins/17395/2).

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -1,5 +1,7 @@
 # no-new-mixins
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Using mixins to share code appears easy at first. But they add significant complexity as a project grows. Furthermore, the [Octane programming model](https://guides.emberjs.com/release/upgrading/current-edition/) eliminates the need to use them in favor of native class semantics and other primitives.
 
 For practical strategies on removing mixins see [this discourse thread](https://discuss.emberjs.com/t/best-way-to-replace-mixins/17395/2).

--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -1,5 +1,7 @@
 # no-observers
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 You should avoid observers for the following reasons:
 
 * Observers deal with data changes contrary to Ember's Data Down, Actions Up (DDAU) convention.

--- a/docs/rules/no-old-shims.md
+++ b/docs/rules/no-old-shims.md
@@ -1,5 +1,7 @@
 # no-old-shims
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Don't use import paths from `ember-cli-shims`.

--- a/docs/rules/no-on-calls-in-components.md
+++ b/docs/rules/no-on-calls-in-components.md
@@ -1,5 +1,7 @@
 # no-on-calls-in-components
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Prevents using `.on()` in favour of component's lifecycle hooks.
 
 The order of execution for `on()` is not deterministic.

--- a/docs/rules/no-pause-test.md
+++ b/docs/rules/no-pause-test.md
@@ -1,5 +1,7 @@
 # no-pause-test
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Disallow use of `pauseTest` helper in tests.
 
 When `pauseTest()` is committed and run in CI it can cause runners to hang which is undesirable.

--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -1,5 +1,7 @@
 # no-private-routing-service
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Disallow the use of the private `-routing` service.
 
 There has been a public `router` service since Ember 2.16 and using the private routing service should be unnecessary.

--- a/docs/rules/no-restricted-resolver-tests.md
+++ b/docs/rules/no-restricted-resolver-tests.md
@@ -1,5 +1,7 @@
 # no-restricted-resolver-tests
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Don't use constructs or configuration that use the restricted resolver in tests.
 
 [RFC-0229](https://github.com/emberjs/rfcs/blob/master/text/0229-deprecate-testing-restricted-resolver.md)

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -1,5 +1,7 @@
 # no-side-effects
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Don't introduce side-effects in computed properties.
 
 When using computed properties do not introduce side effects. It will make reasoning about the origin of the change much harder.

--- a/docs/rules/no-test-and-then.md
+++ b/docs/rules/no-test-and-then.md
@@ -1,5 +1,7 @@
 # no-test-and-then
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Use `await` instead of `andThen` test wait helper.
 
 It's no longer necessary to use the `andThen` test wait helper now that the cleaner [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax is available.

--- a/docs/rules/no-test-import-export.md
+++ b/docs/rules/no-test-import-export.md
@@ -1,5 +1,7 @@
 # no-test-import-export
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 No importing of test files.
 
 **TL;DR** Do not import from a test file (a file ending in "-test.js") in another test file. Doing so will cause the module and tests from the imported file to be executed again. Similarly, test files should not have any exports.

--- a/docs/rules/no-test-module-for.md
+++ b/docs/rules/no-test-module-for.md
@@ -1,5 +1,7 @@
 # no-test-module-for
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Use `module` instead of `moduleFor`.
 
 `moduleForComponent`, `moduleFor`, `moduleForAcceptance`, etc have been deprecated and there are codemods to help migrate.

--- a/docs/rules/no-unnecessary-route-path-option.md
+++ b/docs/rules/no-unnecessary-route-path-option.md
@@ -1,5 +1,7 @@
 # no-unnecessary-route-path-option
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Disallow unnecessary route `path` option.

--- a/docs/rules/no-volatile-computed-properties.md
+++ b/docs/rules/no-volatile-computed-properties.md
@@ -1,5 +1,7 @@
 # no-volatile-computed-properties
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Volatile computed properties are deprecated as of Ember 3.9.
 
 ## Rule Details

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -1,5 +1,7 @@
 # require-computed-macros
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 It is preferred to use Ember's computed property macros as opposed to manually writing out logic in a computed property function. Reasons include:

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -1,5 +1,7 @@
 # require-computed-property-dependencies
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Computed properties should have their property dependencies listed out so that they can recompute upon changes.

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -1,5 +1,7 @@
 # require-return-from-computed
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Always return a value from a computed property function.
 
 ## Examples

--- a/docs/rules/require-super-in-init.md
+++ b/docs/rules/require-super-in-init.md
@@ -1,5 +1,7 @@
 # require-super-in-init
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Call `_super` in init lifecycle hooks.
 
 When overriding the `init` lifecycle hook inside Ember Components, Controllers, Routes or Mixins, it is necessary to include a call to `_super`.

--- a/docs/rules/require-tagless-components.md
+++ b/docs/rules/require-tagless-components.md
@@ -1,5 +1,7 @@
 # require-tagless-components
 
+:car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.
+
 Disallows using the wrapper element of a component.
 
 Ember allows you to disable the wrapper element on a component (turning it into a "tagless" component). This is now the preferred style and the _only_ style allowed with Glimmer components.

--- a/docs/rules/routes-segments-snake-case.md
+++ b/docs/rules/routes-segments-snake-case.md
@@ -1,5 +1,7 @@
 # routes-segments-snake-case
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 Dynamic segments in routes should use _snake case_, so Ember doesn't have to do extra serialization in order to resolve promises.
 
 ## Examples

--- a/docs/rules/use-brace-expansion.md
+++ b/docs/rules/use-brace-expansion.md
@@ -1,5 +1,7 @@
 # use-brace-expansion
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 This allows much less redundancy and is easier to read.
 
 Note that **the dependent keys must be together (without space)** for the brace expansion to work.

--- a/docs/rules/use-ember-data-rfc-395-imports.md
+++ b/docs/rules/use-ember-data-rfc-395-imports.md
@@ -1,5 +1,7 @@
 # use-ember-data-rfc-395-imports
 
+:white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 Use &#34;Ember Data Packages&#34; from Ember RFC #395.

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -57,7 +57,12 @@ describe('rules setup is correct', function () {
     );
   });
 
-  it('should have the right contents (title, examples, fixable notice) for each rule documentation file', function () {
+  it('should have the right contents (title, examples, notices) for each rule documentation file', function () {
+    const CONFIG_MSG_RECOMMENDED =
+      ':white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.';
+    const CONFIG_MSG_OCTANE =
+      ':car: The `"extends": "plugin:ember/octane"` property in a configuration file enables this rule.';
+
     const FIXABLE_MSG =
       ':wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.';
 
@@ -73,6 +78,18 @@ describe('rules setup is correct', function () {
         expect(file).toContain(FIXABLE_MSG);
       } else {
         expect(file).not.toContain(FIXABLE_MSG);
+      }
+
+      if (rule.meta.docs.recommended) {
+        expect(file).toContain(CONFIG_MSG_RECOMMENDED);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_RECOMMENDED);
+      }
+
+      if (rule.meta.docs.octane) {
+        expect(file).toContain(CONFIG_MSG_OCTANE);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_OCTANE);
       }
     });
   });


### PR DESCRIPTION
Matches the eslint plugin rule docs (example: https://eslint.org/docs/rules/no-extra-semi).

This makes it easier to gain a complete picture of the rule by looking at its rule doc (without depending on the overall README.md).

And adds a test to ensure the docs are correct.

Follow-up to #715 which added an autofixable notice to the doc for each autofixable rule.