### PR TITLE
Enable `catchRouterMicrolib` and `catchRouterMain` options in `no-private-routing-service rule` rule

### DIFF
--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -5,8 +5,8 @@
 Disallow the use of:
 
 * The private `-routing` service
-* The private `_routerMicrolib` property (when the `catchRouterMicrolib` option is enabled)
-* The private `router:main` property (when the `catchRouterMain` option is enabled)
+* The private `_routerMicrolib` property
+* The private `router:main` property
 
 There has been a public `router` service since Ember 2.16 and using the private routing service should be unnecessary.
 
@@ -83,8 +83,8 @@ export default class MyComponent extends Component {
 
 This rule takes an optional object containing:
 
-* `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `false`) (TODO: enable this by default in the next major release)
-* `boolean` -- `catchRouterMain` -- whether the rule should catch usages of the private property `router:main` (default `false`) (TODO: enable this by default in the next major release)
+* `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `true`)
+* `boolean` -- `catchRouterMain` -- whether the rule should catch usages of the private property `router:main` (default `true`)
 
 ## References
 

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -34,11 +34,11 @@ module.exports = {
         properties: {
           catchRouterMicrolib: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
           catchRouterMain: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -54,9 +54,8 @@ module.exports = {
     const ROUTING_SERVICE_NAME = '-routing';
     const ROUTER_MICROLIB_NAME = '_routerMicrolib';
 
-    const options = context.options[0] || {};
-    const catchRouterMicrolib = options.catchRouterMicrolib || false;
-    const catchRouterMain = options.catchRouterMain || false;
+    const catchRouterMicrolib = context.options[0] ? context.options[0].catchRouterMicrolib : true;
+    const catchRouterMain = context.options[0] ? context.options[0].catchRouterMain : true;
 
     return {
       Property(node) {

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -56,27 +56,18 @@ ruleTester.run('no-private-routing-service', rule, {
     'class MyComponent extends Component { anIntProp=25; }',
 
     // _routerMicrolib
-    "get(this, 'router._routerMicrolib');",
-    'this.router._routerMicrolib;',
-    { code: "get(this, 'router.somethingElse');", options: [{ catchRouterMicrolib: true }] },
-    { code: 'this.router.somethingElse;', options: [{ catchRouterMicrolib: true }] },
+    { code: "get(this, 'router._routerMicrolib');", options: [{ catchRouterMicrolib: false }] },
+    { code: 'this.router._routerMicrolib;', options: [{ catchRouterMicrolib: false }] },
+    "get(this, 'router.somethingElse');",
+    'this.router.somethingElse;',
 
     // router:main
-    "getOwner(this).lookup('router:main');",
-    "owner.lookup('router:main');",
-    "this.owner.lookup('router:main');",
-    {
-      code: "getOwner(this).lookup('router:somethingElse');",
-      options: [{ catchRouterMicrolib: true }],
-    },
-    {
-      code: "owner.lookup('router:somethingElse');",
-      options: [{ catchRouterMicrolib: true }],
-    },
-    {
-      code: "this.owner.lookup('router:somethingElse');",
-      options: [{ catchRouterMicrolib: true }],
-    },
+    { code: "getOwner(this).lookup('router:main');", options: [{ catchRouterMain: false }] },
+    { code: "owner.lookup('router:main');", options: [{ catchRouterMain: false }] },
+    { code: "this.owner.lookup('router:main');", options: [{ catchRouterMain: false }] },
+    "getOwner(this).lookup('router:somethingElse');",
+    "owner.lookup('router:somethingElse');",
+    "this.owner.lookup('router:somethingElse');",
   ],
   invalid: [
     // Classic
@@ -97,25 +88,21 @@ ruleTester.run('no-private-routing-service', rule, {
     {
       code: "get(this, 'router._routerMicrolib');",
       output: null,
-      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: "get(this, 'router._router._routerMicrolib');",
       output: null,
-      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Literal' }],
     },
     {
       code: 'this.router._routerMicrolib;',
       output: null,
-      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
     },
     {
       code: 'this.router._router._routerMicrolib;',
       output: null,
-      options: [{ catchRouterMicrolib: true }],
       errors: [{ message: ROUTER_MICROLIB_ERROR_MESSAGE, type: 'Identifier' }],
     },
 
@@ -123,26 +110,22 @@ ruleTester.run('no-private-routing-service', rule, {
     {
       code: "getOwner(this).lookup('router:main');",
       output: null,
-      options: [{ catchRouterMain: true }],
       errors: [{ message: ROUTER_MAIN_ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: "owner.lookup('router:main');",
       output: null,
-      options: [{ catchRouterMain: true }],
       errors: [{ message: ROUTER_MAIN_ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       code: "this.owner.lookup('router:main');",
       output: null,
-      options: [{ catchRouterMain: true }],
       errors: [{ message: ROUTER_MAIN_ERROR_MESSAGE, type: 'CallExpression' }],
     },
     {
       // Optional chaining.
       code: "this?.owner?.lookup?.('router:main');",
       output: null,
-      options: [{ catchRouterMain: true }],
       errors: [{ message: ROUTER_MAIN_ERROR_MESSAGE, type: 'OptionalCallExpression' }],
     },
   ],


### PR DESCRIPTION
Rule link: [no-private-routing-service](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-private-routing-service.md)

Part of #825.