### PR TITLE
Add `gatherImports` util function

### DIFF
--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const emberUtils = require('../utils/ember');
-const { getImportIdentifier } = require('../utils/import');
+const { gatherImports, getImportFromMap } = require('../utils/import');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,22 +27,19 @@ module.exports = {
   ERROR_MESSAGE,
 
   create(context) {
-    let importedEmberName;
-    let importedComputedName;
+    const imports = new Map();
 
     return {
-      ImportDeclaration(node) {
-        if (node.source.value === 'ember') {
-          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
-        }
-        if (node.source.value === '@ember/object') {
-          importedComputedName =
-            importedComputedName || getImportIdentifier(node, '@ember/object', 'computed');
-        }
-      },
+      ImportDeclaration: gatherImports(imports),
 
       CallExpression(node) {
-        if (emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
+        if (
+          emberUtils.isComputedProp(
+            node,
+            getImportFromMap(imports, 'ember'),
+            getImportFromMap(imports, '@ember/object', 'computed')
+          )
+        ) {
           emberUtils.parseDependentKeys(node).forEach((key) => {
             const parts = key.split('.');
             const indexOfAtEach = parts.indexOf('@each');

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -4,7 +4,7 @@ const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 const utils = require('../utils/utils');
 const assert = require('assert');
-const { getImportIdentifier } = require('../utils/import');
+const { gatherImports, getImportFromMap } = require('../utils/import');
 
 const ERROR_MESSAGE_GET = "Use ES5 getters (`this.property`) instead of Ember's `get` function";
 
@@ -106,8 +106,7 @@ module.exports = {
     let currentProxyObject = null;
     let currentClassWithUnknownPropertyMethod = null;
 
-    let importedGetName;
-    let importedGetPropertiesName;
+    const imports = new Map();
 
     const filename = context.getFilename();
 
@@ -117,14 +116,7 @@ module.exports = {
     }
 
     return {
-      ImportDeclaration(node) {
-        if (node.source.value === '@ember/object') {
-          importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
-          importedGetPropertiesName =
-            importedGetPropertiesName ||
-            getImportIdentifier(node, '@ember/object', 'getProperties');
-        }
-      },
+      ImportDeclaration: gatherImports(imports),
 
       'CallExpression:exit'(node) {
         if (currentProxyObject === node) {
@@ -196,7 +188,7 @@ module.exports = {
 
         if (
           types.isIdentifier(node.callee) &&
-          node.callee.name === importedGetName &&
+          node.callee.name === getImportFromMap(imports, '@ember/object', 'get') &&
           node.arguments.length === 2 &&
           types.isThisExpression(node.arguments[0]) &&
           types.isStringLiteral(node.arguments[1]) &&
@@ -233,7 +225,7 @@ module.exports = {
 
         if (
           types.isIdentifier(node.callee) &&
-          node.callee.name === importedGetPropertiesName &&
+          node.callee.name === getImportFromMap(imports, '@ember/object', 'getProperties') &&
           types.isThisExpression(node.arguments[0]) &&
           validateGetPropertiesArguments(node.arguments.slice(1), ignoreNestedPaths)
         ) {

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -5,7 +5,7 @@ const emberUtils = require('../utils/ember');
 const propertyGetterUtils = require('../utils/property-getter');
 const assert = require('assert');
 const scopeReferencesThis = require('../utils/scope-references-this');
-const { getImportIdentifier } = require('../utils/import');
+const { gatherImports, getImportFromMap } = require('../utils/import');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -228,23 +228,20 @@ module.exports = {
       });
     }
 
-    let importedEmberName;
-    let importedComputedName;
+    const imports = new Map();
 
     return {
-      ImportDeclaration(node) {
-        if (node.source.value === 'ember') {
-          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
-        }
-        if (node.source.value === '@ember/object') {
-          importedComputedName =
-            importedComputedName || getImportIdentifier(node, '@ember/object', 'computed');
-        }
-      },
+      ImportDeclaration: gatherImports(imports),
 
       // eslint-disable-next-line complexity
       CallExpression(node) {
-        if (!emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
+        if (
+          !emberUtils.isComputedProp(
+            node,
+            getImportFromMap(imports, 'ember'),
+            getImportFromMap(imports, '@ember/object', 'computed')
+          )
+        ) {
           return;
         }
 

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -9,7 +9,7 @@ const utils = require('../utils/utils');
 const propertyGetterUtils = require('../utils/property-getter');
 const computedPropertyDependentKeyUtils = require('../utils/computed-property-dependent-keys');
 const assert = require('assert');
-const { getImportIdentifier } = require('../utils/import');
+const { gatherImports, getImportFromMap } = require('../utils/import');
 
 /**
  * Checks whether the node is an identifier with the given name.
@@ -306,11 +306,7 @@ module.exports = {
 
     let serviceNames = [];
 
-    let importedEmberName;
-    let importedComputedName;
-    let importedGetName;
-    let importedGetPropertiesName;
-    let importedGetWithDefaultName;
+    const imports = new Map();
 
     function checkComputedDependencies(node, nodeArguments, importedNames) {
       const declaredDependencies = parseComputedDependencies(nodeArguments);
@@ -450,44 +446,43 @@ module.exports = {
         serviceNames = requireServiceNames ? [] : findInjectedServiceNames(node);
       },
 
-      ImportDeclaration(node) {
-        if (node.source.value === 'ember') {
-          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
-        }
-        if (node.source.value === '@ember/object') {
-          importedComputedName =
-            importedComputedName || getImportIdentifier(node, '@ember/object', 'computed');
-          importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
-          importedGetPropertiesName =
-            importedGetPropertiesName ||
-            getImportIdentifier(node, '@ember/object', 'getProperties');
-          importedGetWithDefaultName =
-            importedGetWithDefaultName ||
-            getImportIdentifier(node, '@ember/object', 'getWithDefault');
-        }
-      },
+      ImportDeclaration: gatherImports(imports),
 
       Identifier(node) {
-        if (emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
-          checkComputedDependencies(node, [], {
-            importedEmberName,
-            importedGetName,
-            importedGetPropertiesName,
-            importedGetWithDefaultName,
-          });
+        const relevantImports = getRelevantImports(imports);
+        if (
+          emberUtils.isComputedProp(
+            node,
+            relevantImports.importedEmberName,
+            relevantImports.importedComputedName
+          )
+        ) {
+          checkComputedDependencies(node, [], relevantImports);
         }
       },
 
       CallExpression(node) {
-        if (emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
-          checkComputedDependencies(node, node.arguments, {
-            importedEmberName,
-            importedGetName,
-            importedGetPropertiesName,
-            importedGetWithDefaultName,
-          });
+        const relevantImports = getRelevantImports(imports);
+        if (
+          emberUtils.isComputedProp(
+            node,
+            relevantImports.importedEmberName,
+            relevantImports.importedComputedName
+          )
+        ) {
+          checkComputedDependencies(node, node.arguments, relevantImports);
         }
       },
     };
   },
 };
+
+function getRelevantImports(imports) {
+  return {
+    importedEmberName: getImportFromMap(imports, 'ember'),
+    importedComputedName: getImportFromMap(imports, '@ember/object', 'computed'),
+    importedGetName: getImportFromMap(imports, '@ember/object', 'get'),
+    importedGetPropertiesName: getImportFromMap(imports, '@ember/object', 'getProperties'),
+    importedGetWithDefaultName: getImportFromMap(imports, '@ember/object', 'getWithDefault'),
+  };
+}

--- a/lib/utils/import.js
+++ b/lib/utils/import.js
@@ -9,10 +9,58 @@ const {
 } = require('../utils/types');
 
 module.exports = {
+  gatherImports,
+  getImportFromMap,
   getSourceModuleNameForIdentifier,
   getSourceModuleName,
   getImportIdentifier,
 };
+
+const IMPORTS_TO_GATHER = [
+  ['ember'],
+  ['@ember/object', 'computed'],
+  ['@ember/object', 'get'],
+  ['@ember/object', 'getProperties'],
+  ['@ember/object', 'getWithDefault'],
+];
+
+/**
+ * Gathers the names that common imports are imported under.
+ * @param {map<string,string>} imports map of each imported path/function to the name its imported under
+ * @returns {function} a visitor for ImportDeclaration nodes
+ */
+function gatherImports(imports) {
+  return function (node) {
+    IMPORTS_TO_GATHER.forEach((importToGather) => {
+      const [path, namedImport] = importToGather;
+      const key = getImportMapKey(path, namedImport);
+      if (node.source.value === path) {
+        imports.set(key, imports.get(key) || getImportIdentifier(node, path, namedImport));
+      }
+    });
+  };
+}
+
+/**
+ * Generates a key to use for the imports map.
+ * @param {string} path
+ * @param {string} namedImport
+ * @returns {string} key to use for map
+ */
+function getImportMapKey(path, namedImport) {
+  return `${path}|${namedImport}`;
+}
+
+/**
+ * Gets the name that the path/function is imported under from the map.
+ * @param {map<string,string>} map
+ * @param {string} path
+ * @param {string} namedImport
+ * @returns {string}
+ */
+function getImportFromMap(map, path, namedImport) {
+  return map.get(getImportMapKey(path, namedImport));
+}
 
 /**
  * Gets the name of the module that an identifier was imported from,


### PR DESCRIPTION
Consolidates the logic for gathering the names that common functions are imported under.

This is not yet finished but feel free to comment about the new API for checking imports.

TODO:
- [ ] update all remaining rules that could use this (dozens) 
- [ ] unit tests for util functions

Helps with #590.