### PR TITLE
Catch spaces in `no-invalid-dependent-keys` rule

### DIFF
--- a/docs/rules/no-invalid-dependent-keys.md
+++ b/docs/rules/no-invalid-dependent-keys.md
@@ -17,10 +17,6 @@ Currently implemented checks:
 - Invalid position of `@each` or `[]`
 - Leading or trailing periods
 
-Not yet implemented checks:
-
-- Invalid characters
-
 ## Examples
 
 Examples of **incorrect** code for this rule:
@@ -65,6 +61,15 @@ export default Component.extend({
 export default Component.extend({
   // Leading period:
   userId: computed('.user.id', {
+    // Code
+  })
+});
+```
+
+```js
+export default Component.extend({
+  // Space:
+  userId: computed('user .id', {
     // Code
   })
 });

--- a/lib/rules/no-invalid-dependent-keys.js
+++ b/lib/rules/no-invalid-dependent-keys.js
@@ -12,6 +12,7 @@ const ERROR_MESSAGE_UNNECESSARY_BRACES = 'Found unnecessary braces in dependent 
 const ERROR_MESSAGE_TERMINAL_AT_EACH = 'Found terminal `@each`, use `[]` instead';
 const ERROR_MESSAGE_MIDDLE_BRACKETS = '`[]` should only be used at the end of the dependent key';
 const ERROR_MESSAGE_LEADING_TRAILING_PERIOD = 'Found leading or trailing period in dependent key';
+const ERROR_MESSAGE_INVALID_CHARACTER = 'Found invalid character in dependent key';
 
 function hasUnbalancedBraces(str) {
   const foundBraces = str.match(/[{}]/g) || [];
@@ -52,6 +53,7 @@ module.exports = {
   ERROR_MESSAGE_TERMINAL_AT_EACH,
   ERROR_MESSAGE_MIDDLE_BRACKETS,
   ERROR_MESSAGE_LEADING_TRAILING_PERIOD,
+  ERROR_MESSAGE_INVALID_CHARACTER,
 
   create(context) {
     return {
@@ -125,6 +127,17 @@ module.exports = {
               fix(fixer) {
                 const nodeText = sourceCode.getText(node);
                 return fixer.replaceText(node, removeLastOccurrenceOf(nodeText, '.'));
+              },
+            });
+          }
+
+          if (node.value.includes(' ')) {
+            context.report({
+              node,
+              message: ERROR_MESSAGE_INVALID_CHARACTER,
+              fix(fixer) {
+                const nodeText = sourceCode.getText(node);
+                return fixer.replaceText(node, nodeText.replace(/ /g, '')); // Remove all spaces.
               },
             });
           }

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -7,6 +7,7 @@ const {
   ERROR_MESSAGE_TERMINAL_AT_EACH,
   ERROR_MESSAGE_MIDDLE_BRACKETS,
   ERROR_MESSAGE_LEADING_TRAILING_PERIOD,
+  ERROR_MESSAGE_INVALID_CHARACTER,
 } = rule;
 
 // ------------------------------------------------------------------------------
@@ -185,6 +186,18 @@ eslintTester.run('no-invalid-dependent-keys', rule, {
       errors: [
         {
           message: ERROR_MESSAGE_LEADING_TRAILING_PERIOD,
+          type: 'Literal',
+        },
+      ],
+    },
+
+    // Spaces
+    {
+      code: 'computed(" foo . bar", function() {})',
+      output: 'computed("foo.bar", function() {})',
+      errors: [
+        {
+          message: ERROR_MESSAGE_INVALID_CHARACTER,
           type: 'Literal',
         },
       ],


### PR DESCRIPTION
Dependent keys should not have spaces in them.