### PR TITLE
Add `catchEvents` option (default false) to `no-side-effects` rule

### DIFF
--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -41,3 +41,9 @@ export default Component.extend({
   })
 });
 ```
+
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `false`, TODO: enable in next major release)

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -21,7 +21,7 @@ function isEmberSetThis(node, importedEmberName) {
     types.isIdentifier(node.callee.property) &&
     ['set', 'setProperties'].includes(node.callee.property.name) &&
     node.arguments.length > 0 &&
-    memberExpressionBeginWithThis(node.arguments[0])
+    memberExpressionBeginsWithThis(node.arguments[0])
   );
 }
 
@@ -32,7 +32,7 @@ function isImportedSetThis(node, importedSetName, importedSetPropertiesName) {
     types.isIdentifier(node.callee) &&
     [importedSetName, importedSetPropertiesName].includes(node.callee.name) &&
     node.arguments.length > 0 &&
-    memberExpressionBeginWithThis(node.arguments[0])
+    memberExpressionBeginsWithThis(node.arguments[0])
   );
 }
 
@@ -44,15 +44,50 @@ function isThisSet(node) {
     types.isMemberExpression(node.callee) &&
     types.isIdentifier(node.callee.property) &&
     ['set', 'setProperties'].includes(node.callee.property.name) &&
-    memberExpressionBeginWithThis(node.callee.object)
+    memberExpressionBeginsWithThis(node.callee.object)
   );
 }
 
-function memberExpressionBeginWithThis(node) {
+// import { sendEvent } from "@ember/object/events"
+// Ember.sendEvent
+
+// Looks for variations like:
+// - this.send(...)
+// - Ember.send(...)
+const DISALLOWED_FUNCTION_CALLS = new Set(['send', 'sendAction', 'sendEvent', 'trigger']);
+function isDisallowedFunctionCall(node, importedEmberName) {
+  return (
+    types.isCallExpression(node) &&
+    types.isMemberExpression(node.callee) &&
+    (types.isThisExpression(node.callee.object) ||
+      (types.isIdentifier(node.callee.object) && node.callee.object.name === importedEmberName)) &&
+    types.isIdentifier(node.callee.property) &&
+    DISALLOWED_FUNCTION_CALLS.has(node.callee.property.name)
+  );
+}
+
+// sendEvent(...)
+function isImportedSendEventCall(node, importedSendEventName) {
+  return (
+    types.isCallExpression(node) &&
+    types.isIdentifier(node.callee) &&
+    node.callee.name === importedSendEventName
+  );
+}
+
+/**
+ * Finds:
+ * - this
+ * - this.foo
+ * - this.foo.bar
+ * - this?.foo?.bar
+ * @param {node} node
+ */
+function memberExpressionBeginsWithThis(node) {
   if (types.isThisExpression(node)) {
     return true;
-  } else if (types.isMemberExpression(node)) {
-    return memberExpressionBeginWithThis(node.object);
+  } else if (types.isMemberExpression(node) || types.isOptionalMemberExpression(node)) {
+    return memberExpressionBeginsWithThis(node.object);
   }
   return false;
 }
@@ -61,16 +96,20 @@ function memberExpressionBeginWithThis(node) {
  * Recursively finds calls that could be side effects in a computed property function body.
  *
  * @param {ASTNode} computedPropertyBody body of computed property to search
+ * @param {boolean} catchEvents
  * @param {string} importedEmberName
  * @param {string} importedSetName
  * @param {string} importedSetPropertiesName
+ * @param {string} importedSendEventName
  * @returns {Array<ASTNode>}
  */
 function findSideEffects(
   computedPropertyBody,
+  catchEvents,
   importedEmberName,
   importedSetName,
-  importedSetPropertiesName
+  importedSetPropertiesName,
+  importedSendEventName
 ) {
   const results = [];
 
@@ -80,7 +119,9 @@ function findSideEffects(
         isEmberSetThis(child, importedEmberName) || // Ember.set(this, 'foo', 123)
         isImportedSetThis(child, importedSetName, importedSetPropertiesName) || // set(this, 'foo', 123)
         isThisSet(child) || // this.set('foo', 123)
-        propertySetterUtils.isThisSet(child) // this.foo = 123;
+        propertySetterUtils.isThisSet(child) || // this.foo = 123;
+        (catchEvents && isDisallowedFunctionCall(child, importedEmberName)) || // this.send('done')
+        (catchEvents && isImportedSendEventCall(child, importedSendEventName)) // sendEvent(...)
       ) {
         results.push(child);
       }
@@ -103,16 +144,30 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-side-effects.md',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          catchEvents: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+      },
+    ],
   },
 
   ERROR_MESSAGE,
 
   create(context) {
+    // Options:
+    const catchEvents = context.options[0] && context.options[0].catchEvents;
+
     let importedEmberName;
     let importedComputedName;
     let importedSetName;
     let importedSetPropertiesName;
+    let importedSendEventName;
 
     const report = function (node) {
       context.report(node, ERROR_MESSAGE);
@@ -131,6 +186,10 @@ module.exports = {
             importedSetPropertiesName ||
             getImportIdentifier(node, '@ember/object', 'setProperties');
         }
+        if (node.source.value === '@ember/object/events') {
+          importedSendEventName =
+            importedSendEventName || getImportIdentifier(node, '@ember/object/events', 'sendEvent');
+        }
       },
 
       CallExpression(node) {
@@ -142,9 +201,11 @@ module.exports = {
 
         findSideEffects(
           computedPropertyBody,
+          catchEvents,
           importedEmberName,
           importedSetName,
-          importedSetPropertiesName
+          importedSetPropertiesName,
+          importedSendEventName
         ).forEach(report);
       },
 
@@ -157,9 +218,11 @@ module.exports = {
 
         findSideEffects(
           computedPropertyBody,
+          catchEvents,
           importedEmberName,
           importedSetName,
-          importedSetPropertiesName
+          importedSetPropertiesName,
+          importedSendEventName
         ).forEach(report);
       },
     };


### PR DESCRIPTION
Inspired by the [ember-best-practices/no-side-effect-cp](https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/lib/rules/no-side-effect-cp.js) rule.

Catches side-effect-causing function calls like:

* this.send()
* this.sendAction()
* this.sendEvent()
* this.trigger()

CC: @mongoose700 