### PR TITLE
Add decorator support to `require-return-from-computed` rule

### DIFF
--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -25,6 +25,7 @@ export default Component.extend({
       const [firstName, lastName] = value.split(/\s+/);
       this.set('firstName', firstName);
       this.set('lastName', lastName);
+      // Missing return here.
     }
   }),
 
@@ -32,6 +33,7 @@ export default Component.extend({
     if (this.firstName) {
       return `Dr. ${this.firstName}`;
     }
+    // Missing return here.
   })
 });
 ```
@@ -74,11 +76,7 @@ To avoid false positives from relying on implicit returns in some code branches,
 ## Related Rules
 
 * [consistent-return] from eslint
+* [getter-return] from eslint
 
 [consistent-return]: https://eslint.org/docs/rules/consistent-return
-
-## Help Wanted
-
-| Issue | Link |
-| :-- | :-- |
-| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |
+[getter-return]: https://eslint.org/docs/rules/getter-return

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ember = require('../utils/ember');
+const { hasDecorator } = require('../utils/types');
 
 //------------------------------------------------------------------------------
 // General rule - Always return a value from computed properties
@@ -8,6 +9,13 @@ const ember = require('../utils/ember');
 
 function isReachable(segment) {
   return segment.reachable;
+}
+
+function isComputedProp(node) {
+  return (
+    ember.isComputedProp(node) ||
+    (node.type === 'MethodDefinition' && hasDecorator(node, 'computed'))
+  );
 }
 
 const ERROR_MESSAGE = 'Always return a value from computed properties';
@@ -51,7 +59,7 @@ module.exports = {
         funcInfo = {
           upper: funcInfo,
           codePath,
-          shouldCheck: context.getAncestors().findIndex(ember.isComputedProp) > -1,
+          shouldCheck: context.getAncestors().findIndex(isComputedProp) > -1,
         };
       },
 
@@ -60,7 +68,7 @@ module.exports = {
       },
 
       'FunctionExpression:exit'(node) {
-        if (ember.isComputedProp(node.parent) || ember.isComputedProp(node.parent.parent.parent)) {
+        if (isComputedProp(node.parent) || isComputedProp(node.parent.parent.parent)) {
           checkLastSegment(node);
         }
       },

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -47,23 +47,46 @@ module.exports = {
  *
  * @param {Object} node The node to check.
  * @param {string?} decoratorName The decorator to look for
+ * @param {boolean?} checkSiblings Whether to check if the decorators are on another MethodDefinition for the same property.
  * @returns {boolean} Whether or not the node has the given decorator.
  */
-function hasDecorator(node, decoratorName) {
-  if (!node.decorators) {
-    return false;
-  }
-  if (!decoratorName) {
+function hasDecorator(node, decoratorName, checkSiblings = true) {
+  if (!decoratorName && node.decorators && node.decorators.length > 0) {
     return true;
   }
 
-  return node.decorators.some((decorator) => {
-    const expression = decorator.expression;
-    return (
-      (isIdentifier(expression) && expression.name === decoratorName) ||
-      (isCallExpression(expression) && expression.callee.name === decoratorName)
-    );
-  });
+  if (
+    node.decorators &&
+    node.decorators.some((decorator) => {
+      const expression = decorator.expression;
+      return (
+        (isIdentifier(expression) && expression.name === decoratorName) ||
+        (isCallExpression(expression) && expression.callee.name === decoratorName)
+      );
+    })
+  ) {
+    return true;
+  }
+
+  // Check if the decorators are on another MethodDefinition for the same property.
+  // Example:
+  //  @computed()
+  //  set myProp(val) {} // The decorator is stored on this MethodDefinition.
+  //  get myProp() {} // The decorator applies to this too but is not stored on this MethodDefinition.
+  return (
+    checkSiblings &&
+    node.type === 'MethodDefinition' &&
+    node.key.type === 'Identifier' &&
+    node.parent.type === 'ClassBody' &&
+    node.parent.body.some(
+      (node2) =>
+        node2 !== node &&
+        node2.type === 'MethodDefinition' &&
+        node2.key.type === 'Identifier' &&
+        node2.key.name === node.key.name &&
+        hasDecorator(node2, decoratorName, false)
+    )
+  );
 }
 
 /**

--- a/tests/lib/utils/types-test.js
+++ b/tests/lib/utils/types-test.js
@@ -196,40 +196,51 @@ describe('isUnaryExpression', () => {
 });
 
 describe('hasDecorator', () => {
-  const expressionlessParse = (code) => babelEslint.parse(code).body[0];
-  const withDecorator = '@classic class Rectangle {}';
-  const withoutDecorator = 'class Rectangle {}';
-  const testCases = [
-    {
-      code: withoutDecorator,
-      decoratorName: undefined,
-      expected: false,
-    },
-    {
-      code: withoutDecorator,
-      decoratorName: 'classic',
-      expected: false,
-    },
-    {
-      code: withDecorator,
-      decoratorName: undefined,
-      expected: true,
-    },
-    {
-      code: withDecorator,
-      decoratorName: 'classic',
-      expected: true,
-    },
-    {
-      code: withDecorator,
-      decoratorName: 'someOtherDecoratorName',
-      expected: false,
-    },
-  ];
-  testCases.forEach(({ code, decoratorName, expected }) => {
-    it(`('${code}', '${decoratorName}') => ${expected}`, () => {
-      const node = expressionlessParse(code);
-      expect(types.hasDecorator(node, decoratorName)).toStrictEqual(expected);
+  describe('with ClassDeclaration', () => {
+    const expressionlessParse = (code) => babelEslint.parse(code).body[0];
+    const withDecorator = '@classic class Rectangle {}';
+    const withoutDecorator = 'class Rectangle {}';
+    const testCases = [
+      {
+        code: withoutDecorator,
+        decoratorName: undefined,
+        expected: false,
+      },
+      {
+        code: withoutDecorator,
+        decoratorName: 'classic',
+        expected: false,
+      },
+      {
+        code: withDecorator,
+        decoratorName: undefined,
+        expected: true,
+      },
+      {
+        code: withDecorator,
+        decoratorName: 'classic',
+        expected: true,
+      },
+      {
+        code: withDecorator,
+        decoratorName: 'someOtherDecoratorName',
+        expected: false,
+      },
+    ];
+    testCases.forEach(({ code, decoratorName, expected }) => {
+      it(`('${code}', '${decoratorName}') => ${expected}`, () => {
+        const node = expressionlessParse(code);
+        expect(types.hasDecorator(node, decoratorName)).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('with MethodDefinition', () => {
+    it('works with one MethodDefinition with a decorator', () => {
+      const node = babelEslint.parse('class Test { @computed get someProp() {} }').body[0].body
+        .body[0];
+      expect(types.hasDecorator(node)).toBeTruthy();
+      expect(types.hasDecorator(node, 'computed')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Helps address #560 #566.

[Rule doc](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-return-from-computed.md) for reference.