### PR TITLE
Disallow accessing `_routerMicrolib` in `no-private-routing-service` rule

### DIFF
--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -2,7 +2,7 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
-Disallow the use of the private `-routing` service.
+Disallow the use of the private `-routing` service and accessing `_routerMicrolib`.
 
 There has been a public `router` service since Ember 2.16 and using the private routing service should be unnecessary.
 
@@ -24,6 +24,18 @@ import Component from '@ember/component';
 
 export default class MyComponent extends Component {
   @service('-routing') routing;
+}
+```
+
+```javascript
+import Component from '@ember/component';
+
+export default class MyComponent extends Component {
+  @service('router') router;
+
+  get someMethod() {
+    return this.router._routerMicrolib.activeTransition;
+  }
 }
 ```
 

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -7,8 +7,10 @@ const types = require('../utils/types');
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE =
+const PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE =
   "Don't inject the private '-routing' service. Instead use the public 'router' service.";
+
+const ROUTER_MICROLIB_ERROR_MESSAGE = "Don't access the `_routerMicrolib` as it is private API";
 
 module.exports = {
   meta: {
@@ -24,10 +26,12 @@ module.exports = {
     schema: [],
   },
 
-  ERROR_MESSAGE,
+  PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE,
+  ROUTER_MICROLIB_ERROR_MESSAGE,
 
   create(context) {
     const ROUTING_SERVICE_NAME = '-routing';
+    const ROUTER_MICROLIB_NAME = '_routerMicrolib';
 
     return {
       Property(node) {
@@ -36,9 +40,10 @@ module.exports = {
           node.value.arguments.length > 0 &&
           node.value.arguments[0].value === ROUTING_SERVICE_NAME
         ) {
-          context.report({ node, message: ERROR_MESSAGE });
+          context.report({ node, message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE });
         }
       },
+
       ClassProperty(node) {
         if (!node.decorators || !types.isClassPropertyWithDecorator(node, 'service')) {
           return;
@@ -55,7 +60,19 @@ module.exports = {
         });
 
         if (hasRoutingServiceDecorator) {
-          context.report({ node, message: ERROR_MESSAGE });
+          context.report({ node, message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE });
+        }
+      },
+
+      Literal(node) {
+        if (typeof node.value === 'string' && node.value.includes(ROUTER_MICROLIB_NAME)) {
+          context.report({ node, message: ROUTER_MICROLIB_ERROR_MESSAGE });
+        }
+      },
+
+      Identifier(node) {
+        if (node.name === ROUTER_MICROLIB_NAME) {
+          context.report({ node, message: ROUTER_MICROLIB_ERROR_MESSAGE });
         }
       },
     };

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -5,7 +5,7 @@
 const rule = require('../../../lib/rules/no-private-routing-service');
 const RuleTester = require('eslint').RuleTester;
 
-const { ERROR_MESSAGE } = rule;
+const { PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, ROUTER_MICROLIB_ERROR_MESSAGE } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -56,14 +56,36 @@ ruleTester.run('no-private-routing-service', rule, {
     {
       code: "export default Component.extend({ routing: service('-routing') });",
       output: null,
-      errors: [{ message: ERROR_MESSAGE, type: 'Property' }],
+      errors: [{ message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, type: 'Property' }],
     },
 
     // Octane
     {
       code: "export default class MyComponent extends Component { @service('-routing') routing; }",
       output: null,
-      errors: [{ message: ERROR_MESSAGE, type: 'ClassProperty' }],
+      errors: [{ message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, type: 'ClassProperty' }],
+    },
+
+    // _routerMicrolib
+    {
+      code: "get(this, 'router._routerMicrolib');",
+      output: null,
+      errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
+    },
+    {
+      code: "get(this, 'router._router._routerMicrolib');",
+      output: null,
+      errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
+    },
+    {
+      code: 'this.router._routerMicrolib;',
+      output: null,
+      errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
+    },
+    {
+      code: 'this.router._router._routerMicrolib;',
+      output: null,
+      errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
     },
   ],
 });


### PR DESCRIPTION
Fixes 1/2 of #762

Disallows accessing private `_routerMicrolib`. Note this rule disallows any identifier to be called `_routerMicrolib`, which is simpler and faster to run over checking whether the Identifier's parent is `router`.