### PR TITLE
Add .markdownlintignore

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+LICENSE.md
+node_modules

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "changelog": "lerna-changelog",
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint '**/*.md' -i CHANGELOG.md -i LICENSE.md -i node_modules",
+    "lint:docs": "markdownlint '**/*.md'",
     "lint:docs-js": "eslint . --cache --ext md",
     "lint:js": "eslint . --cache",
     "start": "yarn run test:watch",


### PR DESCRIPTION
This should prevent IDEs from autofixing or highlighting violations in files like CHANGELOG.md (which are autogenerated).