### PR TITLE
Handle braces without nesting in `require-computed-property-dependencies` rule

### DIFF
--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -90,7 +90,7 @@ function expandKey(key) {
           ),
         [[]]
       ) // [["foo", "bar"], ["foo", "baz"]]
-      .map((expanded) => expanded.join('.')); // ["foo.bar", "foo.baz"]
+      .map((expanded) => expanded.filter((part) => part !== '').join('.')); // ["foo.bar", "foo.baz"]
   } else {
     // No braces.
     // Example: "hello.world"

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -95,6 +95,12 @@ ruleTester.run('require-computed-property-dependencies', rule, {
         return this.article.title + someFunction(this.article.comments.innerProperty);
       });
     `,
+    // Braces but no nesting:
+    `
+      Ember.computed('{foo,bar}', function() {
+        return this.get('foo') + this.get('bar');
+      });
+    `,
     // Computed macro that should be ignored:
     `
       Ember.computed.someMacro(function() {

--- a/tests/lib/utils/computed-property-dependent-keys-test.js
+++ b/tests/lib/utils/computed-property-dependent-keys-test.js
@@ -32,5 +32,6 @@ describe('expandKey', () => {
       'foo.@each.bar1',
       'foo.@each.bar2',
     ]);
+    expect(cpdkUtils.expandKey('{foo,bar}')).toStrictEqual(['foo', 'bar']);
   });
 });


### PR DESCRIPTION
Fixes #792.