### PR TITLE
Fix crash with variable path in `route-path-style` rule

### DIFF
--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -44,9 +44,12 @@ module.exports = {
         const pathValueNode = hasExplicitPathOption
           ? getPropertyByKeyName(node.arguments[1], 'path').value
           : node.arguments[0];
-        const pathValue = pathValueNode.value;
 
-        const urlSegments = getStaticURLSegments(pathValue);
+        if (!types.isStringLiteral(pathValueNode)) {
+          return;
+        }
+
+        const urlSegments = getStaticURLSegments(pathValueNode.value);
 
         if (urlSegments.some((urlPart) => !isKebabCase(urlPart))) {
           context.report(pathValueNode, ERROR_MESSAGE);

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -11,7 +11,12 @@ const { ERROR_MESSAGE } = rule;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
 ruleTester.run('route-path-style', rule, {
   valid: [
     // Implicit path:
@@ -78,6 +83,10 @@ ruleTester.run('route-path-style', rule, {
 
     // Incorrect usage:
     'this.route();',
+
+    // With variable:
+    "this.route('team', { path: myPath });",
+    "this.route('team', { path: `part-${some-variable}` });", // eslint-disable-line no-template-curly-in-string
   ],
   invalid: [
     {


### PR DESCRIPTION
Avoids this crash:

```
TypeError: Cannot read property ‘split’ of undefined’ error.
```

CC: @mongoose700 