### PR TITLE
Update `no-computed-properties-in-native-classes` rule to ignore classes marked `@classic`

### DIFF
--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -47,13 +47,32 @@ export default Component.extend({});
 ```
 
 ```js
+// Allowed if `ignoreClassic` option is enabled.
+import { computed } from '@ember/object';
+import { alias, or, and } from '@ember/object/computed';
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
+
+@classic
+export default class MyComponent extends Component {}
+```
+
+```js
 import { tracked } from '@glimmer/tracking';
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {}
 ```
 
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `ignoreClassic` -- whether the rule should ignore usage inside of native classes labeled with `@classic` (default `true`)
+
 ## References
 
 * [Ember Guides: Tracked Properties](https://octane-guides-preview.emberjs.com/release/state-management/tracked-properties/)
 * [Tracked Properties Deep Dive](https://www.pzuraq.com/coming-soon-in-ember-octane-part-3-tracked-properties/)
+* [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+* [ember-classic-decorator](https://github.com/emberjs/ember-classic-decorator)

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('../utils/utils');
+const { hasDecorator } = require('../utils/types');
 
 const ERROR_MESSAGE =
   "Don't use computed properties with native classes. Use getters or @tracked properties instead.";
@@ -37,10 +38,22 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-computed-properties-in-native-classes.md',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreClassic: {
+            type: 'boolean',
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {
+    const ignoreClassic = context.options[0] && context.options[0].ignoreClassic;
     let computedNodes = [];
 
     const report = function (node) {
@@ -51,9 +64,11 @@ module.exports = {
       Program(node) {
         computedNodes = findComputedNodes(node.body);
       },
-      ClassDeclaration() {
+      ClassDeclaration(node) {
         computedNodes.forEach((importNode) => {
-          report(importNode);
+          if (!ignoreClassic || !hasDecorator(node, 'classic')) {
+            report(importNode);
+          }
         });
       },
     };

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  hasDecorator,
   isAnyFunctionExpression,
   isArrayExpression,
   isArrowFunctionExpression,
@@ -39,6 +40,31 @@ module.exports = {
   isUnaryExpression,
   isVariableDeclarator,
 };
+
+/**
+ * Check whether or not a node has at least the given decorator
+ * If no decoratorName is provided, will return whether the node has any decorators at all
+ *
+ * @param {Object} node The node to check.
+ * @param {string?} decoratorName The decorator to look for
+ * @returns {boolean} Whether or not the node has the given decorator.
+ */
+function hasDecorator(node, decoratorName) {
+  if (!node.decorators) {
+    return false;
+  }
+  if (!decoratorName) {
+    return true;
+  }
+
+  return node.decorators.some((decorator) => {
+    const expression = decorator.expression;
+    return (
+      (isIdentifier(expression) && expression.name === decoratorName) ||
+      (isCallExpression(expression) && expression.callee.name === decoratorName)
+    );
+  });
+}
 
 /**
  * Check whether or not a node is an ArrowFunctionExpression or FunctionExpression.
@@ -138,23 +164,14 @@ function isClassProperty(node) {
 
 /**
  * Check whether or not a node is a ClassProperty, with at least the given decorator.
+ * If no decoratorName is provided, will return whether the node has any decorators at all
  *
  * @param {Object} node The node to check.
- * @param {string} decoratorName The decorator to look for
+ * @param {string?} decoratorName The decorator to look for
  * @returns {boolean} Whether or not the node is a ClassProperty with the given decorator.
  */
 function isClassPropertyWithDecorator(node, decoratorName) {
-  return (
-    isClassProperty(node) &&
-    node.decorators &&
-    node.decorators.some((decorator) => {
-      const expression = decorator.expression;
-      return (
-        (isIdentifier(expression) && expression.name === decoratorName) ||
-        (isCallExpression(expression) && expression.callee.name === decoratorName)
-      );
-    })
-  );
+  return isClassProperty(node) && hasDecorator(node, decoratorName);
 }
 
 function isCommaToken(token) {

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -4,10 +4,13 @@ const rule = require('../../../lib/rules/no-computed-properties-in-native-classe
 const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
+
 const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
+    ecmaFeatures: { legacyDecorators: true },
   },
 });
 
@@ -37,6 +40,73 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
 
       export default class MyComponent extends Component {}
     `,
+    {
+      code: `
+        import Component from '@ember/component';
+
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: true,
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from '@ember/component';
+
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: false,
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from '@ember/component';
+        import classic from 'ember-classic-decorator';
+
+        @classic
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: true,
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from '@ember/component';
+        import classic from 'ember-classic-decorator';
+
+        @classic
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: false,
+        },
+      ],
+    },
+    {
+      code: `
+        import { computed } from '@ember/object';
+        import Component from '@ember/component';
+        import classic from 'ember-classic-decorator';
+
+        @classic
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: true,
+        },
+      ],
+    },
 
     // Unrelated import statements:
     "import EmberObject from '@ember/object';",
@@ -74,6 +144,53 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
 
       }
       `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
+    },
+    {
+      code: `
+        import { computed } from '@ember/object';
+        import Component from '@ember/component';
+
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: true,
+        },
+      ],
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
+    },
+    {
+      code: `
+        import { computed } from '@ember/object';
+        import Component from '@ember/component';
+
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: false,
+        },
+      ],
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
+    },
+    {
+      code: `
+        import { computed } from '@ember/object';
+        import Component from '@ember/component';
+        import classic from 'ember-classic-decorator';
+
+        @classic
+        export default class MyComponent extends Component {}
+      `,
+      options: [
+        {
+          ignoreClassic: false,
+        },
+      ],
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ImportDeclaration' }],
     },

--- a/tests/lib/utils/types-test.js
+++ b/tests/lib/utils/types-test.js
@@ -194,3 +194,42 @@ describe('isUnaryExpression', () => {
     expect(types.isUnaryExpression(node)).toBeTruthy();
   });
 });
+
+describe('hasDecorator', () => {
+  const expressionlessParse = (code) => babelEslint.parse(code).body[0];
+  const withDecorator = '@classic class Rectangle {}';
+  const withoutDecorator = 'class Rectangle {}';
+  const testCases = [
+    {
+      code: withoutDecorator,
+      decoratorName: undefined,
+      expected: false,
+    },
+    {
+      code: withoutDecorator,
+      decoratorName: 'classic',
+      expected: false,
+    },
+    {
+      code: withDecorator,
+      decoratorName: undefined,
+      expected: true,
+    },
+    {
+      code: withDecorator,
+      decoratorName: 'classic',
+      expected: true,
+    },
+    {
+      code: withDecorator,
+      decoratorName: 'someOtherDecoratorName',
+      expected: false,
+    },
+  ];
+  testCases.forEach(({ code, decoratorName, expected }) => {
+    it(`('${code}', '${decoratorName}') => ${expected}`, () => {
+      const node = expressionlessParse(code);
+      expect(types.hasDecorator(node, decoratorName)).toStrictEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
### What
- adds an `ignoreClassic` (default true) config option to `no-computed-properties-in-native-classes`
  - when enabled, the rule will ignore any classes marked w/ the `@classic` decorator
- refactor - extracts `hasDecorator` util out of `isClassPropertyWithDecorator`
- adds test cases for 2 ^ 3 = 8 possible combinations of `hasComputedImport` x `hasClassicDecorator` x `ignoreClassic`

### Why
- fixes #619 