### PR TITLE
Ignore the left side of an assignment (nested path case) in `require-computed-property-dependencies` rule

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -5,6 +5,7 @@ const emberUtils = require('../utils/ember');
 const computedPropertyUtils = require('../utils/computed-properties');
 const javascriptUtils = require('../utils/javascript');
 const types = require('../utils/types');
+const utils = require('../utils/utils');
 const propertyGetterUtils = require('../utils/property-getter');
 const computedPropertyDependentKeyUtils = require('../utils/computed-property-dependent-keys');
 const assert = require('assert');
@@ -213,6 +214,31 @@ function findInjectedServiceNames(node) {
 }
 
 /**
+ * Check whether a node is inside the left side of an AssignmentExpression.
+ *
+ * Example:
+ * - this.x.y = 123;
+ * Nodes in the left side of this example:
+ * - this
+ * - x
+ * - y
+ *
+ * @param {Node} node - node to check
+ * @returns {boolean} - whether the node is inside the left side of the given AssignmentExpression
+ */
+function isInLeftSideOfAssignmentExpression(node) {
+  return Boolean(
+    utils.getAncestor(
+      node,
+      (ancestor) =>
+        ancestor.parent &&
+        types.isAssignmentExpression(ancestor.parent) &&
+        ancestor === ancestor.parent.left
+    )
+  );
+}
+
+/**
  * Recursively finds all `this.property` usages.
  *
  * @param {ASTNode} node
@@ -229,7 +255,7 @@ function findThisGetCalls(node) {
           (types.isCallExpression(parent) || types.isOptionalCallExpression(parent)) &&
           parent.callee === child
         ) &&
-        !(types.isAssignmentExpression(child.parent) && child === parent.left) && // Ignore the left side (x) of an assignment: this.x = 123;
+        !isInLeftSideOfAssignmentExpression(child) && // Ignore the left side (x) of an assignment: this.x = 123;
         propertyGetterUtils.isSimpleThisExpression(child)
       ) {
         results.push(child);

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -86,6 +86,8 @@ ruleTester.run('require-computed-property-dependencies', rule, {
     `,
     // Should ignore the left side of an assignment.
     "Ember.computed('right', function() { this.left = this.right; })",
+    // Should ignore the left side of an assignment with nested path.
+    "Ember.computed('right', function() { this.left1.left2 = this.right; })",
     // Explicit getter function:
     `
       computed('firstName', 'lastName', {


### PR DESCRIPTION
Follow-up to #786.

CC: @mongoose700 