### PR TITLE
Catch unnecessary braces in `no-invalid-dependent-keys` rule

### DIFF
--- a/docs/rules/no-invalid-dependent-keys.md
+++ b/docs/rules/no-invalid-dependent-keys.md
@@ -12,8 +12,8 @@ This rule aims to avoid invalid dependent keys in computed properties.
 
 Currently implemented:
 
-- Unbalanced open and closed braces. These can be hard to track for complex computed properties
-and are usually unchecked since the expressions are passed as Strings.
+- Unbalanced open and closed braces. These can be hard to track for complex computed properties and are usually unchecked since the expressions are passed as Strings.
+- Unnecessary braces
 - Invalid position of `@each` or `[]`
 
 Not yet implemented:
@@ -28,6 +28,15 @@ Examples of **incorrect** code for this rule:
 export default Component.extend({
   // Unbalanced braces:
   fullName: computed('user.{firstName,lastName', {
+    // Code
+  })
+});
+```
+
+```js
+export default Component.extend({
+  // Unnecessary braces:
+  userId: computed('user.{id}', {
     // Code
   })
 });
@@ -56,6 +65,14 @@ Examples of **correct** code for this rule:
 ```js
 export default Component.extend({
   fullName: computed('user.{firstName,lastName}', {
+    // Code
+  })
+});
+```
+
+```js
+export default Component.extend({
+  userId: computed('user.id', {
     // Code
   })
 });

--- a/lib/rules/no-invalid-dependent-keys.js
+++ b/lib/rules/no-invalid-dependent-keys.js
@@ -8,6 +8,7 @@ const ember = require('../utils/ember');
 //------------------------------------------------------------------------------
 
 const ERROR_MESSAGE_UNBALANCED_BRACES = 'Found unbalanced braces in dependent key';
+const ERROR_MESSAGE_UNNECESSARY_BRACES = 'Found unnecessary braces in dependent key';
 const ERROR_MESSAGE_TERMINAL_AT_EACH = 'Found terminal `@each`, use `[]` instead';
 const ERROR_MESSAGE_MIDDLE_BRACKETS = '`[]` should only be used at the end of the dependent key';
 
@@ -16,6 +17,11 @@ function hasUnbalancedBraces(str) {
   const openBraces = foundBraces.filter((c) => c === '{').length;
   const closeBraces = foundBraces.filter((c) => c === '}').length;
   return openBraces !== closeBraces;
+}
+
+const REGEXP_UNNECESSARY_BRACES = /{([^,.]+)}/g;
+function hasUnnecessaryBraces(str) {
+  return str.match(REGEXP_UNNECESSARY_BRACES);
 }
 
 function hasTerminalAtEach(str) {
@@ -41,6 +47,7 @@ module.exports = {
   },
 
   ERROR_MESSAGE_UNBALANCED_BRACES,
+  ERROR_MESSAGE_UNNECESSARY_BRACES,
   ERROR_MESSAGE_TERMINAL_AT_EACH,
   ERROR_MESSAGE_MIDDLE_BRACKETS,
 
@@ -73,6 +80,17 @@ module.exports = {
             context.report({
               node,
               message: ERROR_MESSAGE_UNBALANCED_BRACES,
+            });
+          }
+
+          if (hasUnnecessaryBraces(node.value)) {
+            context.report({
+              node,
+              message: ERROR_MESSAGE_UNNECESSARY_BRACES,
+              fix(fixer) {
+                const nodeText = sourceCode.getText(node);
+                return fixer.replaceText(node, nodeText.replace(REGEXP_UNNECESSARY_BRACES, '$1'));
+              },
             });
           }
 

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -3,6 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const {
   ERROR_MESSAGE_UNBALANCED_BRACES,
+  ERROR_MESSAGE_UNNECESSARY_BRACES,
   ERROR_MESSAGE_TERMINAL_AT_EACH,
   ERROR_MESSAGE_MIDDLE_BRACKETS,
 } = rule;
@@ -116,6 +117,28 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
           type: 'Literal',
           endLine: 1,
           endColumn: 142,
+        },
+      ],
+    },
+
+    // Unnecessary braces
+    {
+      code: '{ test: computed("foo.{bar}", function() {}) }',
+      output: '{ test: computed("foo.bar", function() {}) }',
+      errors: [
+        {
+          message: ERROR_MESSAGE_UNNECESSARY_BRACES,
+          type: 'Literal',
+        },
+      ],
+    },
+    {
+      code: '{ test: computed("foo.{bar}.{abc}", function() {}) }',
+      output: '{ test: computed("foo.bar.abc", function() {}) }',
+      errors: [
+        {
+          message: ERROR_MESSAGE_UNNECESSARY_BRACES,
+          type: 'Literal',
         },
       ],
     },


### PR DESCRIPTION
Before: `computed("foo.{bar}", function() {})`
After: `computed("foo.bar", function() {})`

Includes autofixer.