### PR TITLE
Enable `catchSafeObjects` option in `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -94,7 +94,7 @@ This rule takes an optional object containing:
 * `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
 * `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (default `false`)
 * `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `false`)
-* `boolean` -- `catchSafeObjects` -- whether the rule should catch `get(foo, 'bar')` (default `false`, TODO: enable in next major release)
+* `boolean` -- `catchSafeObjects` -- whether the rule should catch `get(foo, 'bar')` (default `true`)
 * `boolean` -- `catchUnsafeObjects` -- whether the rule should catch `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)
 
 ## Related Rules

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -104,7 +104,7 @@ module.exports = {
           },
           catchSafeObjects: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
           catchUnsafeObjects: {
             type: 'boolean',
@@ -120,7 +120,7 @@ module.exports = {
     const ignoreGetProperties = context.options[0] && context.options[0].ignoreGetProperties;
     const ignoreNestedPaths = context.options[0] && context.options[0].ignoreNestedPaths;
     const useOptionalChaining = context.options[0] && context.options[0].useOptionalChaining;
-    const catchSafeObjects = context.options[0] && context.options[0].catchSafeObjects;
+    const catchSafeObjects = context.options[0] ? context.options[0].catchSafeObjects : true;
     const catchUnsafeObjects = context.options[0] && context.options[0].catchUnsafeObjects;
 
     if (ignoreNestedPaths && useOptionalChaining) {

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -37,7 +37,10 @@ ruleTester.run('no-get', rule, {
 
     // Not `this`.
     "foo.get('bar');",
-    "import { get } from '@ember/object'; get(foo, 'bar');",
+    {
+      code: "import { get } from '@ember/object'; get(foo, 'bar');",
+      options: [{ catchSafeObjects: false }],
+    },
 
     // Not `get`.
     "this.foo('bar');",
@@ -89,7 +92,11 @@ ruleTester.run('no-get', rule, {
 
     // Not `this`.
     "myObject.getProperties('prop1', 'prop2');",
-    "import { getProperties } from '@ember/object'; getProperties(myObject, 'prop1', 'prop2');",
+    {
+      code:
+        "import { getProperties } from '@ember/object'; getProperties(myObject, 'prop1', 'prop2');",
+      options: [{ catchSafeObjects: false }],
+    },
 
     // Not `getProperties`.
     "this.foo('prop1', 'prop2');",
@@ -214,14 +221,12 @@ ruleTester.run('no-get', rule, {
     {
       // Calling the imported function on an unknown object (without `this`).
       code: "import { get } from '@ember/object'; get(foo1.foo2, 'bar');",
-      options: [{ catchSafeObjects: true }],
       output: "import { get } from '@ember/object'; foo1.foo2.bar;",
       errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
     },
     {
       // Calling the imported function on an unknown object (without `this`) with an object argument that needs parenthesis.
       code: "import { get } from '@ember/object'; get(foo || {}, 'bar');",
-      options: [{ catchSafeObjects: true }],
       output: "import { get } from '@ember/object'; (foo || {}).bar;",
       errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
     },
@@ -302,7 +307,6 @@ ruleTester.run('no-get', rule, {
     {
       // Calling the imported function on an unknown object (without `this`).
       code: "import { getProperties } from '@ember/object'; getProperties(foo, 'prop1', 'prop2');",
-      options: [{ catchSafeObjects: true }],
       output: null,
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },


### PR DESCRIPTION
Rule link: [no-get](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-get.md)

Part of #825.