### PR TITLE
Support `filterBy` and `mapBy` macros in `require-computed-macros` rule

### DIFF
--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -58,6 +58,14 @@ export default Component.extend({
 
   propEqual: computed('x', function () {
     return this.x === 123;
+  }),
+
+  propFilterBy: computed('chores.@each.done', function () {
+    return this.chores.filterBy('done', true);
+  }),
+
+  propMapBy: computed('children.@each.age', function () {
+    return this.children.mapBy('age');
   })
 });
 ```
@@ -66,7 +74,19 @@ Examples of **correct** code for this rule:
 
 ```js
 import Component from '@ember/component';
-import { reads, and, or, gt, gte, lt, lte, not, equal } from '@ember/object/computed';
+import {
+  reads,
+  and,
+  or,
+  gt,
+  gte,
+  lt,
+  lte,
+  not,
+  equal,
+  filterBy,
+  mapBy
+} from '@ember/object/computed';
 
 export default Component.extend({
   propReads: reads('x'),
@@ -85,7 +105,11 @@ export default Component.extend({
 
   propNot: not('x'),
 
-  propEqual: equal('x', 123)
+  propEqual: equal('x', 123),
+
+  propFilterBy: filterBy('chores', 'done', true),
+
+  propMapBy: mapBy('children', 'age')
 });
 ```
 

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -22,6 +22,43 @@ const ERROR_MESSAGE_LT = makeErrorMessage('lt');
 const ERROR_MESSAGE_LTE = makeErrorMessage('lte');
 const ERROR_MESSAGE_NOT = makeErrorMessage('not');
 const ERROR_MESSAGE_EQUAL = makeErrorMessage('equal');
+const ERROR_MESSAGE_FILTER_BY = makeErrorMessage('filterBy');
+const ERROR_MESSAGE_MAP_BY = makeErrorMessage('mapBy');
+
+/**
+ * Checks if a CallExpression node looks like `this.x.someFunction()` or `this.x.y.someFunction()`.
+ *
+ * @param {Node} node The CallExpression node to check.
+ * @param {String} functionName The name of the function call to check for.
+ * @returns {boolean} Whether the node looks like `this.x.someFunction()` or `this.x.y.someFunction()`.
+ */
+function isThisPropertyFunctionCall(node, functionName) {
+  if (
+    node.type !== 'CallExpression' ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.property.type !== 'Identifier' ||
+    node.callee.property.name !== functionName
+  ) {
+    return false;
+  }
+
+  let current = node.callee;
+  while (current !== null) {
+    if (
+      types.isMemberExpression(current) &&
+      !current.computed &&
+      types.isIdentifier(current.property)
+    ) {
+      current = current.object;
+    } else if (types.isThisExpression(current)) {
+      return true;
+    } else {
+      break;
+    }
+  }
+
+  return false;
+}
 
 /**
  * Checks if a LogicalExpression looks like `this.x && this.y && this.z`
@@ -99,6 +136,8 @@ module.exports = {
   ERROR_MESSAGE_LTE,
   ERROR_MESSAGE_NOT,
   ERROR_MESSAGE_EQUAL,
+  ERROR_MESSAGE_FILTER_BY,
+  ERROR_MESSAGE_MAP_BY,
 
   create(context) {
     function reportSingleArg(nodeComputedProperty, nodeWithThisExpression, macro) {
@@ -140,6 +179,25 @@ module.exports = {
             .map((node) => propertyGetterUtils.nodeToDependentKey(node, context))
             .join("', '");
           return fixer.replaceText(nodeComputedProperty, `computed.${macro}('${text}')`);
+        },
+      });
+    }
+
+    function reportFunctionCall(nodeComputedProperty, nodeCallExpression, macro) {
+      context.report({
+        node: nodeComputedProperty,
+        message: makeErrorMessage(macro),
+        fix(fixer) {
+          const sourceCode = context.getSourceCode();
+          const arg1 = propertyGetterUtils.nodeToDependentKey(
+            nodeCallExpression.callee.object,
+            context
+          );
+          const restOfArgs = nodeCallExpression.arguments.map((arg) => sourceCode.getText(arg));
+          return fixer.replaceText(
+            nodeComputedProperty,
+            `computed.${macro}('${arg1}', ${restOfArgs.join(', ')})`
+          );
         },
       });
     }
@@ -203,6 +261,10 @@ module.exports = {
           }
         } else if (propertyGetterUtils.isSimpleThisExpression(statement)) {
           reportSingleArg(node, statement, 'reads');
+        } else if (isThisPropertyFunctionCall(statement, 'filterBy')) {
+          reportFunctionCall(node, statement, 'filterBy');
+        } else if (isThisPropertyFunctionCall(statement, 'mapBy')) {
+          reportFunctionCall(node, statement, 'mapBy');
         }
       },
     };

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -15,6 +15,8 @@ const {
   ERROR_MESSAGE_LTE,
   ERROR_MESSAGE_NOT,
   ERROR_MESSAGE_EQUAL,
+  ERROR_MESSAGE_FILTER_BY,
+  ERROR_MESSAGE_MAP_BY,
 } = rule;
 
 //------------------------------------------------------------------------------
@@ -82,6 +84,12 @@ ruleTester.run('require-computed-macros', rule, {
     'computed(function() { return SOME_VAR === "Hello"; })',
     'computed(function() { return this.prop === MY_VAR; })',
     "computed(function() { return this.get('prop') === MY_VAR; })",
+
+    // FILTERBY
+    "filterBy('chores', 'done', true)",
+
+    // MAPBY
+    "mapBy('children', 'age')",
 
     // Decorator:
     {
@@ -189,6 +197,25 @@ ruleTester.run('require-computed-macros', rule, {
       code: "computed(function() { return this.get('x') === 123; })", // this.get()
       output: "computed.equal('x', 123)",
       errors: [{ message: ERROR_MESSAGE_EQUAL, type: 'CallExpression' }],
+    },
+
+    // FILTERBY
+    {
+      code: "computed(function() { return this.chores.filterBy('done', true); })",
+      output: "computed.filterBy('chores', 'done', true)",
+      errors: [{ message: ERROR_MESSAGE_FILTER_BY, type: 'CallExpression' }],
+    },
+
+    // MAPBY
+    {
+      code: "computed(function() { return this.children.mapBy('age'); })",
+      output: "computed.mapBy('children', 'age')",
+      errors: [{ message: ERROR_MESSAGE_MAP_BY, type: 'CallExpression' }],
+    },
+    {
+      code: "computed(function() { return this.nested.children.mapBy('age'); })",
+      output: "computed.mapBy('nested.children', 'age')",
+      errors: [{ message: ERROR_MESSAGE_MAP_BY, type: 'CallExpression' }],
     },
   ],
 });


### PR DESCRIPTION
Fixes #837.