### PR TITLE
Add decorator support to `no-side-effects` rule

### DIFF
--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -2,9 +2,14 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
-Don't introduce side-effects in computed properties.
+When using computed properties, do not introduce side effects. Side effects make it much more difficult to reason about the origin of changes.
 
-When using computed properties do not introduce side effects. It will make reasoning about the origin of the change much harder.
+This rule currently disallows the following side-effect-causing statements inside computed properties:
+
+* `this.set('x', 123);`
+* `this.setProperties({ x: 123 });`
+
+Note that other side effects like network requests should be avoided as well.
 
 ## Examples
 
@@ -35,9 +40,3 @@ export default Component.extend({
   })
 });
 ```
-
-## Help Wanted
-
-| Issue | Link |
-| :-- | :-- |
-| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -2,6 +2,9 @@
 
 const types = require('../utils/types');
 const ember = require('../utils/ember');
+const computedPropertyUtils = require('../utils/computed-properties');
+const emberUtils = require('../utils/ember');
+const Traverser = require('../utils/traverser');
 
 //------------------------------------------------------------------------------
 // General rule - Don't introduce side-effects in computed properties
@@ -9,6 +12,40 @@ const ember = require('../utils/ember');
 
 function isUnallowedMethod(name) {
   return ['set', 'setProperties'].includes(name);
+}
+
+function isEmberSet(node, emberImportAliasName) {
+  const callee = node.callee;
+  return (
+    (types.isIdentifier(callee) && isUnallowedMethod(callee.name)) ||
+    (types.isMemberExpression(callee) &&
+      (types.isThisExpression(callee.object) ||
+        callee.object.name === 'Ember' ||
+        callee.object.name === emberImportAliasName) &&
+      types.isIdentifier(callee.property) &&
+      isUnallowedMethod(callee.property.name))
+  );
+}
+
+/**
+ * Recursively finds calls that could be side effects in a computed property function body.
+ *
+ * @param {ASTNode} computedPropertyBody body of computed property to search
+ * @param {string} emberImportAliasName
+ * @returns {Array<ASTNode>}
+ */
+function findSideEffects(computedPropertyBody, emberImportAliasName) {
+  const results = [];
+
+  new Traverser().traverse(computedPropertyBody, {
+    enter(child) {
+      if (isEmberSet(child, emberImportAliasName)) {
+        results.push(child);
+      }
+    },
+  });
+
+  return results;
 }
 
 const ERROR_MESSAGE = "Don't introduce side-effects in computed properties";
@@ -44,33 +81,13 @@ module.exports = {
       },
 
       CallExpression(node) {
-        const callee = node.callee;
-        const isEmberSet =
-          (types.isIdentifier(callee) && isUnallowedMethod(callee.name)) ||
-          (types.isMemberExpression(callee) &&
-            (types.isThisExpression(callee.object) ||
-              callee.object.name === 'Ember' ||
-              callee.object.name === emberImportAliasName) &&
-            types.isIdentifier(callee.property) &&
-            isUnallowedMethod(callee.property.name));
-
-        if (isEmberSet) {
-          const ancestors = context.getAncestors();
-          const computedIndex = ancestors.findIndex(ember.isComputedProp);
-          const setPropertyFunctionIndex = ancestors.findIndex(
-            (ancestor) =>
-              ancestor.type === 'Property' &&
-              ancestor.key.name === 'set' &&
-              types.isFunctionExpression(ancestor.value)
-          );
-
-          if (
-            computedIndex > -1 &&
-            (setPropertyFunctionIndex === -1 || setPropertyFunctionIndex < computedIndex)
-          ) {
-            report(node);
-          }
+        if (!emberUtils.isComputedProp(node)) {
+          return;
         }
+
+        const computedPropertyBody = computedPropertyUtils.getComputedPropertyFunctionBody(node);
+
+        findSideEffects(computedPropertyBody, emberImportAliasName).forEach(report);
       },
     };
   },

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -1,18 +1,6 @@
 'use strict';
 
-function getTraverser() {
-  let traverser;
-  try {
-    // eslint-disable-next-line node/no-unpublished-require
-    traverser = require('eslint/lib/shared/traverser'); // eslint >= 6
-  } catch (error) {
-    // eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
-    traverser = require('eslint/lib/util/traverser'); // eslint < 6
-  }
-  return traverser;
-}
-
-const Traverser = getTraverser();
+const Traverser = require('../utils/traverser');
 const emberUtils = require('../utils/ember');
 const computedPropertyUtils = require('../utils/computed-properties');
 const types = require('../utils/types');

--- a/lib/utils/traverser.js
+++ b/lib/utils/traverser.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = getTraverser;
+
+function getTraverser() {
+  let traverser;
+  try {
+    // eslint-disable-next-line node/no-unpublished-require
+    traverser = require('eslint/lib/shared/traverser'); // eslint >= 6
+  } catch (error) {
+    // eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
+    traverser = require('eslint/lib/util/traverser'); // eslint < 6
+  }
+  return traverser;
+}


### PR DESCRIPTION
This is a major refactor/simplification of the [no-side-effects](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-side-effects.md) rule in order to support decorators and other future improvements.

Helps with #560 #566.