### PR TITLE
Rename `error` option to `message` on `no-restricted-service-injections` rule

### DIFF
--- a/docs/rules/no-restricted-service-injections.md
+++ b/docs/rules/no-restricted-service-injections.md
@@ -19,7 +19,7 @@ With this example configuration:
     {
         "paths": ["folder1", "folder2", "folder3"],
         "services": ["deprecated-service"],
-        "error": "Please stop using this service as it is in the process of being deprecated",
+        "message": "Please stop using this service as it is in the process of being deprecated",
     },
     {
         "paths": ["isolated-folder"],
@@ -46,7 +46,7 @@ class MyComponent extends Component {
 * object[] -- containing the following properties:
   * string[] -- `services` -- list of (kebab-case) service names that should be disallowed from being injected under the specified paths
   * string[] -- `paths` -- optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path)
-  * string -- `error` -- optional custom error message to display for violations
+  * string -- `message` -- optional custom error message to display for violations
 
 ## Related Rules
 

--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -37,7 +37,7 @@ module.exports = {
                 type: 'string',
               },
             },
-            error: {
+            message: {
               type: 'string',
             },
           },
@@ -77,7 +77,7 @@ module.exports = {
         if (blacklist.services.includes(serviceNameKebabCase)) {
           context.report({
             node,
-            message: blacklist.error || DEFAULT_ERROR_MESSAGE,
+            message: blacklist.message || DEFAULT_ERROR_MESSAGE,
           });
         }
       });

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -136,7 +136,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
         {
           paths: ['app/components'],
           services: ['my-service'],
-          error: 'my-service is deprecated, please do not use it.',
+          message: 'my-service is deprecated, please do not use it.',
         },
       ],
       output: null,
@@ -147,8 +147,8 @@ ruleTester.run('no-restricted-service-injections', rule, {
       // With multiple violations:
       code: 'Component.extend({ myService: service() })',
       options: [
-        { paths: ['app/components'], services: ['my-service'], error: 'Error 1' },
-        { paths: ['app/components'], services: ['my-service'], error: 'Error 2' },
+        { paths: ['app/components'], services: ['my-service'], message: 'Error 1' },
+        { paths: ['app/components'], services: ['my-service'], message: 'Error 2' },
       ],
       output: null,
       filename: 'app/components/path.js',


### PR DESCRIPTION
Better consistency with other "no-restricted-*" lint rules.

Rule hasn't been released yet. Follow-up to #827.