### PR TITLE
Refactor `require-super-in-init` rule to improve performance

### DIFF
--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -88,28 +88,38 @@ module.exports = {
     };
 
     return {
-      CallExpression(node) {
+      Property(node) {
         if (
-          !ember.isEmberComponent(context, node) &&
-          !ember.isEmberController(context, node) &&
-          !ember.isEmberRoute(context, node) &&
-          !ember.isEmberMixin(context, node) &&
-          !ember.isEmberService(context, node)
+          !types.isIdentifier(node.key) ||
+          node.key.name !== 'init' ||
+          !types.isFunctionExpression(node.value)
         ) {
+          // Not init function.
           return;
         }
 
-        const initProperty = ember
-          .getModuleProperties(node)
-          .find((property) => types.isProperty(property) && property.key.name === 'init');
+        const parentParent = node.parent.parent;
+        if (!types.isCallExpression(node.parent.parent)) {
+          // Not inside potential Ember class.
+          return;
+        }
 
-        if (initProperty && types.isFunctionExpression(initProperty.value)) {
-          const initPropertyBody = initProperty.value.body.body;
-          const nodes = findStmtNodes(initPropertyBody);
-          const hasSuper = checkForSuper(nodes);
-          if (!hasSuper) {
-            report(initProperty);
-          }
+        if (
+          !ember.isEmberComponent(context, parentParent) &&
+          !ember.isEmberController(context, parentParent) &&
+          !ember.isEmberRoute(context, parentParent) &&
+          !ember.isEmberMixin(context, parentParent) &&
+          !ember.isEmberService(context, parentParent)
+        ) {
+          // Not inside an Ember class.
+          return;
+        }
+
+        const initPropertyBody = node.value.body.body;
+        const nodes = findStmtNodes(initPropertyBody);
+        const hasSuper = checkForSuper(nodes);
+        if (!hasSuper) {
+          report(node);
         }
       },
     };


### PR DESCRIPTION
On my large codebase with thousands of JS files, this change reduced the running time of this rule from 3.560 seconds to 0.339 seconds (-90%).