### PR TITLE
Fix default value of `ignoreClassic` option to be true for `no-computed-properties-in-native-classes` rule

### DIFF
--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -53,7 +53,7 @@ module.exports = {
   },
 
   create(context) {
-    const ignoreClassic = context.options[0] && context.options[0].ignoreClassic;
+    const ignoreClassic = !context.options[0] || context.options[0].ignoreClassic;
     let computedNodes = [];
 
     const report = function (node) {

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -107,6 +107,17 @@ ruleTester.run('no-computed-properties-in-native-classes', rule, {
         },
       ],
     },
+    {
+      code: `
+        import { computed } from '@ember/object';
+        import Component from '@ember/component';
+        import classic from 'ember-classic-decorator';
+
+        @classic
+        export default class MyComponent extends Component {}
+      `,
+      options: [], // default options should be: [{ ignoreClassic: true }]
+    },
 
     // Unrelated import statements:
     "import EmberObject from '@ember/object';",


### PR DESCRIPTION
### What
- ensures `no-computed-properties-in-native-classes` defaults the config to: `ignoreClassic: true`

### Why
- fixes #849