### PR TITLE
Fix false negative when aliasing import in `prefer-ember-test-helpers` rule

### DIFF
--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -37,17 +37,17 @@ module.exports = {
       return {};
     }
 
-    let hasBlurFunction = undefined;
-    let hasFindFunction = undefined;
-    let hasFocusFunction = undefined;
+    let seenBlurFunctionName = undefined;
+    let seenFindFunctionName = undefined;
+    let seenFocusFunctionName = undefined;
 
     const markMethodsAsPresent = (fnName) => {
       if (fnName === 'blur') {
-        hasBlurFunction = true;
+        seenBlurFunctionName = 'blur';
       } else if (fnName === 'find') {
-        hasFindFunction = true;
+        seenFindFunctionName = 'find';
       } else if (fnName === 'focus') {
-        hasFocusFunction = true;
+        seenFocusFunctionName = 'focus';
       }
     };
 
@@ -61,9 +61,9 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        hasBlurFunction = getImportName(node, 'blur');
-        hasFindFunction = getImportName(node, 'find');
-        hasFocusFunction = getImportName(node, 'focus');
+        seenBlurFunctionName = getImportName(node, 'blur');
+        seenFindFunctionName = getImportName(node, 'find');
+        seenFocusFunctionName = getImportName(node, 'focus');
       },
       FunctionDeclaration(node) {
         const fnName = node.id.name;
@@ -89,24 +89,30 @@ module.exports = {
         }
       },
       CallExpression(node) {
-        if (!hasBlurFunction) {
-          if (node.callee.name === 'blur') {
-            showErrorMessage(node, 'blur');
-          }
+        if (isDisallowed('blur', seenBlurFunctionName, node.callee.name)) {
+          showErrorMessage(node, 'blur');
         }
 
-        if (!hasFindFunction) {
-          if (node.callee.name === 'find') {
-            showErrorMessage(node, 'find');
-          }
+        if (isDisallowed('find', seenFindFunctionName, node.callee.name)) {
+          showErrorMessage(node, 'find');
         }
 
-        if (!hasFocusFunction) {
-          if (node.callee.name === 'focus') {
-            showErrorMessage(node, 'focus');
-          }
+        if (isDisallowed('focus', seenFocusFunctionName, node.callee.name)) {
+          showErrorMessage(node, 'focus');
         }
       },
     };
   },
 };
+
+function isDisallowed(targetFunctionName, seenFunctionName, currentFunctionName) {
+  // Examples of disallowed scenarios:
+  // * `blur` not imported nor defined, but `blur` function called
+  // * `blur` imported as `blur123`, but `blur` function called
+  return (
+    (!seenFunctionName && currentFunctionName === targetFunctionName) ||
+    (seenFunctionName &&
+      seenFunctionName !== targetFunctionName &&
+      currentFunctionName === targetFunctionName)
+  );
+}

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -256,5 +256,54 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
         },
       ],
     },
+
+    {
+      // Aliased relevant import but didn't use it.
+      filename: TEST_FILE_NAME,
+      code: `
+      import { blur as myBlurName } from '@ember/test-helpers';
+      test('foo', async (assert) => {
+        await blur('.some-element');
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `blur()` method from @ember/test-helpers',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      // Aliased relevant import but didn't use it.
+      filename: TEST_FILE_NAME,
+      code: `
+      import { find as myFindName } from '@ember/test-helpers';
+      test('foo', async (assert) => {
+        await find('.some-element');
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `find()` method from @ember/test-helpers',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      // Aliased relevant import but didn't use it.
+      filename: TEST_FILE_NAME,
+      code: `
+      import { focus as myFocusName } from '@ember/test-helpers';
+      test('foo', async (assert) => {
+        await focus('.some-element');
+      });`,
+      output: null,
+      errors: [
+        {
+          message: 'Import the `focus()` method from @ember/test-helpers',
+          type: 'CallExpression',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Catches this new invalid test case:

```js
import { blur as myBlurName } from '@ember/test-helpers';

test('foo', async (assert) => {
  await blur('.some-element');
});
```

CC: @fierysunset