### PR TITLE
Avoid crash from classes extending a non-identifier superclass during Ember core module check

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -207,7 +207,7 @@ function isEmberCoreModule(context, node, moduleName) {
     return isClassicEmberCoreModule(node, moduleName, context.getFilename());
   } else if (types.isClassDeclaration(node)) {
     // native classes
-    if (!node.superClass) {
+    if (!node.superClass || !types.isIdentifier(node.superClass)) {
       return false;
     }
     const superClassImportPath = importUtils.getSourceModuleNameForIdentifier(

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -204,6 +204,24 @@ describe('isEmberCoreModule', () => {
     expect(emberUtils.isEmberCoreModule(context, node, 'Route')).toBeTruthy();
   });
 
+  it('should check if current file is a route with native class', () => {
+    const context = new FauxContext(
+      "import Route from '@ember/routing/route'; class MyRoute extends Route {}",
+      'example-app/some-twisted-path/some-route.js'
+    );
+    const node = context.ast.body[1];
+    expect(emberUtils.isEmberCoreModule(context, node, 'Route')).toBeTruthy();
+  });
+
+  it('ignores a native class with a non-identifier super class', () => {
+    const context = new FauxContext(
+      'class MyRoute extends this.ContainerObject {}',
+      'example-app/some-twisted-path/some-route.js'
+    );
+    const node = context.ast.body[0];
+    expect(emberUtils.isEmberCoreModule(context, node, 'Route')).toBeFalsy();
+  });
+
   it('throws when called on wrong type of node', () => {
     const context = new FauxContext('const x = 123;');
     const node = context.ast.body[0];


### PR DESCRIPTION
Fixes #905. CC: @buschtoens

Ensures that this example does not cause an assert:

```js
class TestObject extends this.ContainerObject {
  // ...
}
```