### PR TITLE
Avoid some false positives when detecting if a file is an Ember component, controller, etc

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -157,9 +157,8 @@ function isModuleByFilePath(filePath, module) {
   const expectedFileNameTs = `${module}.ts`;
   const expectedFolderName = `${module}s`;
 
-  const filePathParts = filePath.split(path.sep);
-  const actualFolders = filePathParts.slice(0, -1);
-  const actualFileName = filePathParts[filePathParts.length - 1];
+  const actualFolders = path.dirname(filePath).split(path.sep);
+  const actualFileName = path.basename(filePath);
 
   /* Check both folder and filename to support both classic and POD's structure */
   return (

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -153,13 +153,19 @@ function isDSModel(node, filePath) {
 }
 
 function isModuleByFilePath(filePath, module) {
-  const fileNameJs = `${module}.js`;
-  const fileNameTs = `${module}.ts`;
-  const folderName = `${module}s`;
+  const expectedFileNameJs = `${module}.js`;
+  const expectedFileNameTs = `${module}.ts`;
+  const expectedFolderName = `${module}s`;
+
+  const filePathParts = filePath.split(path.sep);
+  const actualFolders = filePathParts.slice(0, -1);
+  const actualFileName = filePathParts[filePathParts.length - 1];
 
   /* Check both folder and filename to support both classic and POD's structure */
   return (
-    filePath.includes(fileNameJs) || filePath.includes(fileNameTs) || filePath.includes(folderName)
+    actualFileName === expectedFileNameJs ||
+    actualFileName === expectedFileNameTs ||
+    actualFolders.includes(expectedFolderName)
   );
 }
 

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -86,6 +86,27 @@ describe('isModuleByFilePath', () => {
     const filePath = 'example-app/components/path/to/some-component.ts';
     expect(emberUtils.isModuleByFilePath(filePath, 'component')).toBeTruthy();
   });
+
+  // Avoid false positives:
+  it('should not detect a component in a folder named `fake-components`', () => {
+    const filePath = 'example-app/fake-components/path/to/file.js';
+    expect(emberUtils.isModuleByFilePath(filePath, 'component')).toBeFalsy();
+  });
+
+  it('should not detect a component with a file named `components`', () => {
+    const filePath = 'example-app/some-folder/path/to/components';
+    expect(emberUtils.isModuleByFilePath(filePath, 'component')).toBeFalsy();
+  });
+
+  it('should not detect a component with a directory named `component.js`', () => {
+    const filePath = 'example-app/component.js/path/to/file.js';
+    expect(emberUtils.isModuleByFilePath(filePath, 'component')).toBeFalsy();
+  });
+
+  it('should not detect a component with a directory named `component.ts`', () => {
+    const filePath = 'example-app/component.ts/path/to/file.js';
+    expect(emberUtils.isModuleByFilePath(filePath, 'component')).toBeFalsy();
+  });
 });
 
 describe('isMirageDirectory', () => {


### PR DESCRIPTION
Many of our rules still use the current filepath to detect if they are running on an Ember component/route/controller/etc. Long-term, we should change this to check import/exports instead (i.e. a route is only a default export that extends from `@ember/routing/route`). But that's a large refactor.

One easy improvement we can make now is to look at specific segments of a filepath instead of the entire filepath when performing our checks. For example, a filepath represents a component only if a folder segment is `components`, or if the file segment is `component.js`. This is an improvement over the previous behavior of simply looking for `components` or `component.js` anywhere in the entire filepath string.

This partially addresses #235. CC: @amk221.