### PR TITLE
Add option for custom computed property macros in `no-assignment-of-untracked-properties-used-in-tracking-contexts` rule

### DIFF
--- a/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
+++ b/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
@@ -86,6 +86,7 @@ The autofixer for this rule will update assignments to use `set`. Alternatively,
         * array -- `keys` -- Array of strings for which keys values should be checked for. If not provided, all values will be checked.
 
 Example configuration:
+
 ```js
 module.exports = {
   rules: {
@@ -121,7 +122,7 @@ module.exports = {
     }
   }
 };
-```        
+```
 
 ## References
 

--- a/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
+++ b/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
@@ -69,6 +69,60 @@ class MyComponent extends Component {
 
 The autofixer for this rule will update assignments to use `set`. Alternatively, you can begin using tracked properties.
 
+## Configuration
+
+* object -- containing the following properties:
+  * array -- `extraMacros` -- array of configurations for custom macros, each with the following properties:
+    * string -- `name` -- The name the macro is exported with
+    * string -- `path` -- The file path used for importing the macro
+    * string -- `indexName` -- If this macro can also be imported through an index (like `computed` for `computed.and`), include it here
+    * string -- `indexPath` -- The path for importing the index
+    * array -- `argumentFormat` -- array of configurations for how to parse the arguments of the macro to extract the computed dependencies, with at least one of the following properties:
+      * object -- `strings` -- Configuration for extracting raw strings from the argument list, with the following options:
+        * number -- `count` -- How many arguments to consider as dependencies. Use `Number.MAX_VALUE` for all of them.
+        * number -- `startIndex` -- Defaults to zero. If it's something else, that many arguments will be skipped before checking for `count` dependencies.
+      * object -- `objects` -- Configuration for extracting the values of an object as dependency keys, with the following properties:
+        * number -- `index` -- The index of the argument to be checked.
+        * array -- `keys` -- Array of strings for which keys values should be checked for. If not provided, all values will be checked.
+
+Example configuration:
+```js
+module.exports = {
+  rules: {
+    'ember/no-assignment-of-untracked-properties-used-in-tracking-contexts': {
+      extraMacros: [
+        {
+          name: 'rejectBy',
+          path: 'custom-macros/macros',
+          indexName: 'customComputed',
+          indexPath: 'custom-macros',
+          argumentFormat: [
+            {
+              strings: {
+                count: 1
+              }
+            }
+          ]
+        },
+        {
+          name: 't',
+          path: 'custom-macros/macros',
+          indexName: 'customComputed',
+          indexPath: 'custom-macros',
+          argumentFormat: [
+            {
+              objects: {
+                index: 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+};
+```        
+
 ## References
 
 * [Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/set) for `set()`

--- a/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -11,6 +11,38 @@ const {
   keyExistsAsPrefixInList,
 } = require('../utils/computed-property-dependent-keys');
 
+function createMacrosByPathMap(macroConfigurations) {
+  const macrosByPath = new Map();
+
+  macroConfigurations.forEach((config) => {
+    if (!macrosByPath.has(config.path)) {
+      macrosByPath.set(config.path, new Map());
+    }
+
+    macrosByPath.get(config.path).set(config.name, config);
+  });
+
+  return macrosByPath;
+}
+
+function createMacrosByIndexPathMap(macroConfigurations) {
+  const macrosByIndexPath = new Map();
+
+  macroConfigurations.forEach((config) => {
+    if (!macrosByIndexPath.has(config.indexPath)) {
+      macrosByIndexPath.set(config.indexPath, new Map());
+    }
+
+    if (!macrosByIndexPath.get(config.indexPath).has(config.indexName)) {
+      macrosByIndexPath.get(config.indexPath).set(config.indexName, new Map());
+    }
+
+    macrosByIndexPath.get(config.indexPath).get(config.indexName).set(config.name, config);
+  });
+
+  return macrosByIndexPath;
+}
+
 const ERROR_MESSAGE =
   "Use `set(this, 'propertyName', 'value')` instead of assignment for untracked properties that are used as computed property dependencies (or convert to using tracked properties).";
 
@@ -80,6 +112,8 @@ module.exports = {
                 path: {
                   type: 'string',
                   minLength: 1,
+                  // Extra macros cannot be in @ember/
+                  pattern: '^(?!@ember/).+/',
                 },
                 name: {
                   type: 'string',
@@ -88,6 +122,8 @@ module.exports = {
                 indexPath: {
                   type: 'string',
                   minLength: 1,
+                  // Extra macros cannot be in @ember/
+                  pattern: '^(?!@ember/).+/',
                 },
                 indexName: {
                   type: 'string',
@@ -162,23 +198,8 @@ module.exports = {
 
     const macroConfigurations = [...DEFAULT_MACRO_CONFIGURATIONS, ...options.extraMacros];
 
-    const macrosByPath = new Map();
-    const macrosByIndexPath = new Map();
-
-    macroConfigurations.forEach((config) => {
-      if (!macrosByPath.has(config.path)) {
-        macrosByPath.set(config.path, new Map());
-      }
-      macrosByPath.get(config.path).set(config.name, config);
-
-      if (!macrosByIndexPath.has(config.indexPath)) {
-        macrosByIndexPath.set(config.indexPath, new Map());
-      }
-      if (!macrosByIndexPath.get(config.indexPath).has(config.indexName)) {
-        macrosByIndexPath.get(config.indexPath).set(config.indexName, new Map());
-      }
-      macrosByIndexPath.get(config.indexPath).get(config.indexName).set(config.name, config);
-    });
+    const macrosByPath = createMacrosByPathMap(macroConfigurations);
+    const macrosByIndexPath = createMacrosByIndexPathMap(macroConfigurations);
 
     // State being tracked for this file.
     let trackedImportName = undefined;
@@ -194,6 +215,7 @@ module.exports = {
       ImportDeclaration(node) {
         const importPath = node.source.value;
 
+        // Checking for something like `import { readOnly } from '@ember/object/computed;`
         if (macrosByPath.has(importPath)) {
           const newMacroImportNameEntries = [...macrosByPath.get(importPath)]
             .map(([name, config]) => [getImportIdentifier(node, importPath, name), config])
@@ -201,6 +223,7 @@ module.exports = {
           macrosByName = new Map([...macrosByName, ...newMacroImportNameEntries]);
         }
 
+        // Checking for something like `import { computed } from '@ember/object;`
         if (macrosByIndexPath.has(importPath)) {
           const newMacroIndexImportEntries = [...macrosByIndexPath.get(importPath)]
             .map(([indexName, propertyConfigs]) => [

--- a/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -5,7 +5,7 @@ const types = require('../utils/types');
 const decoratorUtils = require('../utils/decorators');
 const propertySetterUtils = require('../utils/property-setter');
 const { getImportIdentifier } = require('../utils/import');
-const { getMacros } = require('../utils/computed-property-macros');
+const { DEFAULT_MACRO_CONFIGURATIONS } = require('../utils/computed-property-macros');
 const {
   findComputedPropertyDependentKeys,
   keyExistsAsPrefixInList,
@@ -63,7 +63,91 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md',
     },
     fixable: 'code',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          extraMacros: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['path', 'name'],
+              dependencies: {
+                indexPath: ['indexName'],
+                indexName: ['indexPath'],
+              },
+              properties: {
+                path: {
+                  type: 'string',
+                  minLength: 1,
+                },
+                name: {
+                  type: 'string',
+                  minLength: 1,
+                },
+                indexPath: {
+                  type: 'string',
+                  minLength: 1,
+                },
+                indexName: {
+                  type: 'string',
+                  minLength: 1,
+                },
+                argumentFormat: {
+                  type: 'array',
+                  minItems: 1,
+                  items: {
+                    type: 'object',
+                    properties: {
+                      strings: {
+                        type: 'object',
+                        properties: {
+                          startIndex: {
+                            type: 'number',
+                            multipleOf: 1,
+                            default: 0,
+                            minimum: 0,
+                          },
+                          count: {
+                            type: 'number',
+                            default: Number.MAX_VALUE,
+                            multipleOf: 1,
+                            minimum: 1,
+                          },
+                        },
+                      },
+                      objects: {
+                        type: 'object',
+                        required: ['index'],
+                        properties: {
+                          keys: {
+                            type: 'array',
+                            minItems: 1,
+                            items: {
+                              type: 'string',
+                              minLength: 1,
+                            },
+                          },
+                          index: {
+                            type: 'number',
+                            multipleOf: 1,
+                            minimum: 0,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   ERROR_MESSAGE,
@@ -74,29 +158,64 @@ module.exports = {
       return {};
     }
 
+    const options = context.options[0] || { extraMacros: [] };
+
+    const macroConfigurations = [...DEFAULT_MACRO_CONFIGURATIONS, ...options.extraMacros];
+
+    const macrosByPath = new Map();
+    const macrosByIndexPath = new Map();
+
+    macroConfigurations.forEach((config) => {
+      if (!macrosByPath.has(config.path)) {
+        macrosByPath.set(config.path, new Map());
+      }
+      macrosByPath.get(config.path).set(config.name, config);
+
+      if (!macrosByIndexPath.has(config.indexPath)) {
+        macrosByIndexPath.set(config.indexPath, new Map());
+      }
+      if (!macrosByIndexPath.get(config.indexPath).has(config.indexName)) {
+        macrosByIndexPath.get(config.indexPath).set(config.indexName, new Map());
+      }
+      macrosByIndexPath.get(config.indexPath).get(config.indexName).set(config.name, config);
+    });
+
     // State being tracked for this file.
-    let computedImportName = undefined;
     let trackedImportName = undefined;
+    let computedImportName = undefined;
     let setImportName = undefined;
-    let macroImportNames = new Map();
+    let macrosByName = new Map();
+    let macrosByIndexName = new Map();
 
     // State being tracked for the current class we're inside.
     const classStack = new Stack();
 
     return {
       ImportDeclaration(node) {
+        const importPath = node.source.value;
+
+        if (macrosByPath.has(importPath)) {
+          const newMacroImportNameEntries = [...macrosByPath.get(importPath)]
+            .map(([name, config]) => [getImportIdentifier(node, importPath, name), config])
+            .filter(([importedName]) => importedName);
+          macrosByName = new Map([...macrosByName, ...newMacroImportNameEntries]);
+        }
+
+        if (macrosByIndexPath.has(importPath)) {
+          const newMacroIndexImportEntries = [...macrosByIndexPath.get(importPath)]
+            .map(([indexName, propertyConfigs]) => [
+              getImportIdentifier(node, importPath, indexName),
+              propertyConfigs,
+            ])
+            .filter(([importedName]) => importedName);
+
+          macrosByIndexName = new Map([...macrosByIndexName, ...newMacroIndexImportEntries]);
+        }
+
         if (node.source.value === '@ember/object') {
+          setImportName = setImportName || getImportIdentifier(node, '@ember/object', 'set');
           computedImportName =
             computedImportName || getImportIdentifier(node, '@ember/object', 'computed');
-          setImportName = setImportName || getImportIdentifier(node, '@ember/object', 'set');
-        } else if (node.source.value === '@ember/object/computed') {
-          macroImportNames = new Map(
-            getMacros().map((macro) => [
-              macro,
-              macroImportNames.get(macro) ||
-                getImportIdentifier(node, '@ember/object/computed', macro),
-            ])
-          );
         } else if (node.source.value === '@glimmer/tracking') {
           trackedImportName =
             trackedImportName || getImportIdentifier(node, '@glimmer/tracking', 'tracked');
@@ -109,7 +228,8 @@ module.exports = {
         const computedPropertyDependentKeys = findComputedPropertyDependentKeys(
           node,
           computedImportName,
-          macroImportNames
+          macrosByName,
+          macrosByIndexName
         );
 
         // Gather tracked properties from this class.
@@ -133,7 +253,8 @@ module.exports = {
           const computedPropertyDependentKeys = findComputedPropertyDependentKeys(
             node,
             computedImportName,
-            macroImportNames
+            macrosByName,
+            macrosByIndexName
           );
 
           // No tracked properties in classic classes.

--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -243,6 +243,63 @@ function findComputedPropertyDependentKeys(
 }
 
 /**
+ * Returns an array of the dependency keys for a particular argument and index for a particular configuration.
+ *
+ * @param {Object} argument - the argument to a computed macro
+ * @param {number} index - the index of this particular argument for the computed macro
+ * @param {Object} config - the configuration indicating how dependent keys should be gotten from the argument
+ * @param {Object} [config.strings] - the configuration for which string arguments should be used
+ * @param {number} config.strings.startIndex - the first index to look for string arguments
+ * @param {number} config.strings.count - how many arguments to look at, including the start index.
+ * @param {Object} [config.objects] - the configuration for which object arguments' values should  be used
+ * @param {Object} config.objects.index - the argument index to look for object values in
+ * @param {Object} [config.objects.allowedKeys] - if present, indicates which keys should be looked at for getting values.
+ *   If not present, all key/value pairs will be used.
+ * @returns {String[]} - the list of string dependent keys indicated by the configuration.
+ */
+function getComputedPropertyDependentKeysForConfig(argument, index, { strings, objects }) {
+  if (strings) {
+    const { startIndex, count } = strings;
+    if (
+      index >= startIndex &&
+      index < startIndex + count &&
+      argument.type === 'Literal' &&
+      typeof argument.value === 'string'
+    ) {
+      return [argument.value];
+    }
+  }
+
+  if (objects) {
+    const { index: configIndex, keys: allowedKeys } = objects;
+
+    if (index === configIndex && argument.type === 'ObjectExpression') {
+      return argument.properties
+        .filter(({ key }) => {
+          if (!allowedKeys) {
+            return true;
+          }
+
+          if (key.type === 'Identifier') {
+            return allowedKeys.includes(key.name);
+          } else if (key.type === 'Literal' && typeof key.value === 'string') {
+            return allowedKeys.includes(key.value);
+          } else {
+            return false;
+          }
+        })
+        .filter(
+          (property) =>
+            property.value.type === 'Literal' && typeof property.value.value === 'string'
+        )
+        .map((property) => property.value.value);
+    }
+  }
+
+  return [];
+}
+
+/**
  * Gets the list of string dependent keys from a computed property.
  *
  * @param {Node} node - the computed property node
@@ -266,45 +323,7 @@ function getComputedPropertyDependentKeys(node, computedDependenciesConfig = nul
     return javascriptUtils.flatMap(
       computedDependenciesConfig.argumentFormat,
       ({ strings, objects }) => {
-        if (strings) {
-          const { startIndex, count } = strings;
-          if (
-            index >= startIndex &&
-            index < startIndex + count &&
-            argument.type === 'Literal' &&
-            typeof argument.value === 'string'
-          ) {
-            return [argument.value];
-          }
-        }
-
-        if (objects) {
-          const { index: configIndex, keys: allowedKeys } = objects;
-
-          if (index === configIndex && argument.type === 'ObjectExpression') {
-            return argument.properties
-              .filter(({ key }) => {
-                if (!allowedKeys) {
-                  return true;
-                }
-
-                if (key.type === 'Identifier') {
-                  return allowedKeys.includes(key.name);
-                } else if (key.type === 'Literal' && typeof key.value === 'string') {
-                  return allowedKeys.includes(key.value);
-                } else {
-                  return false;
-                }
-              })
-              .filter(
-                (property) =>
-                  property.value.type === 'Literal' && typeof property.value.value === 'string'
-              )
-              .map((property) => property.value.value);
-          }
-        }
-
-        return [];
+        return getComputedPropertyDependentKeysForConfig(argument, index, { strings, objects });
       }
     );
   });

--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -5,11 +5,7 @@ const { getName } = require('../utils/utils');
 const types = require('../utils/types');
 const decoratorUtils = require('../utils/decorators');
 const assert = require('assert');
-const {
-  getMacrosFromImportNames,
-  getTrackedArgumentCount,
-  macroToCanonicalName,
-} = require('../utils/computed-property-macros');
+const { getMacrosFromImports } = require('../utils/computed-property-macros');
 
 module.exports = {
   collapseKeys,
@@ -179,7 +175,12 @@ function keyExistsAsPrefixInList(keys, key) {
  * @param {Node} nodeClass - Node for the class
  * @returns {Set<string>} - set of dependent keys used inside the class
  */
-function findComputedPropertyDependentKeys(nodeClass, computedImportName, macroImportNames) {
+function findComputedPropertyDependentKeys(
+  nodeClass,
+  computedImportName,
+  macrosByName,
+  macrosByIndexName
+) {
   if (types.isClassDeclaration(nodeClass)) {
     // Native JS class.
     return new Set(
@@ -191,19 +192,14 @@ function findComputedPropertyDependentKeys(nodeClass, computedImportName, macroI
         }
 
         // Check for a computed macro.
-        const macroNames = getMacrosFromImportNames(computedImportName, macroImportNames);
+        const macroConfigsByName = getMacrosFromImports(macrosByName, macrosByIndexName);
         const macroDecorator = decoratorUtils.findDecoratorByNameCallback(node, (decoratorName) =>
-          macroNames.has(decoratorName)
+          macroConfigsByName.has(decoratorName)
         );
         if (macroDecorator) {
           return getComputedPropertyDependentKeys(
             macroDecorator.expression,
-            getTrackedArgumentCount(
-              macroToCanonicalName(
-                decoratorUtils.getDecoratorName(macroDecorator),
-                macroImportNames
-              )
-            )
+            macroConfigsByName.get(decoratorUtils.getDecoratorName(macroDecorator))
           );
         }
 
@@ -229,12 +225,9 @@ function findComputedPropertyDependentKeys(nodeClass, computedImportName, macroI
               }
 
               // Check for a computed macro.
-              const macroNames = getMacrosFromImportNames(computedImportName, macroImportNames);
-              if (macroNames.has(name)) {
-                return getComputedPropertyDependentKeys(
-                  node.value,
-                  getTrackedArgumentCount(macroToCanonicalName(name, macroImportNames))
-                );
+              const macroConfigsByName = getMacrosFromImports(macrosByName, macrosByIndexName);
+              if (macroConfigsByName.has(name)) {
+                return getComputedPropertyDependentKeys(node.value, macroConfigsByName.get(name));
               }
             }
             return [];
@@ -256,15 +249,65 @@ function findComputedPropertyDependentKeys(nodeClass, computedImportName, macroI
  * @param {number} dependentKeyArgumentCount - number of arguments to check for dependent keys
  * @returns {String[]} - the list of string dependent keys from this computed property
  */
-function getComputedPropertyDependentKeys(node, dependentKeyArgumentCount = Number.MAX_VALUE) {
+function getComputedPropertyDependentKeys(node, computedDependenciesConfig = null) {
   if (!node.arguments) {
     return [];
   }
 
-  return expandKeys(
-    node.arguments
-      .slice(0, dependentKeyArgumentCount)
-      .filter((arg) => arg.type === 'Literal' && typeof arg.value === 'string')
-      .map((node) => node.value)
-  );
+  const baseKeys = javascriptUtils.flatMap(node.arguments, (argument, index) => {
+    if (!computedDependenciesConfig) {
+      if (argument.type === 'Literal' && typeof argument.value === 'string') {
+        return [argument.value];
+      } else {
+        return [];
+      }
+    }
+
+    return javascriptUtils.flatMap(
+      computedDependenciesConfig.argumentFormat,
+      ({ strings, objects }) => {
+        if (strings) {
+          const { startIndex, count } = strings;
+          if (
+            index >= startIndex &&
+            index < startIndex + count &&
+            argument.type === 'Literal' &&
+            typeof argument.value === 'string'
+          ) {
+            return [argument.value];
+          }
+        }
+
+        if (objects) {
+          const { index: configIndex, keys: allowedKeys } = objects;
+
+          if (index === configIndex && argument.type === 'ObjectExpression') {
+            return argument.properties
+              .filter(({ key }) => {
+                if (!allowedKeys) {
+                  return true;
+                }
+
+                if (key.type === 'Identifier') {
+                  return allowedKeys.includes(key.name);
+                } else if (key.type === 'Literal' && typeof key.value === 'string') {
+                  return allowedKeys.includes(key.value);
+                } else {
+                  return false;
+                }
+              })
+              .filter(
+                (property) =>
+                  property.value.type === 'Literal' && typeof property.value.value === 'string'
+              )
+              .map((property) => property.value.value);
+          }
+        }
+
+        return [];
+      }
+    );
+  });
+
+  return expandKeys(baseKeys);
 }

--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -170,9 +170,23 @@ function keyExistsAsPrefixInList(keys, key) {
 }
 
 /**
+ * A configuration for determining what arguments of a computed macro should be used as dependency keys
+ * @typedef {Object} ComputedMacroConfiguration
+ * @property {Object} [strings] - the configuration for which string arguments should be used
+ * @property {number} strings.startIndex - the first index to look for string arguments
+ * @property {number} strings.count - how many arguments to look at, including the start index.
+ * @property {Object} [objects] - the configuration for which object arguments' values should  be used
+ * @property {Object} objects.index - the argument index to look for object values in
+ * @property {Object} [objects.allowedKeys] - if present, indicates which keys should be looked at for getting values.
+ */
+
+/**
  * Gets the set of computed property dependency keys used inside a class.
  *
  * @param {Node} nodeClass - Node for the class
+ * @param {string} [computedImportName] - The name by which computed from '@ember/object' as imported with.
+ * @param {Map<String, ComputedMacroConfiguration>} - A mapping from the names by which computed macros were imported to the configuration for what keys they depend on
+ * @param {Map<String, Map<String, ComputedMacroConfiguration>} - A mapping from the names by which a computed macro index was imported to a map from what properties it has to what their macro configurations are.
  * @returns {Set<string>} - set of dependent keys used inside the class
  */
 function findComputedPropertyDependentKeys(
@@ -247,14 +261,7 @@ function findComputedPropertyDependentKeys(
  *
  * @param {Object} argument - the argument to a computed macro
  * @param {number} index - the index of this particular argument for the computed macro
- * @param {Object} config - the configuration indicating how dependent keys should be gotten from the argument
- * @param {Object} [config.strings] - the configuration for which string arguments should be used
- * @param {number} config.strings.startIndex - the first index to look for string arguments
- * @param {number} config.strings.count - how many arguments to look at, including the start index.
- * @param {Object} [config.objects] - the configuration for which object arguments' values should  be used
- * @param {Object} config.objects.index - the argument index to look for object values in
- * @param {Object} [config.objects.allowedKeys] - if present, indicates which keys should be looked at for getting values.
- *   If not present, all key/value pairs will be used.
+ * @param {ComputedMacroConfiguration} config - the configuration indicating how dependent keys should be gotten from the argument
  * @returns {String[]} - the list of string dependent keys indicated by the configuration.
  */
 function getComputedPropertyDependentKeysForConfig(argument, index, { strings, objects }) {
@@ -303,7 +310,8 @@ function getComputedPropertyDependentKeysForConfig(argument, index, { strings, o
  * Gets the list of string dependent keys from a computed property.
  *
  * @param {Node} node - the computed property node
- * @param {number} dependentKeyArgumentCount - number of arguments to check for dependent keys
+ * @param {ComputedMacroConfiguration} [computedDependenciesConfig=null] - the configuration indicating how dependent keys should be gotten from the node.
+ *   If not present, all string arguments will be used.
  * @returns {String[]} - the list of string dependent keys from this computed property
  */
 function getComputedPropertyDependentKeys(node, computedDependenciesConfig = null) {

--- a/lib/utils/computed-property-macros.js
+++ b/lib/utils/computed-property-macros.js
@@ -1,11 +1,5 @@
 const assert = require('assert');
-
-module.exports = {
-  getMacros,
-  getMacrosFromImportNames,
-  getTrackedArgumentCount,
-  macroToCanonicalName,
-};
+const { flatMap } = require('./javascript');
 
 /**
  * Example macros:
@@ -47,6 +41,25 @@ const MACROS_TO_TRACKED_ARGUMENT_COUNT = {
   uniqBy: 1,
 };
 
+// Configurations for the default macros that match the configurations for the
+// no-assignment-of-untracked-properties-used-in-tracking-contexts rule
+const DEFAULT_MACRO_CONFIGURATIONS = Object.entries(MACROS_TO_TRACKED_ARGUMENT_COUNT).map(
+  ([macroName, argumentCount]) => ({
+    name: macroName,
+    path: '@ember/object/computed',
+    indexName: 'computed',
+    indexPath: '@ember/object',
+    argumentFormat: [
+      {
+        strings: {
+          startIndex: 0,
+          count: argumentCount,
+        },
+      },
+    ],
+  })
+);
+
 /**
  * @returns {string[]} - a list of all macros.
  */
@@ -61,10 +74,12 @@ function getMacros() {
  * @param {set<string>} macroImportNames
  * @returns {set<string>} - a set containing all possible macro names to check for.
  */
-function getMacrosFromImportNames(computedImportName, macroImportNames) {
-  return new Set([
-    ...macroImportNames.values(),
-    ...(computedImportName ? getMacros().map((macro) => `${computedImportName}.${macro}`) : []),
+function getMacrosFromImports(macrosByImport, macrosByIndexImport) {
+  return new Map([
+    ...macrosByImport,
+    ...flatMap([...macrosByIndexImport], ([indexName, propertyConfigs]) => {
+      return [...propertyConfigs].map(([name, config]) => [`${indexName}.${name}`, config]);
+    }),
   ]);
 }
 
@@ -92,3 +107,11 @@ function macroToCanonicalName(macro, macroImportNames) {
         (canonicalName) => macroImportNames.get(canonicalName) === macro
       );
 }
+
+module.exports = {
+  getMacros,
+  getMacrosFromImports,
+  getTrackedArgumentCount,
+  macroToCanonicalName,
+  DEFAULT_MACRO_CONFIGURATIONS,
+};

--- a/lib/utils/javascript.js
+++ b/lib/utils/javascript.js
@@ -49,7 +49,7 @@ function flat(arr) {
  * @returns {Array<U>}
  */
 function flatMap(array, callback) {
-  return array.reduce((result, item) => result.concat(callback(item)), []);
+  return array.reduce((result, item, index) => result.concat(callback(item, index)), []);
 }
 
 function removeWhitespace(str) {

--- a/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -24,6 +24,7 @@ ruleTester.run('no-assignment-of-untracked-properties-used-in-tracking-contexts'
     // **********************
     // Native class
     // **********************
+
     {
       // Assignment of property which is not used as a dependent key.
       code: `
@@ -178,6 +179,7 @@ ruleTester.run('no-assignment-of-untracked-properties-used-in-tracking-contexts'
     // **********************
     // Native class
     // **********************
+
     {
       // Assignment of dependent key property.
       code: `

--- a/tests/lib/utils/computed-property-macros-test.js
+++ b/tests/lib/utils/computed-property-macros-test.js
@@ -1,6 +1,6 @@
 const {
   getMacros,
-  getMacrosFromImportNames,
+  getMacrosFromImports,
   getTrackedArgumentCount,
   macroToCanonicalName,
 } = require('../../../lib/utils/computed-property-macros');
@@ -11,13 +11,31 @@ describe('getMacros', () => {
   });
 });
 
-describe('getMacrosFromImportNames', () => {
+describe('getMacrosFromImports', () => {
   it('returns some of the correct macros', () => {
-    const result = [
-      ...getMacrosFromImportNames('computedRenamed', new Map([['readOnly', 'readOnlyRenamed']])),
-    ];
+    const macrosByImport = new Map([
+      ['readOnlyRenamed', 'read-only-config'],
+      ['aliasRenamed', 'alias-config'],
+    ]);
+    const macrosByIndexImport = new Map([
+      [
+        'computed',
+        new Map([
+          ['readOnly', 'read-only-config'],
+          ['alias', 'alias-config'],
+        ]),
+      ],
+      ['customComputed', new Map([['rejectBy', 'reject-by-config']])],
+    ]);
+    const result = [...getMacrosFromImports(macrosByImport, macrosByIndexImport)];
     expect(result).toStrictEqual(
-      expect.arrayContaining(['computedRenamed.readOnly', 'readOnlyRenamed'])
+      expect.arrayContaining([
+        ['readOnlyRenamed', 'read-only-config'],
+        ['aliasRenamed', 'alias-config'],
+        ['computed.readOnly', 'read-only-config'],
+        ['computed.alias', 'alias-config'],
+        ['customComputed.rejectBy', 'reject-by-config'],
+      ])
     );
   });
 });


### PR DESCRIPTION
This change allows for configuring the dependency key checks to also check custom macros, such as the [t macro](https://ember-intl.github.io/ember-intl/versions/master/docs/guide/translating-text#t) from ember-intl. The configuration options a a bit strange, since I'm expecting that objects are generally used at a specific index, while strings could be used for a range of indices. The possibilities are endless, so I'm trying to support what I expect to be the common cases.

cc @bmish 