### PR TITLE
Drop Node 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## ❗️Requirements
 
 - [ESLint](https://eslint.org/) `>= 5`
-- [Node.js](https://nodejs.org/) `10.* || >= 12`
+- [Node.js](https://nodejs.org/) `10.* || 12.* || >= 14`
 
 ## 🚀 Usage
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rules"
   ],
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "10.* || 12.* || >= 14"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Node 13 is no longer supported now that Node 14 has been released as of 2020-04.

https://nodejs.org/en/about/releases/

Part of #825.