### PR TITLE
Add `checkInitOnly` (default true) and `checkNativeClasses` (default false) options to `require-super-in-init` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 | :white_check_mark::wrench: | [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function |
 | :white_check_mark::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
 |  | [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |
-| :white_check_mark::wrench: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require `this._super` to be called in `init` hooks |
+| :white_check_mark::wrench: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require super to be called in lifecycle hooks |
 | :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
 
 ### Ember Octane

--- a/docs/rules/require-super-in-init.md
+++ b/docs/rules/require-super-in-init.md
@@ -4,9 +4,11 @@
 
 :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-Call `_super` in init lifecycle hooks.
+Call super in lifecycle hooks.
 
-When overriding the `init` lifecycle hook inside Ember Components, Controllers, Routes or Mixins, it is necessary to include a call to `_super`.
+When overriding lifecycle hooks inside Ember Components, Controllers, Routes, Mixins, or Services, it is necessary to include a call to super.
+
+By default, this rule only applies to the `init` lifecycle hook and classic classes (see rule options to configure this).
 
 ## Examples
 
@@ -22,6 +24,28 @@ export default Component.extend({
 });
 ```
 
+```javascript
+// With: checkInitOnly = false
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    // ...
+  }
+});
+```
+
+```javascript
+// With: checkNativeClasses = true
+import Component from '@ember/component';
+
+class Foo extends Component {
+  init() {
+    // ...
+  }
+}
+```
+
 Examples of **correct** code for this rule:
 
 ```javascript
@@ -34,3 +58,43 @@ export default Component.extend({
   }
 });
 ```
+
+```javascript
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement(...args) {
+    this._super(...args);
+    // ...
+  }
+});
+```
+
+```javascript
+import Component from '@ember/component';
+
+class Foo extends Component {
+  init(...args) {
+    super.init(...args);
+    // ...
+  }
+}
+```
+
+```javascript
+import Component from '@ember/component';
+
+class Foo extends Component {
+  didInsertElement(...args) {
+    super.didInsertElement(...args);
+    // ...
+  }
+}
+```
+
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `true`, TODO: change default to `false` and rename rule to `require-super-in-lifecycle-hooks` in next major release)
+* `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `false`, TODO: change default to `true` in next major release)

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -1,140 +1,234 @@
 'use strict';
 
 const ember = require('../utils/ember');
-const utils = require('../utils/utils');
 const types = require('../utils/types');
+const Traverser = require('../utils/traverser');
 
-/**
- * Locates nodes with either an ExpressionStatement or ReturnStatement
- * given name.
- * @param {Node[]} nodeBody Array of nodes.
- * @returns {Node[]} Array of nodes with given names.
- */
-function findStmtNodes(nodeBody) {
-  const nodes = [];
-  const fnExpressions = utils.findNodes(nodeBody, 'ExpressionStatement');
-  const returnStatement = utils.findNodes(nodeBody, 'ReturnStatement');
-
-  if (fnExpressions.length !== 0) {
-    fnExpressions.forEach((item) => {
-      nodes.push(item);
-    });
-  }
-
-  if (returnStatement.length !== 0) {
-    returnStatement.forEach((item) => {
-      nodes.push(item);
-    });
-  }
-
-  return nodes;
+function hasMatchingNode(node, matcher) {
+  let foundMatch = false;
+  new Traverser().traverse(node, {
+    enter(child) {
+      if (!foundMatch && matcher(child)) {
+        foundMatch = true;
+      }
+    },
+  });
+  return foundMatch;
 }
 
 /**
- * Checks whether a node has the '_super' property.
- * @param {Node[]} nodes An array of nodes.
+ * Checks for this._super() call.
+ * @param {node} node
  * @returns {Boolean}
  */
-function checkForSuper(nodes) {
-  if (nodes.length === 0) {
-    return false;
-  }
+function isClassicSuper(node) {
+  return (
+    types.isCallExpression(node) &&
+    types.isMemberExpression(node.callee) &&
+    types.isThisExpression(node.callee.object) &&
+    types.isIdentifier(node.callee.property) &&
+    node.callee.property.name === '_super'
+  );
+}
 
-  return nodes.some((n) => {
-    if (types.isCallExpression(n.expression)) {
-      const fnCallee = n.expression.callee;
-      return (
-        types.isMemberExpression(fnCallee) &&
-        types.isThisExpression(fnCallee.object) &&
-        types.isIdentifier(fnCallee.property) &&
-        fnCallee.property.name === '_super'
-      );
-    } else if (types.isReturnStatement(n)) {
-      if (!n.argument || !types.isCallExpression(n.argument)) {
-        return false;
-      }
-
-      const fnCallee = n.argument.callee;
-      return fnCallee.property.name === '_super';
-    }
-
-    return false;
-  });
+/**
+ * Checks for a call like super.init() or super.didInsertElement().
+ * @param {node} node
+ * @param {string} hook - name of hook
+ * @returns {Boolean}
+ */
+function isNativeSuper(node, hook) {
+  return (
+    types.isCallExpression(node) &&
+    types.isMemberExpression(node.callee) &&
+    node.callee.object.type === 'Super' &&
+    types.isIdentifier(node.callee.property) &&
+    node.callee.property.name === hook
+  );
 }
 
 //----------------------------------------------
-// General rule - Call _super in init lifecycle hooks
+// General rule - Call super in lifecycle hooks
 //----------------------------------------------
 
+const ERROR_MESSAGE = 'Call super in lifecycle hooks';
+
 module.exports = {
+  ERROR_MESSAGE,
+
   meta: {
     type: 'problem',
     docs: {
-      description: 'require `this._super` to be called in `init` hooks',
+      description: 'require super to be called in lifecycle hooks',
       category: 'Ember Object',
       recommended: true,
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-init.md',
     },
     fixable: 'code',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          checkInitOnly: {
+            type: 'boolean',
+            default: true,
+          },
+          checkNativeClasses: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {
-    const message = 'Call this._super(...arguments) in init hook';
+    const checkInitOnly = !context.options[0] || context.options[0].checkInitOnly;
+    const checkNativeClasses = context.options[0] && context.options[0].checkNativeClasses;
 
-    const report = function (node) {
+    function report(node, isNativeClass, lifecycleHookName) {
       context.report({
         node,
-        message,
+        message: ERROR_MESSAGE,
         fix(fixer) {
+          const replacement = isNativeClass
+            ? `super.${lifecycleHookName}(...arguments);`
+            : 'this._super(...arguments);';
           if (node.value.body.body.length > 0) {
             // Function has at least one statement in it so just insert before that.
-            return fixer.insertTextBefore(node.value.body.body[0], 'this._super(...arguments);\n');
+            return fixer.insertTextBefore(node.value.body.body[0], `${replacement}\n`);
           } else {
             // Function is empty so insert after curly brace.
             const sourceCode = context.getSourceCode();
             const startOfBlockStatement = sourceCode.getFirstToken(node.value.body);
-            return fixer.insertTextAfter(startOfBlockStatement, 'this._super(...arguments);');
+            return fixer.insertTextAfter(startOfBlockStatement, replacement);
           }
         },
       });
-    };
+    }
+
+    function isLifecycleHook(node) {
+      return (
+        types.isIdentifier(node.key) &&
+        types.isFunctionExpression(node.value) &&
+        ((checkInitOnly && node.key.name === 'init') ||
+          (!checkInitOnly && (node.key.name === 'init' || ember.isComponentLifecycleHook(node))))
+      );
+    }
+
+    function checkAndReport(
+      node,
+      isInEmberComponent,
+      isInEmberController,
+      isInEmberRoute,
+      isInEmberMixin,
+      isInEmberService,
+      isNativeClass
+    ) {
+      const hookName = node.key.name;
+
+      if (
+        hookName === 'init' &&
+        !isInEmberComponent &&
+        !isInEmberController &&
+        !isInEmberRoute &&
+        !isInEmberMixin &&
+        !isInEmberService
+      ) {
+        // Checking `init` hook but not inside any Ember class.
+        return;
+      } else if (hookName !== 'init' && !isInEmberComponent && !isInEmberMixin) {
+        // Checking a component lifecycle hook but not inside a component/mixin which could have them.
+        return;
+      }
+
+      const body = isNativeSuper ? node.value.body : node.body;
+      const hasSuper = hasMatchingNode(body, (bodyChild) =>
+        isNativeClass ? isNativeSuper(bodyChild, hookName) : isClassicSuper(bodyChild)
+      );
+      if (!hasSuper) {
+        report(node, isNativeClass, hookName);
+      }
+    }
+
+    let currentEmberComponent = null;
+    let currentEmberController = null;
+    let currentEmberRoute = null;
+    let currentEmberMixin = null;
+    let currentEmberService = null;
 
     return {
-      Property(node) {
-        if (
-          !types.isIdentifier(node.key) ||
-          node.key.name !== 'init' ||
-          !types.isFunctionExpression(node.value)
-        ) {
-          // Not init function.
+      ClassDeclaration(node) {
+        if (ember.isEmberComponent(context, node)) {
+          currentEmberComponent = node;
+        } else if (ember.isEmberController(context, node)) {
+          currentEmberController = node;
+        } else if (ember.isEmberRoute(context, node)) {
+          currentEmberRoute = node;
+        } else if (ember.isEmberMixin(context, node)) {
+          currentEmberMixin = node;
+        } else if (ember.isEmberService(context, node)) {
+          currentEmberService = node;
+        }
+      },
+
+      'ClassDeclaration:exit'(node) {
+        if (currentEmberComponent === node) {
+          currentEmberComponent = null;
+        } else if (currentEmberController === node) {
+          currentEmberController = null;
+        } else if (currentEmberRoute === node) {
+          currentEmberRoute = null;
+        } else if (currentEmberMixin === node) {
+          currentEmberMixin = null;
+        } else if (currentEmberService === node) {
+          currentEmberService = null;
+        }
+      },
+
+      MethodDefinition(node) {
+        if (!checkNativeClasses) {
+          // Option off.
           return;
         }
 
+        if (!isLifecycleHook(node)) {
+          return;
+        }
+
+        checkAndReport(
+          node,
+          currentEmberComponent,
+          currentEmberController,
+          currentEmberRoute,
+          currentEmberMixin,
+          currentEmberService,
+          true
+        );
+      },
+
+      Property(node) {
         const parentParent = node.parent.parent;
-        if (!types.isCallExpression(node.parent.parent)) {
+        if (!types.isCallExpression(parentParent)) {
           // Not inside potential Ember class.
           return;
         }
 
-        if (
-          !ember.isEmberComponent(context, parentParent) &&
-          !ember.isEmberController(context, parentParent) &&
-          !ember.isEmberRoute(context, parentParent) &&
-          !ember.isEmberMixin(context, parentParent) &&
-          !ember.isEmberService(context, parentParent)
-        ) {
-          // Not inside an Ember class.
+        if (!isLifecycleHook(node)) {
           return;
         }
 
-        const initPropertyBody = node.value.body.body;
-        const nodes = findStmtNodes(initPropertyBody);
-        const hasSuper = checkForSuper(nodes);
-        if (!hasSuper) {
-          report(node);
-        }
+        checkAndReport(
+          node,
+          ember.isEmberComponent(context, parentParent),
+          ember.isEmberController(context, parentParent),
+          ember.isEmberRoute(context, parentParent),
+          ember.isEmberMixin(context, parentParent),
+          ember.isEmberService(context, parentParent),
+          false
+        );
       },
     };
   },


### PR DESCRIPTION
In the next major release, we can rename this rule to `require-super-in-lifecycle-hooks`, and change the defaults for these options.

Fixes #228.