### PR TITLE
Move new functionality behind `catchRouterMicrolib` option on `no-private-routing-service` rule

### DIFF
--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -2,7 +2,10 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
-Disallow the use of the private `-routing` service and accessing `_routerMicrolib`.
+Disallow the use of:
+
+* The private `-routing` service
+* The private `_routerMicrolib` property (when the `catchRouterMicrolib` option is enabled)
 
 There has been a public `router` service since Ember 2.16 and using the private routing service should be unnecessary.
 
@@ -28,6 +31,8 @@ export default class MyComponent extends Component {
 ```
 
 ```javascript
+// When `catchRouterMicrolib` option is enabled.
+
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
@@ -58,6 +63,12 @@ export default class MyComponent extends Component {
   router;
 }
 ```
+
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `false`) (TODO: enable this by default in the next major release)
 
 ## References
 

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -23,7 +23,18 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-private-routing-service.md',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          catchRouterMicrolib: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE,
@@ -32,6 +43,9 @@ module.exports = {
   create(context) {
     const ROUTING_SERVICE_NAME = '-routing';
     const ROUTER_MICROLIB_NAME = '_routerMicrolib';
+
+    const options = context.options[0] || {};
+    const catchRouterMicrolib = options.catchRouterMicrolib || false;
 
     return {
       Property(node) {
@@ -65,13 +79,17 @@ module.exports = {
       },
 
       Literal(node) {
-        if (typeof node.value === 'string' && node.value.includes(ROUTER_MICROLIB_NAME)) {
+        if (
+          catchRouterMicrolib &&
+          typeof node.value === 'string' &&
+          node.value.includes(ROUTER_MICROLIB_NAME)
+        ) {
           context.report({ node, message: ROUTER_MICROLIB_ERROR_MESSAGE });
         }
       },
 
       Identifier(node) {
-        if (node.name === ROUTER_MICROLIB_NAME) {
+        if (catchRouterMicrolib && node.name === ROUTER_MICROLIB_NAME) {
           context.report({ node, message: ROUTER_MICROLIB_ERROR_MESSAGE });
         }
       },

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -50,6 +50,10 @@ ruleTester.run('no-private-routing-service', rule, {
     'class MyComponent extends Component { aProp="-routing"; }',
     'class MyComponent extends Component { aProp="another value"; }',
     'class MyComponent extends Component { anIntProp=25; }',
+
+    // _routerMicrolib (`catchRouterMicrolib` option off)
+    "get(this, 'router._routerMicrolib');",
+    'this.router._routerMicrolib;',
   ],
   invalid: [
     // Classic
@@ -66,25 +70,29 @@ ruleTester.run('no-private-routing-service', rule, {
       errors: [{ message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, type: 'ClassProperty' }],
     },
 
-    // _routerMicrolib
+    // _routerMicrolib (`catchRouterMicrolib` option on)
     {
       code: "get(this, 'router._routerMicrolib');",
       output: null,
+      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: "get(this, 'router._router._routerMicrolib');",
       output: null,
+      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.router._routerMicrolib;',
       output: null,
+      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
     },
     {
       code: 'this.router._router._routerMicrolib;',
       output: null,
+      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
     },
   ],


### PR DESCRIPTION
Follow-up to #795 so that this new behavior won't be a breaking change. CC: @nlfurniss.