### PR TITLE
Ignore the left side of an assignment in `require-computed-property-dependencies` rule

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -248,6 +248,7 @@ function findThisGetCalls(node) {
       if (
         types.isMemberExpression(child) &&
         !(types.isCallExpression(parent) && parent.callee === child) &&
+        !(types.isAssignmentExpression(child.parent) && child === parent.left) && // Ignore the left side (x) of an assignment: this.x = 123;
         propertyGetterUtils.isSimpleThisExpression(child)
       ) {
         results.push(child);

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -4,6 +4,7 @@ module.exports = {
   isAnyFunctionExpression,
   isArrayExpression,
   isArrowFunctionExpression,
+  isAssignmentExpression,
   isBinaryExpression,
   isCallExpression,
   isCallWithFunctionExpression,
@@ -67,6 +68,16 @@ function isArrayExpression(node) {
  */
 function isArrowFunctionExpression(node) {
   return node !== undefined && node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * Check whether or not a node is an AssignmentExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an AssignmentExpression.
+ */
+function isAssignmentExpression(node) {
+  return node.type === 'AssignmentExpression';
 }
 
 /**

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -136,6 +136,12 @@ ruleTester.run('require-computed-property-dependencies', rule, {
     `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    // Should ignore the left side of an assignment.
+    `
+      Ember.computed('right', function() {
+        this.left = this.right;
+      })
+    `,
     // Explicit getter function:
     {
       code: `
@@ -723,6 +729,25 @@ ruleTester.run('require-computed-property-dependencies', rule, {
       errors: [
         {
           message: 'Use of undeclared dependencies in computed property: intl',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      // Should ignore the left side of an assignment but not the right side.
+      code: `
+        Ember.computed(function() {
+          this.left = this.right;
+        })
+      `,
+      output: `
+        Ember.computed('right', function() {
+          this.left = this.right;
+        })
+      `,
+      errors: [
+        {
+          message: 'Use of undeclared dependencies in computed property: right',
           type: 'CallExpression',
         },
       ],


### PR DESCRIPTION
The left side of an assignment (`this.x =`) should be ignored when determining what the dependent keys for a computed property should be.

```js
// x should not be a dependent key
Ember.computed(function() {
  this.x = true; 
})
```

Fixes #785. CC: @boris-petrov.