### PR TITLE
Fix false positive with multiple imports in `prefer-ember-test-helpers` rule

### DIFF
--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -1,19 +1,31 @@
 'use strict';
 
 const emberUtils = require('../utils/ember');
+const assert = require('assert');
 
-const getImportName = (node, namedImportIdentifier) => {
-  return node.specifiers
-    .filter((specifier) => {
-      return (
-        (specifier.type === 'ImportSpecifier' &&
-          specifier.imported.name === namedImportIdentifier) ||
-        (!namedImportIdentifier && specifier.type === 'ImportDefaultSpecifier')
-      );
-    })
-    .map((specifier) => specifier.local.name)
-    .pop();
-};
+/**
+ * Check if an identifier is being imported from an ImportDeclaration node.
+ *
+ * Examples where the identifier name 'foo' is being imported from the ImportDeclaration node:
+ * * import foo from 'bar';
+ * * import { foo } from 'bar';
+ * * import { something as foo } from 'bar';
+ *
+ * @param {node} importDeclaration - the ImportDeclaration node to check
+ * @param {string} identifierName - the identifier name we are checking for
+ */
+function hasImportedIdentifier(importDeclaration, identifierName) {
+  assert(
+    importDeclaration.type === 'ImportDeclaration',
+    'parameter should be an ImportDeclaration'
+  );
+  assert(typeof identifierName === 'string', 'parameter should be a string');
+  return (
+    importDeclaration.specifiers.find((specifier) => {
+      return specifier.local.name === identifierName;
+    }) !== undefined
+  );
+}
 
 //-------------------------------------------------------------------------------------
 // Rule Definition
@@ -37,17 +49,17 @@ module.exports = {
       return {};
     }
 
-    let seenBlurFunctionName = undefined;
-    let seenFindFunctionName = undefined;
-    let seenFocusFunctionName = undefined;
+    let hasDefinedBlurFunction = false;
+    let hasDefinedFindFunction = false;
+    let hasDefinedFocusFunction = false;
 
     const markMethodsAsPresent = (fnName) => {
       if (fnName === 'blur') {
-        seenBlurFunctionName = 'blur';
+        hasDefinedBlurFunction = true;
       } else if (fnName === 'find') {
-        seenFindFunctionName = 'find';
+        hasDefinedFindFunction = true;
       } else if (fnName === 'focus') {
-        seenFocusFunctionName = 'focus';
+        hasDefinedFocusFunction = true;
       }
     };
 
@@ -61,9 +73,17 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        seenBlurFunctionName = getImportName(node, 'blur');
-        seenFindFunctionName = getImportName(node, 'find');
-        seenFocusFunctionName = getImportName(node, 'focus');
+        if (hasImportedIdentifier(node, 'blur')) {
+          hasDefinedBlurFunction = true;
+        }
+
+        if (hasImportedIdentifier(node, 'find')) {
+          hasDefinedFindFunction = true;
+        }
+
+        if (hasImportedIdentifier(node, 'focus')) {
+          hasDefinedFocusFunction = true;
+        }
       },
       FunctionDeclaration(node) {
         const fnName = node.id.name;
@@ -89,15 +109,19 @@ module.exports = {
         }
       },
       CallExpression(node) {
-        if (isDisallowed('blur', seenBlurFunctionName, node.callee.name)) {
+        if (node.callee.type !== 'Identifier') {
+          return;
+        }
+
+        if (isGlobalFunctionCall(node.callee.name, 'blur', hasDefinedBlurFunction)) {
           showErrorMessage(node, 'blur');
         }
 
-        if (isDisallowed('find', seenFindFunctionName, node.callee.name)) {
+        if (isGlobalFunctionCall(node.callee.name, 'find', hasDefinedFindFunction)) {
           showErrorMessage(node, 'find');
         }
 
-        if (isDisallowed('focus', seenFocusFunctionName, node.callee.name)) {
+        if (isGlobalFunctionCall(node.callee.name, 'focus', hasDefinedFocusFunction)) {
           showErrorMessage(node, 'focus');
         }
       },
@@ -105,14 +129,17 @@ module.exports = {
   },
 };
 
-function isDisallowed(targetFunctionName, seenFunctionName, currentFunctionName) {
-  // Examples of disallowed scenarios:
-  // * `blur` not imported nor defined, but `blur` function called
-  // * `blur` imported as `blur123`, but `blur` function called
-  return (
-    (!seenFunctionName && currentFunctionName === targetFunctionName) ||
-    (seenFunctionName &&
-      seenFunctionName !== targetFunctionName &&
-      currentFunctionName === targetFunctionName)
-  );
+/**
+ * Check to see if a function call is calling a specific global function.
+ * (i.e. `blur` not imported nor defined, but `blur` function called)
+ *
+ * @param {string} currentFnName - the name of the current function call
+ * @param {string} targetFnName - name of relevant function we're checking for
+ * @param {boolean} hasDefinedTargetFunction - whether we have seen the target function defined or imported
+ */
+function isGlobalFunctionCall(currentFnName, targetFnName, hasDefinedTargetFunction) {
+  assert(typeof currentFnName === 'string', 'parameter should be a string');
+  assert(typeof targetFnName === 'string', 'parameter should be a string');
+  assert(typeof hasDefinedTargetFunction === 'boolean', 'parameter should be a boolean');
+  return currentFnName === targetFnName && !hasDefinedTargetFunction;
 }

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -40,7 +40,9 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Ember test helper method properly imported
     {
       filename: TEST_FILE_NAME,
-      code: `import { blur } from '@ember/test-helpers';
+      code: `
+      import { blur } from '@ember/test-helpers';
+      import foo1, { foo2 } from 'bar';
 
       test('foo', async (assert) => {
         await blur('.some-element');
@@ -48,7 +50,9 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
-      code: `import { find } from '@ember/test-helpers';
+      code: `
+      import { find } from '@ember/test-helpers';
+      import foo1, { foo2 } from 'bar';
 
       test('foo', async (assert) => {
         await find('.some-element');
@@ -56,7 +60,9 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
-      code: `import { focus } from '@ember/test-helpers';
+      code: `
+      import { focus } from '@ember/test-helpers';
+      import foo1, { foo2 } from 'bar';
 
       test('foo', async (assert) => {
         await focus('.some-element');
@@ -138,20 +144,47 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Method imported from any source
     {
       filename: TEST_FILE_NAME,
-      code: `import { blur } from 'irrelevant-import-path';
-
+      code: `import blur from 'irrelevant-import-path';
       blur('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
-      code: `import { find } from 'irrelevant-import-path';
-
+      code: `import { blur } from 'irrelevant-import-path';
+      blur('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: `import { something as blur } from 'irrelevant-import-path';
+      blur('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: `import find from 'irrelevant-import-path';
       find('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      code: `import { find } from 'irrelevant-import-path';
+      find('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: `import { something as find } from 'irrelevant-import-path';
+      find('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: `import focus from 'irrelevant-import-path';
+      focus('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
       code: `import { focus } from 'irrelevant-import-path';
-
+      focus('.some-element');`,
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: `import { something as focus } from 'irrelevant-import-path';
       focus('.some-element');`,
     },
 


### PR DESCRIPTION
This should be a valid test case:

```js
import { blur } from '@ember/test-helpers';
import foo1, { foo2 } from 'bar';

test('foo', async (assert) => {
  await blur('.some-element');
});
```

Having multiple imports was causing the rule to incorrectly report a violation. The issue was that each time the rule saw an import statement, it would lose track of the previous import state.

Fixes #811. CC: @pfernandom, @GabrielCousin, @fierysunset.