### PR TITLE
Remove invalid test case with no error

### DIFF
--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -74,12 +74,6 @@ ruleTester.run('no-arrow-function-computed-properties', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],
     },
     {
-      code: 'computed(() => { return 123; })',
-      output: null,
-      errors: [],
-      options: [{ onlyThisContexts: true }],
-    },
-    {
       code: "computed('prop', () => { return this.prop; })",
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'ArrowFunctionExpression' }],


### PR DESCRIPTION
This gets caught by ESLint 7.3.0.