### PR TITLE
Explain why `require-return-from-computed` rule does not apply to native classes

### DIFF
--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -4,6 +4,8 @@
 
 Always return a value from a computed property function.
 
+Note that this rule applies only to computed properties in classic classes (i.e. `Component.extend({})`) and not in native JavaScript classes with decorators. ESLint already has two recommended rules [getter-return] and [no-setter-return] that enforce the correct behavior with native classes.
+
 ## Examples
 
 Examples of **incorrect** code for this rule:
@@ -25,6 +27,7 @@ export default Component.extend({
       const [firstName, lastName] = value.split(/\s+/);
       this.set('firstName', firstName);
       this.set('lastName', lastName);
+      // Missing return here.
     }
   }),
 
@@ -32,6 +35,7 @@ export default Component.extend({
     if (this.firstName) {
       return `Dr. ${this.firstName}`;
     }
+    // Missing return here.
   })
 });
 ```
@@ -74,11 +78,9 @@ To avoid false positives from relying on implicit returns in some code branches,
 ## Related Rules
 
 * [consistent-return] from eslint
+* [getter-return] from eslint
+* [no-setter-return] from eslint
 
 [consistent-return]: https://eslint.org/docs/rules/consistent-return
-
-## Help Wanted
-
-| Issue | Link |
-| :-- | :-- |
-| :x: Missing native JavaScript class support | [#560](https://github.com/ember-cli/eslint-plugin-ember/issues/560) |
+[getter-return]: https://eslint.org/docs/rules/getter-return
+[no-setter-return]: https://eslint.org/docs/rules/no-setter-return

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -23,22 +23,13 @@ eslintTester.run('require-return-from-computed', rule, {
     'let foo = computed("test", { get() { data.forEach(function() { }); return true; }, set() { return true; } })',
     'let foo = computed("test", function() { data.forEach(function() { }); return ""; })',
 
-    // Decorator:
     {
-      // TODO: this should be an invalid test case.
-      // Still missing native class and decorator support: https://github.com/ember-cli/eslint-plugin-ember/issues/560
-      code: 'class Test { @computed() get someProp() {} }',
-      parser: require.resolve('babel-eslint'),
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        ecmaFeatures: { legacyDecorators: true },
-      },
-    },
-    {
-      // TODO: this should be an invalid test case.
-      // Still missing native class and decorator support: https://github.com/ember-cli/eslint-plugin-ember/issues/560
-      code: 'class Test { @computed get someProp() {} }',
+      // This rule intentionally does not apply to native classes / decorator usage.
+      // ESLint already has its own recommended rules `getter-return` and `no-setter-return` for this.
+      code: `
+        import { computed } from '@ember/object';
+        class Test { @computed() get someProp() {} set someProp(val) {} }
+      `,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,


### PR DESCRIPTION
Follow-up to #841.

Related: #560 #566.

[Rule doc](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-return-from-computed.md) for reference.