### PR TITLE
WIP: Failing test case for #782

### DIFF
--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -95,6 +95,12 @@ ruleTester.run('require-computed-property-dependencies', rule, {
         return this.article.title + someFunction(this.article.comments.innerProperty);
       });
     `,
+    // Nesting after braces:
+    `
+      Ember.computed('article.{comments,title}.innerProperty', function() {
+        return this.article.title.innerProperty + someFunction(this.article.comments.innerProperty);
+      });
+    `,
     // Computed macro that should be ignored:
     `
       Ember.computed.someMacro(function() {


### PR DESCRIPTION
### What
failing test case for #782 

```javascript
Ember.computed('article.{comments,title}.innerProperty', function() {
  return this.article.title.innerProperty + someFunction(this.article.comments.innerProperty);
});
```
throws from `require-computed-property-dependencies`.

the auto-fixer will expand the keys, which causes `use-brace-expansion` to throw:
```javascript
Ember.computed('article.comments.innerProperty', 'article.title.innerProperty', function () {
  return this.article.title.innerProperty + someFunction(this.article.comments.innerProperty);
}),
```