### PR TITLE
Extract some computed property dependent key utils into util file

### DIFF
--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -114,53 +114,6 @@ function parseComputedDependencies(args) {
   return { keys, dynamicKeys };
 }
 
-const ARRAY_PROPERTIES = new Set(['length', 'firstObject', 'lastObject']);
-
-/**
- * Determines whether a computed property dependency matches a key path.
- *
- * @param {string} dependency
- * @param {string} keyPath
- * @returns {boolean}
- */
-function computedPropertyDependencyMatchesKeyPath(dependency, keyPath) {
-  const dependencyParts = dependency.split('.');
-  const keyPathParts = keyPath.split('.');
-  const minLength = Math.min(dependencyParts.length, keyPathParts.length);
-
-  for (let i = 0; i < minLength; i++) {
-    const dependencyPart = dependencyParts[i];
-    const keyPathPart = keyPathParts[i];
-
-    if (dependencyPart === keyPathPart) {
-      continue;
-    }
-
-    // When dealing with arrays some keys encompass others. For example, `@each`
-    // encompasses `[]` and `length` because any `@each` is triggered on any
-    // array mutation as well as for some element property. `[]` is triggered
-    // only on array mutation and so will always be triggered when `@each` is.
-    // Similarly, `length` will always trigger if `[]` triggers and so is
-    // encompassed by it.
-    if (dependencyPart === '[]' || dependencyPart === '@each') {
-      const subordinateProperties = new Set(ARRAY_PROPERTIES);
-
-      if (dependencyPart === '@each') {
-        subordinateProperties.add('[]');
-      }
-
-      return (
-        !keyPathPart || (keyPathParts.length === i + 1 && subordinateProperties.has(keyPathPart))
-      );
-    }
-
-    return false;
-  }
-
-  // len(foo.bar.baz) > len(foo.bar), and so matches.
-  return dependencyParts.length > keyPathParts.length;
-}
-
 /**
  * Recursively finds all calls to `Ember#get`, whether like `Ember.get(this, …)`
  * or `this.get(…)`.
@@ -328,24 +281,10 @@ function extractThisGetDependencies(memberExpression, context) {
   return propertyGetterUtils.nodeToDependentKey(memberExpression, context);
 }
 
-/**
- * Checks if the `key` is a prefix of any item in `keys`.
- *
- * Example:
- *    `keys`: `['a', 'b.c']`
- *    `key`: `'b'`
- *    Result: `true`
- *
- * @param {String[]} keys - list of dependent keys
- * @param {String} key - dependent key
- * @returns boolean
- */
-function keyExistsAsPrefixInList(keys, key) {
-  return keys.some((currentKey) => computedPropertyDependencyMatchesKeyPath(currentKey, key));
-}
-
 function removeRedundantKeys(keys) {
-  return keys.filter((currentKey) => !keyExistsAsPrefixInList(keys, currentKey));
+  return keys.filter(
+    (currentKey) => !computedPropertyDependentKeyUtils.keyExistsAsPrefixInList(keys, currentKey)
+  );
 }
 
 function removeServiceNames(keys, serviceNames) {
@@ -435,7 +374,10 @@ module.exports = {
             expandedDeclaredKeys.every(
               (declaredKey) =>
                 declaredKey !== usedKey &&
-                !computedPropertyDependencyMatchesKeyPath(declaredKey, usedKey)
+                !computedPropertyDependentKeyUtils.computedPropertyDependencyMatchesKeyPath(
+                  declaredKey,
+                  usedKey
+                )
             )
           )
           .reduce((keys, key) => {

--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -6,6 +6,8 @@ module.exports = {
   collapseKeys,
   expandKeys,
   expandKey,
+  computedPropertyDependencyMatchesKeyPath,
+  keyExistsAsPrefixInList,
 };
 
 function isBare(key) {
@@ -96,4 +98,67 @@ function expandKey(key) {
     // Example: "hello.world"
     return key;
   }
+}
+
+const ARRAY_PROPERTIES = new Set(['length', 'firstObject', 'lastObject']);
+
+/**
+ * Determines whether a computed property dependency matches a key path.
+ *
+ * @param {string} dependency
+ * @param {string} keyPath
+ * @returns {boolean}
+ */
+function computedPropertyDependencyMatchesKeyPath(dependency, keyPath) {
+  const dependencyParts = dependency.split('.');
+  const keyPathParts = keyPath.split('.');
+  const minLength = Math.min(dependencyParts.length, keyPathParts.length);
+
+  for (let i = 0; i < minLength; i++) {
+    const dependencyPart = dependencyParts[i];
+    const keyPathPart = keyPathParts[i];
+
+    if (dependencyPart === keyPathPart) {
+      continue;
+    }
+
+    // When dealing with arrays some keys encompass others. For example, `@each`
+    // encompasses `[]` and `length` because any `@each` is triggered on any
+    // array mutation as well as for some element property. `[]` is triggered
+    // only on array mutation and so will always be triggered when `@each` is.
+    // Similarly, `length` will always trigger if `[]` triggers and so is
+    // encompassed by it.
+    if (dependencyPart === '[]' || dependencyPart === '@each') {
+      const subordinateProperties = new Set(ARRAY_PROPERTIES);
+
+      if (dependencyPart === '@each') {
+        subordinateProperties.add('[]');
+      }
+
+      return (
+        !keyPathPart || (keyPathParts.length === i + 1 && subordinateProperties.has(keyPathPart))
+      );
+    }
+
+    return false;
+  }
+
+  // len(foo.bar.baz) > len(foo.bar), and so matches.
+  return dependencyParts.length > keyPathParts.length;
+}
+
+/**
+ * Checks if the `key` is a prefix of any item in `keys`.
+ *
+ * Example:
+ *    `keys`: `['a', 'b.c']`
+ *    `key`: `'b'`
+ *    Result: `true`
+ *
+ * @param {String[]} keys - list of dependent keys
+ * @param {String} key - dependent key
+ * @returns boolean
+ */
+function keyExistsAsPrefixInList(keys, key) {
+  return keys.some((currentKey) => computedPropertyDependencyMatchesKeyPath(currentKey, key));
 }

--- a/tests/lib/utils/computed-property-dependent-keys-test.js
+++ b/tests/lib/utils/computed-property-dependent-keys-test.js
@@ -35,3 +35,36 @@ describe('expandKey', () => {
     expect(cpdkUtils.expandKey('{foo,bar}')).toStrictEqual(['foo', 'bar']);
   });
 });
+
+describe('computedPropertyDependencyMatchesKeyPath', () => {
+  it('returns the right result', () => {
+    // False:
+    expect(cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo', 'bar')).toStrictEqual(false);
+    expect(cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo.bar', 'bar')).toStrictEqual(
+      false
+    );
+
+    // True:
+    expect(cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo.bar', 'foo')).toStrictEqual(
+      true
+    );
+    expect(
+      cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo.@each.bar', 'foo')
+    ).toStrictEqual(true);
+    expect(cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo.[]', 'foo')).toStrictEqual(true);
+    expect(
+      cpdkUtils.computedPropertyDependencyMatchesKeyPath('foo.bar.xyz', 'foo.bar')
+    ).toStrictEqual(true);
+  });
+});
+
+describe('keyExistsAsPrefixInList', () => {
+  it('returns the right result', () => {
+    // False:
+    expect(cpdkUtils.keyExistsAsPrefixInList(['a', 'b.c'], 'x')).toStrictEqual(false);
+    expect(cpdkUtils.keyExistsAsPrefixInList(['a', 'b.c'], 'c')).toStrictEqual(false);
+
+    // True:
+    expect(cpdkUtils.keyExistsAsPrefixInList(['a', 'b.c'], 'b')).toStrictEqual(true);
+  });
+});


### PR DESCRIPTION
For use in upcoming `no-assignment-of-untracked-properties-used-in-tracking-contexts` rule.