### PR TITLE
WIP - DO NOT MERGE - New Rule: prefer-ember-test-helpers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     sourceType: 'script'
   },
   plugins: [
+    'ember',
     'eslint-plugin',
     'filenames',
     'import',
@@ -17,6 +18,7 @@ module.exports = {
   ],
   extends: [
     'eslint:recommended',
+    'plugin:ember/recommended',
     'plugin:eslint-comments/recommended',
     'plugin:eslint-plugin/all',
     'plugin:jest/recommended',
@@ -77,6 +79,7 @@ module.exports = {
     'no-void': 'error',
     'no-with': 'error',
     'object-shorthand': 'error',
+    'prefer-ember-test-helpers': 'error',
     'prefer-const': 'error',
     'prefer-numeric-literals': 'error',
     'prefer-promise-reject-errors': 'error',

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 | :white_check_mark: | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
 | :white_check_mark: | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
 | :white_check_mark: | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |
+| :white_check_mark: | [prefer-ember-test-helpers](./docs/rules/prefer-ember-test-helpers.md) | prefer import of Ember test helper methods |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/prefer-ember-test-helpers.md
+++ b/docs/rules/prefer-ember-test-helpers.md
@@ -1,0 +1,66 @@
+# prefer-ember-test-helpers
+
+This rule ensures the correct Ember test helper is imported when using methods with `await` that have a native window counterpart.
+
+There are currently 3 Ember test helper methods that have a native window counterpart:
+
+* blur
+* find
+* focus
+
+If these methods are not properly imported from Ember's test-helpers suite, the native window method version is used instead, and any intended asynchronous functions won't work as intended, which causes tests to fail silently.
+
+See the origin and background of the rule proposal: [eslint-plugin-ember issue 676](https://github.com/ember-cli/eslint-plugin-ember/issues/676)
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+test('foo', async function(assert) {
+  await blur();
+});
+```
+
+```js
+test('foo', async function(assert) {
+  await find();
+});`
+```
+
+```js
+test('foo', async function(assert) {
+  await focus();
+});`
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { blur } from '@ember/test-helpers';
+
+test('foo', async function(assert) {
+  await blur();
+});
+```
+
+```js
+import { find } from '@ember/test-helpers';
+
+test('foo', async function(assert) {
+  await find();
+});`
+```
+
+```js
+import { focus } from '@ember/test-helpers';
+
+test('foo', async function(assert) {
+  await focus();
+});`
+```
+
+## References
+
+* (Web API Window Methods)[https://developer.mozilla.org/en-US/docs/Web/API/Window#Methods]
+* (Ember Test Helpers API Methods)[https://github.com/emberjs/ember-test-helpers/blob/master/API.md]

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ module.exports = {
     'order-in-controllers': require('./rules/order-in-controllers'),
     'order-in-models': require('./rules/order-in-models'),
     'order-in-routes': require('./rules/order-in-routes'),
+    'prefer-ember-test-helpers': require('./rules/prefer-ember-test-helpers'),
     'require-computed-macros': require('./rules/require-computed-macros'),
     'require-computed-property-dependencies': require('./rules/require-computed-property-dependencies'),
     'require-return-from-computed': require('./rules/require-return-from-computed'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -42,6 +42,7 @@ module.exports = {
   "ember/no-test-module-for": "error",
   "ember/no-unnecessary-route-path-option": "error",
   "ember/no-volatile-computed-properties": "error",
+  "ember/prefer-ember-test-helpers": "error",
   "ember/require-computed-macros": "error",
   "ember/require-computed-property-dependencies": "error",
   "ember/require-return-from-computed": "error",

--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview help users writing tests in Ember using @ember/test-helpers check their imports to ensure they are using the correct method rather than the native method on window
+ * @author Connie Chang
+ */
+'use strict';
+
+const { getImportIdentifier } = require('../utils/import');
+
+let hasImportedBlur = undefined;
+let hasImportedFind = undefined;
+let hasImportedFocus = undefined;
+
+//-------------------------------------------------------------------------------------
+// Rule Definition
+// See proposal on Github: https://github.com/ember-cli/eslint-plugin-ember/issues/676
+//-------------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'enforce import of @ember/test-helpers method to ensure native method on `window` is not incorrectly used',
+      category: 'Testing',
+      recommended: true,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/prefer-ember-test-helpers.md',
+    },
+    schema: [],
+  },
+
+  create: context => {
+    const showErrorMessage = function(node, methodName) {
+      let errorMessage = 'Import the correct method from Ember test-helpers';
+
+      switch (methodName) {
+        case 'blur':
+          errorMessage = 'Import the `blur()` method from Ember test-helpers';
+          break;
+        case 'find':
+          errorMessage = 'Import the `find()` method from Ember test-helpers';
+          break;
+        case 'focus':
+          errorMessage = 'Import the `focus()` method from Ember test-helpers';
+          break;
+        default:
+      }
+
+      context.report({
+        message: errorMessage,
+        node,
+      });
+    };
+
+    return {
+      ImportDeclaration(node) {
+        hasImportedBlur = getImportIdentifier(node, '@ember/test-helpers', 'blur');
+        hasImportedFind = getImportIdentifier(node, '@ember/test-helpers', 'find');
+        hasImportedFocus = getImportIdentifier(node, '@ember/test-helpers', 'focus');
+      },
+      CallExpression(node) {
+        if (!hasImportedBlur) {
+          if (node.parent && node.parent.type === 'AwaitExpression') {
+            if (node.callee.name === 'blur') {
+              showErrorMessage(node, 'blur');
+            }
+          }
+        }
+
+        if (!hasImportedFind) {
+          if (node.parent && node.parent.type === 'AwaitExpression') {
+            if (node.callee.name === 'find') {
+              showErrorMessage(node, 'find');
+            }
+          }
+        }
+
+        if (!hasImportedFocus) {
+          if (node.parent && node.parent.type === 'AwaitExpression') {
+            if (node.callee.name === 'focus') {
+              showErrorMessage(node, 'focus');
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview help users writing tests in Ember using @ember/test-helpers check their imports to ensure they are using the correct method rather than the native method on window
+ * @author Connie C Chang
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/prefer-ember-test-helpers');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+ruleTester.run('prefer-ember-test-helpers', rule, {
+  valid: [
+    `import { blur } from '@ember/test-helpers';
+
+    test('foo', async function(assert) {
+      await blur();
+    });`,
+
+    `import { find } from '@ember/test-helpers';
+
+    test('foo', async function(assert) {
+      await find();
+    });`,
+
+    `import { focus } from '@ember/test-helpers';
+
+    test('foo', async function(assert) {
+      await focus();
+    });`,
+  ],
+
+  invalid: [
+    {
+      code: `test('foo', async function(assert) {
+        await blur();
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `blur()` method from Ember test-helpers',
+        },
+      ],
+    },
+    {
+      code: `test('foo', async function(assert) {
+        await find();
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `find()` method from Ember test-helpers',
+        },
+      ],
+    },
+    {
+      code: `test('foo', async function(assert) {
+        await focus();
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `focus()` method from Ember test-helpers',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
New Rule: Use ember test-helper util function in tests instead of native window method
ID: prefer-ember-test-helpers
Addresses #676: https://github.com/ember-cli/eslint-plugin-ember/issues/676