### PR TITLE
Add test for `no-replace-test-comments` rule with TODO-prefixed comment

### DIFF
--- a/tests/lib/rules/no-replace-test-comments.js
+++ b/tests/lib/rules/no-replace-test-comments.js
@@ -36,5 +36,16 @@ ruleTester.run('no-replace-test-comments', rule, {
         },
       ],
     },
+    {
+      filename: 'test/some-app-file-test.js',
+      code: '// TODO: Replace this with your real tests',
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'Line',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
The Ember blueprint was [updated](https://github.com/emberjs/ember.js/pull/18828) to add a `TODO:` prefix to this comment. The lint rule can still handle that.

Fixes #765.