### PR TITLE
Handle nested paths with ES5 setters in `no-side-effects` rule

### DIFF
--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -3,6 +3,7 @@
 const types = require('../utils/types');
 const ember = require('../utils/ember');
 const computedPropertyUtils = require('../utils/computed-properties');
+const propertySetterUtils = require('../utils/property-setter');
 const emberUtils = require('../utils/ember');
 const Traverser = require('../utils/traverser');
 
@@ -27,15 +28,6 @@ function isEmberSet(node, emberImportAliasName) {
   );
 }
 
-function isThisSet(node) {
-  return (
-    types.isAssignmentExpression(node) &&
-    types.isMemberExpression(node.left) &&
-    types.isThisExpression(node.left.object) &&
-    types.isIdentifier(node.left.property)
-  );
-}
-
 /**
  * Recursively finds calls that could be side effects in a computed property function body.
  *
@@ -48,7 +40,7 @@ function findSideEffects(computedPropertyBody, emberImportAliasName) {
 
   new Traverser().traverse(computedPropertyBody, {
     enter(child) {
-      if (isEmberSet(child, emberImportAliasName) || isThisSet(child)) {
+      if (isEmberSet(child, emberImportAliasName) || propertySetterUtils.isThisSet(child)) {
         results.push(child);
       }
     },

--- a/lib/utils/property-setter.js
+++ b/lib/utils/property-setter.js
@@ -1,0 +1,30 @@
+const types = require('./types');
+
+module.exports = {
+  isThisSet,
+};
+
+/**
+ * Checks if an AssignmentExpression looks like `this.x =` or `this.x.y =`.
+ *
+ * @param {Node} node The AssignmentExpression node to check.
+ * @returns {boolean} Whether the node looks as expected.
+ */
+function isThisSet(node) {
+  if (!types.isAssignmentExpression(node)) {
+    return false;
+  }
+
+  let current = node.left;
+  if (!types.isMemberExpression(current)) {
+    return false;
+  }
+  while (types.isMemberExpression(current.object)) {
+    current = current.object;
+  }
+  if (!types.isThisExpression(current.object)) {
+    return false;
+  }
+
+  return true;
+}

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -68,6 +68,7 @@ eslintTester.run('no-side-effects', rule, {
     "this.set('x', 123);",
     'this.setProperties({ x: 123 });',
     'this.x = 123;',
+    'this.x.y = 123;',
   ],
   invalid: [
     {
@@ -297,7 +298,20 @@ eslintTester.run('no-side-effects', rule, {
     },
 
     {
+      // ES5 setter:
       code: 'computed("test", function() { this.x = 123; })',
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'AssignmentExpression',
+        },
+      ],
+    },
+
+    {
+      // ES5 setter with nested path:
+      code: 'computed("test", function() { this.x.y = 123; })',
       output: null,
       errors: [
         {

--- a/tests/lib/utils/property-setter-test.js
+++ b/tests/lib/utils/property-setter-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const babelEslint = require('babel-eslint');
+const propertySetterUtils = require('../../../lib/utils/property-setter');
+
+function parse(code) {
+  return babelEslint.parse(code).body[0];
+}
+
+describe('isThisSet', () => {
+  it('behaves correctly', () => {
+    // False:
+    expect(propertySetterUtils.isThisSet(parse('this.x').expression)).toBeFalsy();
+    expect(propertySetterUtils.isThisSet(parse('this.x()').expression)).toBeFalsy();
+    expect(propertySetterUtils.isThisSet(parse('let x = 123;'))).toBeFalsy();
+    expect(propertySetterUtils.isThisSet(parse('x = 123;'))).toBeFalsy();
+
+    // True:
+    expect(propertySetterUtils.isThisSet(parse('this.x = 123').expression)).toBeTruthy();
+    expect(propertySetterUtils.isThisSet(parse('this.x.y = 123').expression)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
CC: @mongoose700 