### PR TITLE
Update `no-test-import-export` rule to allow importing from anything under `tests/helpers` path (when using relative path)

### DIFF
--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const { dirname, resolve } = require('path');
 const emberUtils = require('../utils/ember');
 
 const NO_IMPORT_MESSAGE =
@@ -45,7 +46,10 @@ module.exports = {
       ImportDeclaration(node) {
         const importSource = node.source.value;
 
-        if (importSource.endsWith('-test') && !isTestHelperImportSource(importSource)) {
+        if (
+          importSource.endsWith('-test') &&
+          !isTestHelperImportSource(resolve(dirname(context.getFilename()), importSource))
+        ) {
           context.report({
             message: NO_IMPORT_MESSAGE,
             node,

--- a/tests/lib/rules/no-test-import-export.js
+++ b/tests/lib/rules/no-test-import-export.js
@@ -40,10 +40,20 @@ ruleTester.run('no-test-file-importing', rule, {
     },
 
     // Importing anything from tests/helpers is allowed.
-    "import setupApplicationTest from 'tests/helpers/setup-application-test.js';",
+    "import setupApplicationTest from 'tests/helpers/setup-application-test';",
     "import { setupApplicationTest } from 'tests/helpers';",
-    "import setupApplicationTest from 'my-app-name/tests/helpers/setup-application-test.js';",
+    "import setupApplicationTest from 'my-app-name/tests/helpers/setup-application-test';",
     "import { setupApplicationTest } from 'my-app-name/tests/helpers';",
+
+    // Importing anything from test/helpers is allowed (using relative path)
+    {
+      filename: 'my-app-name/tests/helpers/foo.js',
+      code: "import setupApplicationTest from './setup-application-test';",
+    },
+    {
+      filename: 'my-app-name/tests/helpers/nested/foo.js',
+      code: "import setupApplicationTest from '../setup-application-test';",
+    },
   ],
   invalid: [
     {
@@ -90,6 +100,13 @@ ruleTester.run('no-test-file-importing', rule, {
           message: NO_IMPORT_MESSAGE,
         },
       ],
+    },
+    {
+      // Importing from a test file outside test/helpers is disallowed.
+      filename: 'my-app-name/tests/helpers/foo.js',
+      code: "import testModule from '../../test-dir/another-test';",
+      output: null,
+      errors: [{ message: NO_IMPORT_MESSAGE }],
     },
     {
       filename: 'tests/some-test.js',


### PR DESCRIPTION
For example, in this test case, we can resolve the import source path to find out that it is actually a test helper being imported which is allowed:

```
filename: 'my-app-name/tests/helpers/foo.js'
code: "import setupApplicationTest from './setup-application-test';"
```

Follow-up fix for #889 https://github.com/ember-cli/eslint-plugin-ember/pull/895#discussion_r469170711

CC: @raido @mongoose700 