### PR TITLE
Add new rule `no-controller-access-in-routes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js |
+|  | [no-controller-access-in-routes](./docs/rules/no-controller-access-in-routes.md) | disallow routes from accessing the controller outside of setupController/resetController |
 | :white_check_mark: | [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service |
 |  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |
 | :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option |

--- a/docs/rules/no-controller-access-in-routes.md
+++ b/docs/rules/no-controller-access-in-routes.md
@@ -1,0 +1,66 @@
+# no-controller-access-in-routes
+
+Accessing the controller in a route outside of `setupController`/`resetController` hooks (where it is passed as an argument) is discouraged.
+
+Additionally doing so without using `controllerFor` might return undefined as the controller is not guaranteed to be eagerly loaded (for optimization purposes).
+
+## Rule Details
+
+This rule disallows routes from accessing the controller outside of `setupController`/`resetController`.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+
+export default class MyRoute extends Route {
+  @action
+  myAction() {
+    const controller = this.controller;
+  }
+}
+```
+
+```js
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+
+export default class MyRoute extends Route {
+  @action
+  myAction() {
+    const controller = this.controllerFor('my');
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import Route from '@ember/routing/route';
+
+export default class MyRoute extends Route {
+  setupController(controller, ...args) {
+    super.setupController(controller, ...args);
+    const foo = controller.foo;
+  }
+}
+```
+
+```js
+import Route from '@ember/routing/route';
+
+export default class MyRoute extends Route {
+  resetController(controller, ...args) {
+    super.resetController(controller, ...args);
+    const foo = controller.foo;
+  }
+}
+```
+
+## Configuration
+
+* object -- containing the following properties:
+  * boolean -- `allowControllerFor` -- wheter the rule should allow or disallow routes from accessing the controller outside of setupController/resetController via `controllerFor` (default: `false`)

--- a/docs/rules/no-controller-access-in-routes.md
+++ b/docs/rules/no-controller-access-in-routes.md
@@ -2,7 +2,7 @@
 
 Accessing the controller in a route outside of `setupController`/`resetController` hooks (where it is passed as an argument) is discouraged.
 
-Additionally doing so without using `controllerFor` might return undefined as the controller is not guaranteed to be eagerly loaded (for optimization purposes).
+If access is required regardless, `controllerFor` must be used to assert the controller isn't undefined as it is not guaranteed to be eagerly loaded (for optimization purposes).
 
 ## Rule Details
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-classic-components': require('./rules/no-classic-components'),
     'no-component-lifecycle-hooks': require('./rules/no-component-lifecycle-hooks'),
     'no-computed-properties-in-native-classes': require('./rules/no-computed-properties-in-native-classes'),
+    'no-controller-access-in-routes': require('./rules/no-controller-access-in-routes'),
     'no-controllers': require('./rules/no-controllers'),
     'no-deeply-nested-dependent-keys-with-each': require('./rules/no-deeply-nested-dependent-keys-with-each'),
     'no-duplicate-dependent-keys': require('./rules/no-duplicate-dependent-keys'),

--- a/lib/rules/no-controller-access-in-routes.js
+++ b/lib/rules/no-controller-access-in-routes.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const ember = require('../utils/ember');
+const types = require('../utils/types');
+const { getImportIdentifier } = require('../utils/import');
+
+const ERROR_MESSAGE =
+  'Do not access controller in route outside of setupController/resetController';
+
+//------------------------------------------------------------------------------
+// Routing - No controller access in routes
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'disallow routes from accessing the controller outside of setupController/resetController',
+      category: 'Routes',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-controller-access-in-routes.md',
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowControllerFor: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  ERROR_MESSAGE,
+
+  create(context) {
+    const allowControllerFor = context.options[0] && context.options[0].allowControllerFor;
+    let importedGetName;
+    let importedGetPropertiesName;
+    let inEmberRoute = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === '@ember/object') {
+          importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
+          importedGetPropertiesName =
+            importedGetPropertiesName ||
+            getImportIdentifier(node, '@ember/object', 'getProperties');
+        }
+      },
+
+      ClassDeclaration(node) {
+        inEmberRoute = ember.isEmberRoute(context, node);
+      },
+      'ClassDeclaration:exit'() {
+        inEmberRoute = false;
+      },
+
+      MemberExpression(node) {
+        if (
+          inEmberRoute &&
+          types.isThisExpression(node.object) &&
+          node.property.name === 'controller'
+        ) {
+          // Example: this.controller;
+          context.report(node, ERROR_MESSAGE);
+        }
+      },
+
+      // eslint-disable-next-line complexity
+      CallExpression(node) {
+        if (
+          inEmberRoute &&
+          types.isMemberExpression(node.callee) &&
+          types.isThisExpression(node.callee.object) &&
+          types.isIdentifier(node.callee.property) &&
+          !allowControllerFor &&
+          node.callee.property.name === 'controllerFor'
+        ) {
+          // Example this.controllerFor(...);
+          context.report(node, ERROR_MESSAGE);
+        }
+
+        if (
+          inEmberRoute &&
+          types.isMemberExpression(node.callee) &&
+          types.isThisExpression(node.callee.object) &&
+          types.isIdentifier(node.callee.property) &&
+          node.callee.property.name === 'get' &&
+          node.arguments.length === 1 &&
+          types.isStringLiteral(node.arguments[0]) &&
+          node.arguments[0].value === 'controller'
+        ) {
+          // Example: this.get('controller');
+          context.report(node, ERROR_MESSAGE);
+        }
+
+        if (
+          inEmberRoute &&
+          types.isIdentifier(node.callee) &&
+          node.callee.name === importedGetName &&
+          node.arguments.length === 2 &&
+          types.isThisExpression(node.arguments[0]) &&
+          types.isStringLiteral(node.arguments[1]) &&
+          node.arguments[1].value === 'controller'
+        ) {
+          // Example: get(this, 'controller');
+          context.report(node, ERROR_MESSAGE);
+        }
+
+        if (
+          inEmberRoute &&
+          types.isMemberExpression(node.callee) &&
+          types.isThisExpression(node.callee.object) &&
+          types.isIdentifier(node.callee.property) &&
+          node.callee.property.name === 'getProperties' &&
+          getPropertiesArgumentsIncludeController(node.arguments)
+        ) {
+          // Example: this.getProperties('controller');
+          context.report(node, ERROR_MESSAGE);
+        }
+
+        if (
+          inEmberRoute &&
+          types.isIdentifier(node.callee) &&
+          node.callee.name === importedGetPropertiesName &&
+          types.isThisExpression(node.arguments[0]) &&
+          getPropertiesArgumentsIncludeController(node.arguments.slice(1))
+        ) {
+          // Example: getProperties(this, 'controller');
+          context.report(node, ERROR_MESSAGE);
+        }
+      },
+    };
+  },
+};
+
+function getPropertiesArgumentsIncludeController(args) {
+  if (args.length === 1 && types.isArrayExpression(args[0])) {
+    return getPropertiesArgumentsIncludeController(args[0].elements);
+  }
+  return args.find(
+    (argument) => types.isStringLiteral(argument) && argument.value === 'controller'
+  );
+}

--- a/lib/rules/no-controller-access-in-routes.js
+++ b/lib/rules/no-controller-access-in-routes.js
@@ -13,7 +13,7 @@ const ERROR_MESSAGE =
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description:
         'disallow routes from accessing the controller outside of setupController/resetController',
@@ -43,7 +43,7 @@ module.exports = {
     const allowControllerFor = context.options[0] && context.options[0].allowControllerFor;
     let importedGetName;
     let importedGetPropertiesName;
-    let inEmberRoute = false;
+    let currentRouteNode = null;
 
     return {
       ImportDeclaration(node) {
@@ -56,16 +56,25 @@ module.exports = {
       },
 
       ClassDeclaration(node) {
-        inEmberRoute = ember.isEmberRoute(context, node);
+        if (ember.isEmberRoute(context, node)) {
+          currentRouteNode = node;
+        }
       },
-      'ClassDeclaration:exit'() {
-        inEmberRoute = false;
+
+      'ClassDeclaration:exit'(node) {
+        if (currentRouteNode === node) {
+          currentRouteNode = null;
+        }
       },
 
       MemberExpression(node) {
+        if (!currentRouteNode) {
+          return;
+        }
+
         if (
-          inEmberRoute &&
           types.isThisExpression(node.object) &&
+          types.isIdentifier(node.property) &&
           node.property.name === 'controller'
         ) {
           // Example: this.controller;
@@ -75,8 +84,15 @@ module.exports = {
 
       // eslint-disable-next-line complexity
       CallExpression(node) {
+        if (ember.isEmberRoute(context, node)) {
+          currentRouteNode = node;
+        }
+
+        if (!currentRouteNode) {
+          return;
+        }
+
         if (
-          inEmberRoute &&
           types.isMemberExpression(node.callee) &&
           types.isThisExpression(node.callee.object) &&
           types.isIdentifier(node.callee.property) &&
@@ -88,7 +104,6 @@ module.exports = {
         }
 
         if (
-          inEmberRoute &&
           types.isMemberExpression(node.callee) &&
           types.isThisExpression(node.callee.object) &&
           types.isIdentifier(node.callee.property) &&
@@ -102,7 +117,6 @@ module.exports = {
         }
 
         if (
-          inEmberRoute &&
           types.isIdentifier(node.callee) &&
           node.callee.name === importedGetName &&
           node.arguments.length === 2 &&
@@ -115,7 +129,6 @@ module.exports = {
         }
 
         if (
-          inEmberRoute &&
           types.isMemberExpression(node.callee) &&
           types.isThisExpression(node.callee.object) &&
           types.isIdentifier(node.callee.property) &&
@@ -127,7 +140,6 @@ module.exports = {
         }
 
         if (
-          inEmberRoute &&
           types.isIdentifier(node.callee) &&
           node.callee.name === importedGetPropertiesName &&
           types.isThisExpression(node.arguments[0]) &&
@@ -135,6 +147,12 @@ module.exports = {
         ) {
           // Example: getProperties(this, 'controller');
           context.report(node, ERROR_MESSAGE);
+        }
+      },
+
+      'CallExpression:exit'(node) {
+        if (currentRouteNode === node) {
+          currentRouteNode = null;
         }
       },
     };

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -32,6 +32,15 @@ ruleTester.run('no-controller-access-in-routes', rule, {
     `,
     `
       import Route from '@ember/routing/route';
+      export default Route.extend({
+        setupController(controller, ...args) {
+          this._super(controller, ...args);
+          const foo = controller.foo;
+        }
+      });
+    `,
+    `
+      import Route from '@ember/routing/route';
       export default class MyRoute extends Route {
         resetController(controller, ...args) {
           super.resetController(controller, ...args);
@@ -39,6 +48,16 @@ ruleTester.run('no-controller-access-in-routes', rule, {
         }
       }
     `,
+    `
+      import Route from '@ember/routing/route';
+      export default Route.extend({
+        resetController(controller, ...args) {
+          this._super(controller, ...args);
+          const foo = controller.foo;
+        }
+      });
+    `,
+
     `
       import Component from '@ember/component';
       import { action, get } from '@ember/object';
@@ -48,6 +67,18 @@ ruleTester.run('no-controller-access-in-routes', rule, {
           const controller = this.controller;
         }
       }
+    `,
+    `
+      import Route from '@ember/routing/route';
+      export default class MyRoute extends Route {}
+      this.controller;
+      this.controllerFor('my');
+    `,
+    `
+      import Route from '@ember/routing/route';
+      export default Route.extend({});
+      this.controller;
+      this.controllerFor('my');
     `,
     {
       code: `
@@ -59,6 +90,19 @@ ruleTester.run('no-controller-access-in-routes', rule, {
             const controller = this.controllerFor('my');
           }
         }
+      `,
+      options: [{ allowControllerFor: true }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        export default Route.extend({
+          actions: {
+            myAction() {
+              const controller = this.controllerFor('my');
+            },
+          },
+        });
       `,
       options: [{ allowControllerFor: true }],
     },
@@ -77,6 +121,34 @@ ruleTester.run('no-controller-access-in-routes', rule, {
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'MemberExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        export default Route.extend({
+          actions: {
+            myAction() {
+              const controller = this.controller;
+            },
+          },
+        });
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'MemberExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = this.controllerFor('my');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: `

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -1,0 +1,209 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-controller-access-in-routes');
+const RuleTester = require('eslint').RuleTester;
+
+const { ERROR_MESSAGE } = rule;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-controller-access-in-routes', rule, {
+  valid: [
+    `
+      import Route from '@ember/routing/route';
+      export default class MyRoute extends Route {
+        setupController(controller, ...args) {
+          super.setupController(controller, ...args);
+          const foo = controller.foo;
+        }
+      }
+    `,
+    `
+      import Route from '@ember/routing/route';
+      export default class MyRoute extends Route {
+        resetController(controller, ...args) {
+          super.resetController(controller, ...args);
+          const foo = controller.foo;
+        }
+      }
+    `,
+    `
+      import Component from '@ember/component';
+      import { action, get } from '@ember/object';
+      export default class MyComponent extends Component {
+        @action
+        myAction() {
+          const controller = this.controller;
+        }
+      }
+    `,
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = this.controllerFor('my');
+          }
+        }
+      `,
+      options: [{ allowControllerFor: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = this.controller;
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'MemberExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = this.controllerFor('my');
+          }
+        }
+      `,
+      options: [{ allowControllerFor: false }],
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = this.get('controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action, get } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = get(this, 'controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action, get as g } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const controller = g(this, 'controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { foo, controller } = this.getProperties('foo', 'controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { foo, controller } = this.getProperties(['foo', 'controller']);
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action, getProperties } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { foo, controller } = getProperties(this, 'foo', 'controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action, getProperties } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { foo, controller } = getProperties(this, ['foo', 'controller']);
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action, getProperties as gp } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { controller } = gp(this, 'controller');
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #896 

Adding a new rule `no-controller-access-in-routes` to prevent accessing the controller in a route outside of `setupController`/`resetController`. These hooks receive the controller as an argument; accessing the controller from outside of these hooks is discouraged.

Also, accessing the controller outside of these hooks without using `controllerFor` might return undefined as the controller is not guaranteed to be eagerly loaded. The rule includes an `allowControllerFor` option (default: `false`) that allows using it to access the controller in the route outside of `setupController`/`resetController`.
