### PR TITLE
Drop ESLint 5 support and add peer dependency on ESLint 6+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,4 @@ jobs:
     - run: yarn lint
     - run: yarn update && git diff --exit-code
     - run: yarn test:coverage --runInBand
-    - run: yarn add --dev eslint@5 && yarn test --runInBand
     - run: yarn add --dev eslint@6 && yarn test --runInBand

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## ❗️Requirements
 
-- [ESLint](https://eslint.org/) `>= 5`
+- [ESLint](https://eslint.org/) `>= 6`
 - [Node.js](https://nodejs.org/) `10.* || 12.* || >= 14`
 
 ## 🚀 Usage

--- a/lib/utils/traverser.js
+++ b/lib/utils/traverser.js
@@ -2,13 +2,13 @@
 
 module.exports = getTraverser;
 
+/* eslint node/no-unpublished-require:"off", node/no-missing-require:"off" */
+
 function getTraverser() {
   let traverser;
   try {
-    // eslint-disable-next-line node/no-unpublished-require
     traverser = require('eslint/lib/shared/traverser'); // eslint >= 6
   } catch {
-    // eslint-disable-next-line node/no-unpublished-require, node/no-missing-require
     traverser = require('eslint/lib/util/traverser'); // eslint < 6
   }
   return traverser;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   "engines": {
     "node": "10.* || 12.* || >= 14"
   },
+  "peerDependencies": {
+    "eslint": ">= 6"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ember-cli/eslint-plugin-ember/issues"


### PR DESCRIPTION
* Drop eslint 5 support (now that two newer versions are available: eslint 6 released 2019-06, eslint 7 released 2020-05).
* Add `peerDependencies: { eslint: ">=6" }` now that ember-cli-eslint is [deprecated](https://emberjs.github.io/rfcs/0121-remove-ember-cli-eslint.html) (related: #529)

Part of https://github.com/ember-cli/eslint-plugin-ember/issues/825.