### PR TITLE
Remove duplicate example from `no-observers` rule doc

### DIFF
--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -30,16 +30,6 @@ export default Controller.extend({
 ```
 
 ```js
-import { observer } from '@ember/object';
-
-export default Controller.extend({
-  change: observer('text', function () {
-    console.log(`change detected: ${this.text}`);
-  })
-});
-```
-
-```js
 import { observes } from '@ember-decorators/object';
 
 class FooComponent extends Component {


### PR DESCRIPTION
I just realized that there are duplicates examples of **incorrect** code for `no-observers` rule. This PR is just removing one of them.