### PR TITLE
Upgrade to eslint 7 internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,17 +4,9 @@ module.exports = {
   root: true,
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'script'
+    sourceType: 'script',
   },
-  plugins: [
-    'eslint-plugin',
-    'filenames',
-    'import',
-    'jest',
-    'node',
-    'prettier',
-    'unicorn'
-  ],
+  plugins: ['eslint-plugin', 'filenames', 'import', 'jest', 'node', 'prettier', 'unicorn'],
   extends: [
     'eslint:recommended',
     'plugin:eslint-comments/recommended',
@@ -25,7 +17,7 @@ module.exports = {
     'plugin:import/warnings',
     'plugin:node/recommended',
     'plugin:unicorn/recommended',
-    'prettier'
+    'prettier',
   ],
   env: {
     es6: true,
@@ -40,6 +32,7 @@ module.exports = {
     'consistent-return': 'error',
     curly: 'error',
     'default-case': 'error',
+    'default-case-last': 'error',
     eqeqeq: 'error',
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
@@ -65,6 +58,7 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-unused-expressions': 'error',
     'no-use-before-define': ['error', 'nofunc'],
+    'no-useless-backreference': 'error',
     'no-useless-call': 'error',
     'no-useless-catch': 'error',
     'no-useless-computed-key': 'error',
@@ -83,7 +77,7 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    'quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }], // Disallow unnecessary template literals.
+    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }], // Disallow unnecessary template literals.
     radix: 'error',
     'require-atomic-updates': 'error',
     'require-await': 'error',
@@ -100,13 +94,17 @@ module.exports = {
     // eslint-plugin rules:
     'eslint-plugin/consistent-output': ['error', 'always'],
     'eslint-plugin/no-deprecated-report-api': 'off',
-    'eslint-plugin/require-meta-docs-url': ['error', {
-      pattern: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/{{name}}.md',
-    }],
+    'eslint-plugin/require-meta-docs-url': [
+      'error',
+      {
+        pattern:
+          'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/{{name}}.md',
+      },
+    ],
     'eslint-plugin/test-case-property-ordering': 'off',
 
     // Filenames:
-    'filenames/match-regex': ['error', '^[a-z0-9-]+$'], // Kebab-case.
+    'filenames/match-regex': ['error', '^.?[a-z0-9-]+$'], // Kebab-case.
 
     // Optional jest rules:
     'jest/consistent-test-it': 'error',
@@ -127,31 +125,31 @@ module.exports = {
     'jest/valid-title': 'error',
 
     // Optional import rules:
-    'import/extensions': 'error',
-    'import/first': 'error',
-    'import/newline-after-import': 'error',
-    'import/no-absolute-path': 'error',
-    'import/no-cycle': 'error',
-    'import/no-deprecated': 'error',
-    'import/no-dynamic-require': 'error',
-    'import/no-mutable-exports': 'error',
-    'import/no-named-default': 'error',
-    'import/no-self-import': 'error',
-    'import/no-unassigned-import': 'error',
-    'import/no-unused-modules': 'error',
-    'import/no-useless-path-segments': 'error',
-    'import/no-webpack-loader-syntax': 'error',
+    'import/extensions': 'error',
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-absolute-path': 'error',
+    'import/no-cycle': 'error',
+    'import/no-deprecated': 'error',
+    'import/no-dynamic-require': 'error',
+    'import/no-mutable-exports': 'error',
+    'import/no-named-default': 'error',
+    'import/no-self-import': 'error',
+    'import/no-unassigned-import': 'error',
+    'import/no-unused-modules': 'error',
+    'import/no-useless-path-segments': 'error',
+    'import/no-webpack-loader-syntax': 'error',
     'import/unambiguous': 'error',
 
     // Unicorn rules:
     'unicorn/no-fn-reference-in-iterator': 'off',
     'unicorn/no-null': 'off',
-    'unicorn/prevent-abbreviations': 'off'
+    'unicorn/prevent-abbreviations': 'off',
   },
   overrides: [
     {
       // Test files:
-      files: ['tests/**/*.js',],
+      files: ['tests/**/*.js'],
       env: { jest: true },
     },
     {
@@ -161,7 +159,7 @@ module.exports = {
       parser: 'babel-eslint',
       parserOptions: {
         sourceType: 'module',
-        ecmaFeatures: { legacyDecorators: true }
+        ecmaFeatures: { legacyDecorators: true },
       },
       rules: {
         // Ignore violations that generally don't matter inside code samples.
@@ -181,8 +179,8 @@ module.exports = {
         'node/no-missing-require': 'off',
         'node/no-unsupported-features/es-syntax': 'off',
         'prettier/prettier': ['error', { trailingComma: 'none' }],
-        'unicorn/filename-case': 'off'
-      }
-    }
+        'unicorn/filename-case': 'off',
+      },
+    },
   ],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,4 @@ jobs:
     - run: yarn update && git diff --exit-code
     - run: yarn test:coverage --runInBand
     - run: yarn add --dev eslint@5 && yarn test --runInBand
+    - run: yarn add --dev eslint@6 && yarn test --runInBand

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -253,10 +253,14 @@ function reportUnorderedProperties(node, context, parentType, ORDER) {
           const propertyOffset = getCommentOffsetBefore(property, sourceCode);
           const foundPropertyOffset = getCommentOffsetBefore(foundProperty, sourceCode);
 
-          const offset = nextToken.start - property.end;
-          const textBetween = property.start - propertyOffset - foundProperty.end - whitespaceCount;
+          const offset = nextToken.range[0] - property.range[1];
+          const textBetween =
+            property.range[0] - propertyOffset - foundProperty.range[1] - whitespaceCount;
 
-          const replaceTextRange = [foundProperty.start - foundPropertyOffset, nextToken.start];
+          const replaceTextRange = [
+            foundProperty.range[0] - foundPropertyOffset,
+            nextToken.range[0],
+          ];
           const movedProperty = sourceCode.getText(property, propertyOffset, offset);
           const restText = sourceCode.getText(foundProperty, foundPropertyOffset, textBetween);
 
@@ -294,7 +298,7 @@ function getCommentOffsetBefore(property, sourceCode) {
     previousToken.type === 'Block' && commentBlockRegExp.test(previousTokenText);
 
   if (isLineComment || isBlockComment) {
-    return property.start - previousToken.start;
+    return property.range[0] - previousToken.range[0];
   }
 
   return 0;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/ember-cli/eslint-plugin-ember#readme",
   "devDependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-eslint-plugin": "^2.2.1",

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -1,5 +1,3 @@
-/* eslint eslint-plugin/consistent-output: "off" */
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -355,6 +353,16 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: computed("attitude", "health", () => {
         })
       });`,
+      output: `export default Component.extend({
+        role: "sloth",
+
+        actions: {},
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -376,6 +384,16 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
 
         role: ${`${'sloth'}`},
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
+      output: `export default Component.extend({
+        role: ${`${'sloth'}`},
+
+        actions: {},
 
         vehicle: alias("car"),
 
@@ -409,6 +427,16 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
+      output: `export default Component.extend({
+        role: "sloth",
+
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        actions: {}
+      });`,
       errors: [
         {
           message:
@@ -423,6 +451,16 @@ eslintTester.run('order-in-components', rule, {
         }),
 
         vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
+      output: `export default Component.extend({
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
 
         role: "sloth",
 
@@ -452,6 +490,16 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
+      output: `export default Component.extend(TestMixin, {
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
       errors: [
         {
           message:
@@ -471,6 +519,16 @@ eslintTester.run('order-in-components', rule, {
         }),
 
         vehicle: alias("car"),
+
+        role: "sloth",
+
+        actions: {}
+      });`,
+      output: `export default Component.extend(TestMixin, TestMixin2, {
+        vehicle: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
 
         role: "sloth",
 
@@ -494,6 +552,10 @@ eslintTester.run('order-in-components', rule, {
         abc: true,
         i18n: service()
       });`,
+      output: `export default Component.extend({
+        i18n: service(),
+              abc: true,
+});`,
       errors: [
         {
           message: 'The "i18n" service injection should be above the "abc" property on line 2',
@@ -506,6 +568,10 @@ eslintTester.run('order-in-components', rule, {
         vehicle: alias("car"),
         i18n: service()
       });`,
+      output: `export default Component.extend({
+        i18n: service(),
+              vehicle: alias("car"),
+});`,
       errors: [
         {
           message:
@@ -522,6 +588,13 @@ eslintTester.run('order-in-components', rule, {
           i18n: inject()
         });
       `,
+      output: `
+        import { inject } from '@ember/service';
+        export default Component.extend({
+          i18n: inject(),
+                  vehicle: alias("car"),
+});
+      `,
       errors: [
         {
           message:
@@ -536,6 +609,11 @@ eslintTester.run('order-in-components', rule, {
         }),
         vehicle: alias("car")
       });`,
+      output: `export default Component.extend({
+        vehicle: alias("car"),
+              levelOfHappiness: observer("attitude", "health", () => {
+        }),
+});`,
       errors: [
         {
           message:
@@ -551,6 +629,12 @@ eslintTester.run('order-in-components', rule, {
         aaa: computed("attitude", "health", () => {
         })
       });`,
+      output: `export default Component.extend({
+        aaa: computed("attitude", "health", () => {
+        }),
+              levelOfHappiness: observer("attitude", "health", () => {
+        }),
+});`,
       errors: [
         {
           message:
@@ -566,6 +650,12 @@ eslintTester.run('order-in-components', rule, {
         levelOfHappiness: observer("attitude", "health", () => {
         })
       });`,
+      output: `export default Component.extend({
+        levelOfHappiness: observer("attitude", "health", () => {
+        }),
+              init() {
+        },
+});`,
       errors: [
         {
           message:
@@ -580,6 +670,11 @@ eslintTester.run('order-in-components', rule, {
         init() {
         }
       });`,
+      output: `export default Component.extend({
+        init() {
+        },
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "init" lifecycle hook should be above the actions hash on line 2',
@@ -594,6 +689,12 @@ eslintTester.run('order-in-components', rule, {
         },
         actions: {}
       });`,
+      output: `export default Component.extend({
+        actions: {},
+              customFunc() {
+          const foo = 'bar';
+        },
+});`,
       errors: [
         {
           message: 'The actions hash should be above the "customFunc" method on line 2',
@@ -607,6 +708,11 @@ eslintTester.run('order-in-components', rule, {
         }),
         actions: {}
       });`,
+      output: `export default Component.extend({
+        actions: {},
+              tAction: test(function() {
+        }),
+});`,
       errors: [
         {
           message: 'The actions hash should be above the "tAction" method on line 2',
@@ -624,6 +730,18 @@ eslintTester.run('order-in-components', rule, {
         vehicle: alias("car"),
 
         role: "sloth",
+
+        actions: {}
+      });`,
+      output: `export default Component.extend(TestMixin, TestMixin2, {
+        role: "sloth",
+
+        foo: alias("car"),
+
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+
+        vehicle: alias("car"),
 
         actions: {}
       });`,
@@ -646,6 +764,12 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         [foo]: 'foo',
       });`,
+      output: `let foo = 'foo';
+
+      export default Component.extend(TestMixin, TestMixin2, {
+        [foo]: 'foo',
+              actions: {},
+});`,
       errors: [
         {
           message: 'The property should be above the actions hash on line 4',
@@ -659,6 +783,10 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
+      output: `export default CustomComponent.extend({
+        role: "sloth",
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -672,6 +800,10 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
+      output: `export default CustomComponent.extend({
+        role: "sloth",
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -685,6 +817,10 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         role: "sloth",
       });`,
+      output: `export default Component.extend({
+        role: "sloth",
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "role" property should be above the actions hash on line 2',
@@ -698,6 +834,11 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         template: hbs\`Hello world {{name}}\`,
       });`,
+      output: `export default Component.extend({
+        name: "Jon Snow",
+        template: hbs\`Hello world {{name}}\`,
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "template" property should be above the actions hash on line 3',
@@ -712,6 +853,12 @@ eslintTester.run('order-in-components', rule, {
 
         tabindex: -1,
       });`,
+      output: `export default Component.extend({
+        layout,
+        tabindex: -1,
+              someComputedValue: computed.reads('count'),
+
+});`,
       errors: [
         {
           message:
@@ -726,6 +873,11 @@ eslintTester.run('order-in-components', rule, {
         }).volatile(),
         name: "Jon Snow",
       });`,
+      output: `export default Component.extend({
+        name: "Jon Snow",
+              foo: computed(function() {
+        }).volatile(),
+});`,
       errors: [
         {
           message: 'The "name" property should be above the "foo" multi-line function on line 2',
@@ -737,6 +889,13 @@ eslintTester.run('order-in-components', rule, {
       code: `export default Component.extend({
         actions: {},
         didReceiveAttrs() {},
+        willDestroyElement() {},
+        didInsertElement() {},
+        init() {},
+      });`,
+      output: `export default Component.extend({
+        didReceiveAttrs() {},
+        actions: {},
         willDestroyElement() {},
         didInsertElement() {},
         init() {},
@@ -768,6 +927,13 @@ eslintTester.run('order-in-components', rule, {
         foo: computed(function() {
         }).volatile(),
         onFoo() {},
+        bar() { const foo = 'bar'},
+        onBar: () => {}
+      });`,
+      output: `export default Component.extend({
+        onFoo() {},
+        foo: computed(function() {
+        }).volatile(),
         bar() { const foo = 'bar'},
         onBar: () => {}
       });`,
@@ -816,6 +982,11 @@ eslintTester.run('order-in-components', rule, {
         actions: {},
         customProp: { a: 1 }
       });`,
+      output: `export default Component.extend({
+        prop: null,
+        customProp: { a: 1 },
+              actions: {},
+});`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {
@@ -836,6 +1007,12 @@ eslintTester.run('order-in-components', rule, {
           console.log('not empty');
         }
       });`,
+      output: `export default Component.extend({
+        aMethod() {
+          console.log('not empty');
+        },
+              customProp: { a: 1 },
+});`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -1,5 +1,3 @@
-/* eslint eslint-plugin/consistent-output: "off" */
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -140,6 +138,10 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
+      output: `export default Controller.extend({
+        currentUser: service(),
+              queryParams: [],
+});`,
       errors: [
         {
           message:
@@ -153,6 +155,10 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: inject()
       });`,
+      output: `export default Controller.extend({
+        currentUser: inject(),
+              queryParams: [],
+});`,
       errors: [
         {
           message:
@@ -167,6 +173,11 @@ eslintTester.run('order-in-controllers', rule, {
         customProp: "test",
         queryParams: []
       });`,
+      output: `export default Controller.extend({
+        currentUser: service(),
+        queryParams: [],
+              customProp: "test",
+});`,
       errors: [
         {
           message: 'The "queryParams" property should be above the "customProp" property on line 3',
@@ -180,6 +191,11 @@ eslintTester.run('order-in-controllers', rule, {
         actions: {},
         customProp: "test"
       });`,
+      output: `export default Controller.extend({
+        queryParams: [],
+        customProp: "test",
+              actions: {},
+});`,
       errors: [
         {
           message: 'The "customProp" property should be above the actions hash on line 3',
@@ -193,6 +209,11 @@ eslintTester.run('order-in-controllers', rule, {
         _customAction() { const foo = 'bar'; },
         actions: {}
       });`,
+      output: `export default Controller.extend({
+        queryParams: [],
+        actions: {},
+              _customAction() { const foo = 'bar'; },
+});`,
       errors: [
         {
           message: 'The actions hash should be above the "_customAction" method on line 3',
@@ -204,6 +225,11 @@ eslintTester.run('order-in-controllers', rule, {
       code: `export default Controller.extend({
         test: "asd",
         queryParams: [],
+        actions: {}
+      });`,
+      output: `export default Controller.extend({
+        queryParams: [],
+        test: "asd",
         actions: {}
       });`,
       errors: [
@@ -218,6 +244,10 @@ eslintTester.run('order-in-controllers', rule, {
         currentUser: service(),
         application: controller()
       });`,
+      output: `export default Controller.extend({
+        application: controller(),
+              currentUser: service(),
+});`,
       errors: [
         {
           message:
@@ -233,6 +263,12 @@ eslintTester.run('order-in-controllers', rule, {
         comp: computed("asd", function() {}),
         actions: {}
       });`,
+      output: `export default Controller.extend({
+        test: "asd",
+        comp: computed("asd", function() {}),
+        obs: observer("asd", function() {}),
+        actions: {}
+      });`,
       errors: [
         {
           message: 'The "comp" single-line function should be above the "obs" observer on line 3',
@@ -246,6 +282,10 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
+      output: `export default CustomController.extend({
+        currentUser: service(),
+              queryParams: [],
+});`,
       errors: [
         {
           message:
@@ -260,6 +300,10 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
+      output: `export default CustomController.extend({
+        currentUser: service(),
+              queryParams: [],
+});`,
       errors: [
         {
           message:
@@ -274,6 +318,10 @@ eslintTester.run('order-in-controllers', rule, {
         queryParams: [],
         currentUser: service()
       });`,
+      output: `export default Controller.extend({
+        currentUser: service(),
+              queryParams: [],
+});`,
       errors: [
         {
           message:
@@ -294,6 +342,17 @@ eslintTester.run('order-in-controllers', rule, {
           }
         });
       `,
+      output: `
+        export default Controller.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+                  actions: {
+            onKeyPress: function (event) {}
+          },
+});
+      `,
       errors: [
         {
           message: 'The "init" lifecycle hook should be above the actions hash on line 4',
@@ -310,6 +369,15 @@ eslintTester.run('order-in-controllers', rule, {
             this._super(...arguments);
           }
         });
+      `,
+      output: `
+        export default Controller.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+                  customFoo() {},
+});
       `,
       errors: [
         {
@@ -328,6 +396,14 @@ eslintTester.run('order-in-controllers', rule, {
           foo: service()
         });
       `,
+      output: `
+        export default Controller.extend({
+          foo: service(),
+                  init() {
+            this._super(...arguments);
+          },
+});
+      `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
@@ -345,6 +421,14 @@ eslintTester.run('order-in-controllers', rule, {
           },
           someProp: null
         });
+      `,
+      output: `
+        export default Controller.extend({
+          someProp: null,
+                  init() {
+            this._super(...arguments);
+          },
+});
       `,
       errors: [
         {
@@ -374,29 +458,17 @@ eslintTester.run('order-in-controllers', rule, {
     },
     {
       code: `export default Controller.extend({
-        test: "asd",
-        queryParams: [],
-        actions: {}
-      });`,
-      output: `export default Controller.extend({
-        queryParams: [],
-        test: "asd",
-        actions: {}
-      });`,
-      errors: [
-        {
-          message: 'The "queryParams" property should be above the "test" property on line 2',
-          line: 3,
-        },
-      ],
-    },
-    {
-      code: `export default Controller.extend({
         customProp: { a: 1 },
         aMethod() {
           console.log('not empty');
         }
       });`,
+      output: `export default Controller.extend({
+        aMethod() {
+          console.log('not empty');
+        },
+              customProp: { a: 1 },
+});`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -1,5 +1,3 @@
-/* eslint eslint-plugin/consistent-output: "off" */
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -99,6 +97,12 @@ eslintTester.run('order-in-models', rule, {
         mood: computed("health", "hunger", function() {
         })
       });`,
+      output: `export default Model.extend({
+        shape: attr("string"),
+        behaviors: hasMany("behaviour"),
+        mood: computed("health", "hunger", function() {
+        })
+      });`,
       errors: [
         {
           message: 'The "shape" attribute should be above the "behaviors" relationship on line 2',
@@ -113,6 +117,12 @@ eslintTester.run('order-in-models', rule, {
         }),
         behaviors: hasMany("behaviour")
       });`,
+      output: `export default Model.extend({
+        shape: attr("string"),
+        behaviors: hasMany("behaviour"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message:
@@ -127,6 +137,11 @@ eslintTester.run('order-in-models', rule, {
         }),
         shape: attr("string")
       });`,
+      output: `export default Model.extend({
+        shape: attr("string"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message: 'The "shape" attribute should be above the "mood" multi-line function on line 2',
@@ -138,6 +153,12 @@ eslintTester.run('order-in-models', rule, {
       code: `export default DS.Model.extend({
         behaviors: hasMany("behaviour"),
         shape: DS.attr("string"),
+        mood: Ember.computed("health", "hunger", function() {
+        })
+      });`,
+      output: `export default DS.Model.extend({
+        shape: DS.attr("string"),
+        behaviors: hasMany("behaviour"),
         mood: Ember.computed("health", "hunger", function() {
         })
       });`,
@@ -155,6 +176,12 @@ eslintTester.run('order-in-models', rule, {
         }),
         behaviors: hasMany("behaviour")
       });`,
+      output: `export default DS.Model.extend({
+        shape: attr("string"),
+        behaviors: hasMany("behaviour"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message:
@@ -169,6 +196,11 @@ eslintTester.run('order-in-models', rule, {
         }),
         shape: attr("string")
       });`,
+      output: `export default DS.Model.extend({
+        shape: attr("string"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message: 'The "shape" attribute should be above the "mood" multi-line function on line 2',
@@ -182,6 +214,11 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
+      output: `export default DS.Model.extend({
+        test: computed.alias("qwerty"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message:
@@ -196,6 +233,11 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
+      output: `export default DS.Model.extend(TestMixin, {
+        test: computed.alias("qwerty"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message:
@@ -210,31 +252,16 @@ eslintTester.run('order-in-models', rule, {
         }),
         test: computed.alias("qwerty")
       });`,
+      output: `export default DS.Model.extend(TestMixin, TestMixin2, {
+        test: computed.alias("qwerty"),
+              mood: computed("health", "hunger", function() {
+        }),
+});`,
       errors: [
         {
           message:
             'The "test" single-line function should be above the "mood" multi-line function on line 2',
           line: 4,
-        },
-      ],
-    },
-    {
-      code: `export default Model.extend({
-        behaviors: hasMany("behaviour"),
-        shape: attr("string"),
-        mood: computed("health", "hunger", function() {
-        })
-      });`,
-      output: `export default Model.extend({
-        shape: attr("string"),
-        behaviors: hasMany("behaviour"),
-        mood: computed("health", "hunger", function() {
-        })
-      });`,
-      errors: [
-        {
-          message: 'The "shape" attribute should be above the "behaviors" relationship on line 2',
-          line: 3,
         },
       ],
     },
@@ -245,6 +272,12 @@ eslintTester.run('order-in-models', rule, {
           console.log('not empty');
         }
       });`,
+      output: `export default DS.Model.extend({
+        aMethod() {
+          console.log('not empty');
+        },
+              customProp: { a: 1 },
+});`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -1,5 +1,3 @@
-/* eslint eslint-plugin/consistent-output: "off" */
-
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -168,6 +166,16 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
+      output: `export default Route.extend({
+        currentUser: service(),
+        queryParams: {},
+        customProp: "test",
+        vehicle: alias("car"),
+        beforeModel() {},
+        model() {},
+        actions: {},
+        _customAction() {}
+      });`,
       errors: [
         {
           message:
@@ -192,6 +200,16 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
+      output: `export default Route.extend({
+        currentUser: inject(),
+        queryParams: {},
+        customProp: "test",
+        vehicle: alias("car"),
+        beforeModel() {},
+        model() {},
+        actions: {},
+        _customAction() {}
+      });`,
       errors: [
         {
           message:
@@ -209,6 +227,16 @@ eslintTester.run('order-in-routes', rule, {
       code: `export default Route.extend({
         customProp: "test",
         queryParams: {},
+        beforeModel() {},
+        model() {},
+        actions: {},
+        _customAction() {},
+        levelOfHappiness: computed("attitude", "health", () => {
+        })
+      });`,
+      output: `export default Route.extend({
+        queryParams: {},
+        customProp: "test",
         beforeModel() {},
         model() {},
         actions: {},
@@ -238,6 +266,14 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
+      output: `export default Route.extend({
+        queryParams: {},
+        customProp: "test",
+        model() {},
+        beforeModel() {},
+        actions: {},
+        _customAction() {}
+      });`,
       errors: [
         {
           message:
@@ -259,6 +295,14 @@ eslintTester.run('order-in-routes', rule, {
         _customAction() { const foo = 'bar'; },
         actions: {}
       });`,
+      output: `export default Route.extend({
+        queryParams: {},
+        customProp: "test",
+        vehicle: alias("car"),
+        model() {},
+        actions: {},
+              _customAction() { const foo = 'bar'; },
+});`,
       errors: [
         {
           message:
@@ -277,6 +321,11 @@ eslintTester.run('order-in-routes', rule, {
         customProp: "test",
         actions: {}
       });`,
+      output: `export default Route.extend({
+        customProp: "test",
+        model() {},
+        actions: {}
+      });`,
       errors: [
         {
           message: 'The "customProp" property should be above the "model" hook on line 2',
@@ -288,6 +337,11 @@ eslintTester.run('order-in-routes', rule, {
       code: `export default Route.extend({
         test: "asd",
         mergedProperties: {},
+        model() {}
+      });`,
+      output: `export default Route.extend({
+        mergedProperties: {},
+        test: "asd",
         model() {}
       });`,
       errors: [
@@ -315,6 +369,28 @@ eslintTester.run('order-in-routes', rule, {
         activate() {},
         deactivate() {},
         renderTemplate() {},
+        resetController() {},
+        actions: {},
+        _customAction() {},
+        _customAction2: function() {},
+        tSomeTask: task(function* () {})
+      });`,
+      output: `export default Route.extend({
+        currentUser: service(),
+        queryParams: {},
+        customProp: "test",
+        vehicle: alias("car"),
+        levelOfHappiness: computed("attitude", "health", () => {
+        }),
+        beforeModel() {},
+        model() {},
+        afterModel() {},
+        redirect() {},
+        setupController() {},
+        serialize() {},
+        activate() {},
+        renderTemplate() {},
+        deactivate() {},
         resetController() {},
         actions: {},
         _customAction() {},
@@ -355,6 +431,11 @@ eslintTester.run('order-in-routes', rule, {
         _test2() { const foo = 'bar'; },
         model() {}
       });`,
+      output: `export default Route.extend({
+        test: "asd",
+        model() {},
+              _test2() { const foo = 'bar'; },
+});`,
       errors: [
         {
           message: 'The "model" hook should be above the "_test2" method on line 3',
@@ -368,6 +449,10 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
+      output: `export default CustomRoute.extend({
+        test: "asd",
+              model() {},
+});`,
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -381,6 +466,10 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
+      output: `export default CustomRoute.extend({
+        test: "asd",
+              model() {},
+});`,
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -394,6 +483,10 @@ eslintTester.run('order-in-routes', rule, {
         model() {},
         test: "asd",
       });`,
+      output: `export default Route.extend({
+        test: "asd",
+              model() {},
+});`,
       errors: [
         {
           message: 'The "test" property should be above the "model" hook on line 2',
@@ -410,6 +503,15 @@ eslintTester.run('order-in-routes', rule, {
             this._super(...arguments);
           }
         });
+      `,
+      output: `
+        export default Route.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+                  actions: {},
+});
       `,
       errors: [
         {
@@ -428,6 +530,15 @@ eslintTester.run('order-in-routes', rule, {
           },
         });
       `,
+      output: `
+        export default Route.extend({
+          foo: service(),
+          init() {
+            this._super(...arguments);
+          },
+                  customFoo() {},
+});
+      `,
       errors: [
         {
           message:
@@ -444,6 +555,14 @@ eslintTester.run('order-in-routes', rule, {
           },
           foo: service()
         });
+      `,
+      output: `
+        export default Route.extend({
+          foo: service(),
+                  init() {
+            this._super(...arguments);
+          },
+});
       `,
       errors: [
         {
@@ -462,44 +581,18 @@ eslintTester.run('order-in-routes', rule, {
           someProp: null
         });
       `,
+      output: `
+        export default Route.extend({
+          someProp: null,
+                  init() {
+            this._super(...arguments);
+          },
+});
+      `,
       errors: [
         {
           message: 'The "someProp" property should be above the "init" lifecycle hook on line 3',
           line: 6,
-        },
-      ],
-    },
-    {
-      code: `export default Route.extend({
-        queryParams: {},
-        currentUser: service(),
-        customProp: "test",
-        beforeModel() {},
-        model() {},
-        vehicle: alias("car"),
-        actions: {},
-        _customAction() {}
-      });`,
-      output: `export default Route.extend({
-        currentUser: service(),
-        queryParams: {},
-        customProp: "test",
-        vehicle: alias("car"),
-        beforeModel() {},
-        model() {},
-        actions: {},
-        _customAction() {}
-      });`,
-      errors: [
-        {
-          message:
-            'The "currentUser" service injection should be above the inherited "queryParams" property on line 2',
-          line: 3,
-        },
-        {
-          message:
-            'The "vehicle" single-line function should be above the "beforeModel" lifecycle hook on line 5',
-          line: 7,
         },
       ],
     },
@@ -651,6 +744,12 @@ eslintTester.run('order-in-routes', rule, {
           console.log('not empty');
         }
       });`,
+      output: `export default Route.extend({
+        aMethod() {
+          console.log('not empty');
+        },
+              customProp: { a: 1 },
+});`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       options: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,7 +1030,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1279,6 +1279,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz#d0d7dcfa74e89115c7619f4f721a94e1fdb716d6"
+  integrity sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
@@ -1351,9 +1360,9 @@ deep-extend@~0.5.1:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
   integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 deepmerge@^4.2.2:
@@ -1704,13 +1713,6 @@ eslint-template-visitor@^1.1.0:
     espree "^6.1.1"
     multimap "^1.0.2"
 
-eslint-utils@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
-  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
 eslint-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
@@ -1723,22 +1725,22 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
-  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+eslint@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-7.0.0.tgz#c35dfd04a4372110bd78c69a8d79864273919a08"
+  integrity sha512-qY1cwdOxMONHJfGqw52UOpZDeqXy8xmD0u8CT6jIstil72jkhURC704W8CFyTPDPllz4z4lu0Ql1+07PG/XdIg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
     eslint-scope "^5.0.0"
-    eslint-utils "^1.4.3"
+    eslint-utils "^2.0.0"
     eslint-visitor-keys "^1.1.0"
-    espree "^6.1.2"
-    esquery "^1.0.1"
+    espree "^7.0.0"
+    esquery "^1.2.0"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
@@ -1751,25 +1753,33 @@ eslint@^6.8.0:
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
+    levn "^0.4.1"
     lodash "^4.17.14"
     minimatch "^3.0.4"
-    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.3"
+    optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^6.1.2"
-    strip-ansi "^5.2.0"
-    strip-json-comments "^3.0.1"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^6.1.1, espree@^6.1.2:
+espree@^6.1.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
   integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
+
+espree@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz#8a7a60f218e69f120a842dc24c5a88aa7748a74e"
+  integrity sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==
   dependencies:
     acorn "^7.1.1"
     acorn-jsx "^5.2.0"
@@ -1780,12 +1790,12 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.2.0.tgz#a010a519c0288f2530b3404124bfb5f02e9797fe"
-  integrity sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==
+esquery@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
+  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
   dependencies:
-    estraverse "^5.0.0"
+    estraverse "^5.1.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -1799,10 +1809,10 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.0.0.tgz#ac81750b482c11cca26e4b07e83ed8f75fbcdc22"
-  integrity sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==
+estraverse@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
+  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1940,9 +1950,9 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fb-watchman@^2.0.0:
@@ -3228,7 +3238,15 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levn@^0.3.0, levn@~0.3.0:
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
+levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
@@ -3832,7 +3850,7 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-optionator@^0.8.1, optionator@^0.8.3:
+optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -3843,6 +3861,18 @@ optionator@^0.8.1, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -4067,6 +4097,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4234,15 +4269,15 @@ regexp-tree@^0.1.21, regexp-tree@~0.1.1:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.21.tgz#55e2246b7f7d36f1b461490942fa780299c400d7"
   integrity sha512-kUUXjX4AnqnR8KRTCrayAo9PzYMRKmVoGgaz2tBuz0MF3g1ZbGebmtW0yFHfFK9CmBjQKeYIgoL22pFLBJY7sw==
 
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
 regexpp@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
   integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
+
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 remark-parse@^5.0.0:
   version "5.0.0"
@@ -4499,7 +4534,7 @@ saxes@^5.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -4862,10 +4897,10 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
-  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+strip-json-comments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
+  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -5078,6 +5113,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -5357,9 +5399,9 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^5.1.0:


### PR DESCRIPTION
This is mostly an internal-only upgrade (except possibly item 4).

Changes:

1. Formats `.eslintrc.js` (no longer ignored)
2. Enables new optional eslint rules [default-case-last](https://eslint.org/docs/rules/default-case-last) and [no-useless-backreference](https://eslint.org/docs/rules/no-useless-backreference)
3. Updates CI tests to test under eslint 5, 6, and 7
4. Switches `token.start` / `token.end` to `token.range[0]` / `token.range[1]` (avoid using non-standard AST properties, see [RFC](https://github.com/eslint/rfcs/tree/master/designs/2019-rule-tester-improvements))
5. Adds test output assertions to `order-in-*` rules that were missing them (now required, see [RFC](https://github.com/eslint/rfcs/tree/master/designs/2019-rule-tester-improvements))

https://eslint.org/blog/2020/05/eslint-v7.0.0-released