### PR TITLE
Ignore `mirage/config.js` file in `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -18,6 +18,8 @@ This rule disallows:
 * Ember proxy objects (`ObjectProxy`, `ArrayProxy`)
 * Objects implementing the `unknownProperty` method
 
+In addition, `mirage/config.js` will be excluded from this rule.
+
 ## Examples
 
 Examples of **incorrect** code for this rule:

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 
@@ -53,6 +54,19 @@ module.exports = {
 
     let currentProxyObject = null;
     let currentClassWithUnknownPropertyMethod = null;
+
+    const filename = context.getFilename();
+
+    function isFileInDirectory(dirname) {
+      const pathParts = filename.split(path.sep);
+      return pathParts.includes(dirname);
+    }
+
+    const directoriesToSkipCompletely = ['mirage'];
+
+    if (directoriesToSkipCompletely.some((dir) => isFileInDirectory(dir))) {
+      return {};
+    }
 
     return {
       'CallExpression:exit'(node) {

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -57,7 +57,7 @@ module.exports = {
     const filename = context.getFilename();
 
     // Skip mirage directory
-    if (emberUtils.isMirageDirectory(filename)) {
+    if (emberUtils.isMirageConfig(filename)) {
       return {};
     }
 

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 
@@ -57,14 +56,8 @@ module.exports = {
 
     const filename = context.getFilename();
 
-    function isFileInDirectory(dirname) {
-      const pathParts = filename.split(path.sep);
-      return pathParts.includes(dirname);
-    }
-
-    const directoriesToSkipCompletely = ['mirage'];
-
-    if (directoriesToSkipCompletely.some((dir) => isFileInDirectory(dir))) {
+    // Skip mirage directory
+    if (emberUtils.isMirageDirectory(filename)) {
       return {};
     }
 

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const ember = require('../utils/ember');
 const utils = require('../utils/utils');
 const types = require('../utils/types');
@@ -51,11 +50,6 @@ module.exports = {
     const options = context.options[0] || {};
     const message = 'Use get/set';
 
-    function isFileInDirectory(dirname) {
-      const pathParts = filename.split(path.sep);
-      return pathParts.includes(dirname);
-    }
-
     function report(node) {
       context.report({
         node: node.callee.property,
@@ -88,9 +82,8 @@ module.exports = {
 
     const testMethodsToSkip = new Set(['get', 'set']);
 
-    const directoriesToSkipCompletely = ['mirage'];
-
-    if (directoriesToSkipCompletely.some((dir) => isFileInDirectory(dir))) {
+    // Skip mirage directory
+    if (ember.isMirageDirectory(filename)) {
       return {};
     }
 
@@ -121,7 +114,7 @@ module.exports = {
 
         // Skip this.get() and this.set() in tests/
         if (
-          isFileInDirectory('tests') &&
+          ember.isTestFile(filename) &&
           isThisExpression(callee.object) &&
           isIdentifier(method) &&
           testMethodsToSkip.has(method.name)

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -11,6 +11,7 @@ module.exports = {
   isModule,
   isModuleByFilePath,
   isMirageDirectory,
+  isMirageConfig,
   isTestFile,
 
   isEmberCoreModule,
@@ -169,6 +170,10 @@ function isTestFile(fileName) {
 function isMirageDirectory(fileName) {
   const pathParts = fileName.split(path.sep);
   return pathParts.includes('mirage');
+}
+
+function isMirageConfig(fileName) {
+  return fileName.endsWith(path.join('mirage', 'config.js'));
 }
 
 function isEmberObject(node) {

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const utils = require('./utils');
 const importUtils = require('./import');
 const types = require('./types');
@@ -9,6 +10,7 @@ module.exports = {
   isDSModel,
   isModule,
   isModuleByFilePath,
+  isMirageDirectory,
   isTestFile,
 
   isEmberCoreModule,
@@ -162,6 +164,11 @@ function isModuleByFilePath(filePath, module) {
 
 function isTestFile(fileName) {
   return fileName.endsWith('-test.js') || fileName.endsWith('-test.ts');
+}
+
+function isMirageDirectory(fileName) {
+  const pathParts = fileName.split(path.sep);
+  return pathParts.includes('mirage');
 }
 
 function isEmberObject(node) {

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const rule = require('../../../lib/rules/no-get');
 const RuleTester = require('eslint').RuleTester;
 
@@ -51,6 +52,12 @@ ruleTester.run('no-get', rule, {
     // Unknown sub-function call:
     "this.get.foo('bar');",
     "get.foo(this, 'bar');",
+
+    // In mirage directory
+    {
+      code: 'this.get("/resources")',
+      filename: path.join('app', 'mirage', 'config.js'),
+    },
 
     // **************************
     // getProperties

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -101,6 +101,19 @@ describe('isMirageDirectory', () => {
   });
 });
 
+describe('isMirageConfig', () => {
+  it('detects the mirage config file', () => {
+    expect(emberUtils.isMirageConfig('example-app/mirage/config.js')).toBeTruthy();
+  });
+
+  it('does not detect other directories', () => {
+    expect(emberUtils.isMirageConfig('example-app/app/app.js')).toBeFalsy();
+    expect(emberUtils.isMirageConfig('example-app/tests/test.js')).toBeFalsy();
+    expect(emberUtils.isMirageConfig('example-addon/addon/addon.js')).toBeFalsy();
+    expect(emberUtils.isMirageConfig('example-app/mirage/scenarios/foo.js')).toBeFalsy();
+  });
+});
+
 describe('isTestFile', () => {
   it('detects test files', () => {
     expect(emberUtils.isTestFile('some-test.js')).toBeTruthy();

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -88,6 +88,19 @@ describe('isModuleByFilePath', () => {
   });
 });
 
+describe('isMirageDirectory', () => {
+  it('detects the mirage directory', () => {
+    expect(emberUtils.isMirageDirectory('example-app/mirage/config.js')).toBeTruthy();
+    expect(emberUtils.isMirageDirectory('example-app/mirage/scenarios/foo.js')).toBeTruthy();
+  });
+
+  it('does not detect other directories', () => {
+    expect(emberUtils.isMirageDirectory('example-app/app/app.js')).toBeFalsy();
+    expect(emberUtils.isMirageDirectory('example-app/tests/test.js')).toBeFalsy();
+    expect(emberUtils.isMirageDirectory('example-addon/addon/addon.js')).toBeFalsy();
+  });
+});
+
 describe('isTestFile', () => {
   it('detects test files', () => {
     expect(emberUtils.isTestFile('some-test.js')).toBeTruthy();


### PR DESCRIPTION
I've noticed the latest `plugin:ember/recommended` rules want to auto fix the following mirage route handler

```js
this.get('resource')

// auto fixes to..

this.resource
```

I saw the `use-ember-get-and-set` rule does something similar.

https://github.com/ember-cli/eslint-plugin-ember/blob/5645fdd4859aa230c8d46dd63a6880e9bc244cb7/lib/rules/use-ember-get-and-set.js#L91-L95

I'm happy to create a seperate `skipDirectories()` utility function, or similar, if this is the right approach