### PR TITLE
Add optional chaining support to `require-computed-property-dependencies` rule

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -224,8 +224,11 @@ function findThisGetCalls(node) {
   new Traverser().traverse(node, {
     enter(child, parent) {
       if (
-        types.isMemberExpression(child) &&
-        !(types.isCallExpression(parent) && parent.callee === child) &&
+        (types.isOptionalMemberExpression(child) || types.isMemberExpression(child)) &&
+        !(
+          (types.isCallExpression(parent) || types.isOptionalCallExpression(parent)) &&
+          parent.callee === child
+        ) &&
         !(types.isAssignmentExpression(child.parent) && child === parent.left) && // Ignore the left side (x) of an assignment: this.x = 123;
         propertyGetterUtils.isSimpleThisExpression(child)
       ) {

--- a/lib/utils/property-getter.js
+++ b/lib/utils/property-getter.js
@@ -87,7 +87,7 @@ function nodeToDependentKey(nodeWithThisExpression, context) {
   return javascriptUtils.removeWhitespace(
     sourceCode
       .getText(nodeWithThisExpression)
-      .replace(/^this\./, '')
+      .replace(/^this\??\./, '')
       .replace(/\?\./g, '.') // Replace any optional chaining.
   );
 }

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -29,6 +29,7 @@ module.exports = {
   isNewExpression,
   isObjectExpression,
   isObjectPattern,
+  isOptionalCallExpression,
   isOptionalMemberExpression,
   isProperty,
   isReturnStatement,
@@ -339,6 +340,16 @@ function isObjectExpression(node) {
  */
 function isObjectPattern(node) {
   return node !== undefined && node.type === 'ObjectPattern';
+}
+
+/**
+ * Check whether or not a node is an OptionalCallExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an OptionalCallExpression.
+ */
+function isOptionalCallExpression(node) {
+  return node.type === 'OptionalCallExpression';
 }
 
 /**

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -135,6 +135,12 @@ ruleTester.run('require-computed-macros', rule, {
       errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }],
     },
     {
+      // Optional chaining unnecessarily used on `this`.
+      code: 'computed(function() { return this?.x?.y?.z; })',
+      output: "computed.reads('x.y.z')",
+      errors: [{ message: ERROR_MESSAGE_READS, type: 'CallExpression' }],
+    },
+    {
       // Decorator:
       code: "class Test { @computed('x') get someProp() { return this.x; } }",
       options: [{ includeNativeGetters: true }],


### PR DESCRIPTION
Detect the dependent keys needed when using examples like this inside computed property getter bodies:
* `this.x?.y` requires `x.y` as a dependent key
* `this.x?.y()` requires `x` as a dependent key

Fixes #847.