### PR TITLE
Fix false negatives in `no-invalid-test-waiters` rule

### DIFF
--- a/lib/rules/no-invalid-test-waiters.js
+++ b/lib/rules/no-invalid-test-waiters.js
@@ -42,7 +42,10 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        buildWaiter = getImportIdentifier(node, 'ember-test-waiters', 'buildWaiter');
+        if (node.source.value === 'ember-test-waiters') {
+          buildWaiter =
+            buildWaiter || getImportIdentifier(node, 'ember-test-waiters', 'buildWaiter');
+        }
       },
 
       CallExpression(node) {

--- a/tests/lib/rules/no-invalid-test-waiters.js
+++ b/tests/lib/rules/no-invalid-test-waiters.js
@@ -16,6 +16,8 @@ ruleTester.run('no-invalid-test-waiters', rule, {
   valid: [
     `
     import { buildWaiter } from 'ember-test-waiters';
+    import { random } from 'random';
+    import { somethingElse } from 'ember-test-waiters';
 
     let myWaiter = buildWaiter('waiterName');
   `,
@@ -52,6 +54,8 @@ ruleTester.run('no-invalid-test-waiters', rule, {
     {
       code: `
       import { buildWaiter } from 'ember-test-waiters';
+      import { random } from 'random';
+      import { somethingElse } from 'ember-test-waiters';
 
       function useWaiter() {
           let myOtherWaiter = buildWaiter('the second');


### PR DESCRIPTION
Any import statement after the `ember-test-waiters` import would cause this rule to lose track of the imported `buildWaiter` name and thus no longer report any violations.