### PR TITLE
WIP: failing test case for #769 - `no-legacy-test-waiters` incorrectly flagging registerHelper import

### DIFF
--- a/tests/lib/rules/no-legacy-test-waiters.js
+++ b/tests/lib/rules/no-legacy-test-waiters.js
@@ -36,6 +36,16 @@ ruleTester.run('no-legacy-test-waiters', rule, {
 
       unregisterWaiter();
     `,
+    `
+      import { registerHelper } from '@ember/test';
+
+      export default registerHelper('findAllContaining', function (app, selector, text) {
+        return [...document.querySelectorAll(selector)]
+          .filter((element) => {
+            return RegExp(text).test(element.textContent);
+          });
+      });
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
### What
- A failing test case to illustrate issue #769 