### PR TITLE
Update `no-test-import-export` rule to allow importing from anything under `tests/helpers` path

### DIFF
--- a/docs/rules/no-test-import-export.md
+++ b/docs/rules/no-test-import-export.md
@@ -67,3 +67,14 @@ function beforeEachSetup() {}
 
 export default { beforeEachSetup };
 ```
+
+```javascript
+// Any imports from `tests/helpers` are allowed.
+import { setupApplicationTest } from 'tests/helpers/setup-application-test';
+```
+
+```javascript
+// Any exports from `tests/helpers` are allowed.
+// tests/helpers/setup-application-test.js
+export default function setupApplicationTest() {}
+```

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -28,7 +28,10 @@ module.exports = {
 
   create: function create(context) {
     const noExports = function (node) {
-      if (!emberUtils.isTestFile(context.getFilename())) {
+      if (
+        !emberUtils.isTestFile(context.getFilename()) ||
+        isTestHelperFilename(context.getFilename())
+      ) {
         return;
       }
 
@@ -42,7 +45,7 @@ module.exports = {
       ImportDeclaration(node) {
         const importSource = node.source.value;
 
-        if (importSource.endsWith('-test')) {
+        if (importSource.endsWith('-test') && !isTestHelperImportSource(importSource)) {
           context.report({
             message: NO_IMPORT_MESSAGE,
             node,
@@ -58,3 +61,16 @@ module.exports = {
     };
   },
 };
+
+function isTestHelperImportSource(importSource) {
+  return (
+    importSource.startsWith('tests/helpers/') ||
+    importSource.includes('/tests/helpers/') ||
+    importSource.endsWith('/tests/helpers') ||
+    importSource === 'tests/helpers'
+  );
+}
+
+function isTestHelperFilename(filename) {
+  return filename.startsWith('tests/helpers/') || filename.includes('/tests/helpers/');
+}

--- a/tests/lib/rules/no-test-import-export.js
+++ b/tests/lib/rules/no-test-import-export.js
@@ -24,6 +24,26 @@ ruleTester.run('no-test-file-importing', rule, {
         export function beforeEachSetup(){};
       `,
     },
+
+    // Exporting from files in tests/helpers is allowed.
+    {
+      filename: 'tests/helpers/setup-application-test.js',
+      code: 'export default function setupApplicationTest(){};',
+    },
+    {
+      filename: 'tests/helpers/index.js',
+      code: 'export function setupApplicationTest(){};',
+    },
+    {
+      filename: 'my-app-name/tests/helpers/setup-application-test.js',
+      code: 'export default function setupApplicationTest(){};',
+    },
+
+    // Importing anything from tests/helpers is allowed.
+    "import setupApplicationTest from 'tests/helpers/setup-application-test.js';",
+    "import { setupApplicationTest } from 'tests/helpers';",
+    "import setupApplicationTest from 'my-app-name/tests/helpers/setup-application-test.js';",
+    "import { setupApplicationTest } from 'my-app-name/tests/helpers';",
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #889.

CC: @mongoose700 @raido