### PR TITLE
Add `checkPlainGetters` option (default false) to `no-side-effects` rule

### DIFF
--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -47,3 +47,4 @@ export default Component.extend({
 This rule takes an optional object containing:
 
 * `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `true`)
+* `boolean` -- `checkPlainGetters` -- whether the rule should check plain (non-computed) getters in native classes for side effects (default `false`, TODO: change default to `true` in next major release)

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -152,6 +152,10 @@ module.exports = {
             type: 'boolean',
             default: true,
           },
+          checkPlainGetters: {
+            type: 'boolean',
+            default: false,
+          },
         },
       },
     ],
@@ -162,12 +166,15 @@ module.exports = {
   create(context) {
     // Options:
     const catchEvents = context.options[0] ? context.options[0].catchEvents : true;
+    const checkPlainGetters = context.options[0] && context.options[0].checkPlainGetters;
 
     let importedEmberName;
     let importedComputedName;
     let importedSetName;
     let importedSetPropertiesName;
     let importedSendEventName;
+
+    let currentEmberClass;
 
     const report = function (node) {
       context.report(node, ERROR_MESSAGE);
@@ -192,8 +199,43 @@ module.exports = {
         }
       },
 
+      MethodDefinition(node) {
+        if (
+          !checkPlainGetters ||
+          !currentEmberClass ||
+          node.kind !== 'get' ||
+          !types.isFunctionExpression(node.value)
+        ) {
+          return;
+        }
+
+        findSideEffects(
+          node.value,
+          catchEvents,
+          importedEmberName,
+          importedSetName,
+          importedSetPropertiesName,
+          importedSendEventName
+        ).forEach(report);
+      },
+
+      ClassDeclaration(node) {
+        if (emberUtils.isAnyEmberCoreModule(context, node)) {
+          currentEmberClass = node;
+        }
+      },
+
+      'ClassDeclaration:exit'(node) {
+        if (currentEmberClass === node) {
+          currentEmberClass = null;
+        }
+      },
+
       CallExpression(node) {
-        if (!emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
+        if (
+          (checkPlainGetters && currentEmberClass) ||
+          !emberUtils.isComputedProp(node, importedEmberName, importedComputedName)
+        ) {
           return;
         }
 
@@ -210,7 +252,10 @@ module.exports = {
       },
 
       Identifier(node) {
-        if (!emberUtils.isComputedProp(node, importedEmberName, importedComputedName)) {
+        if (
+          (checkPlainGetters && currentEmberClass) ||
+          !emberUtils.isComputedProp(node, importedEmberName, importedComputedName)
+        ) {
           return;
         }
 

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -102,6 +102,31 @@ eslintTester.run('no-side-effects', rule, {
     'this.sendEvent()',
     'this.trigger()',
     'import { sendEvent } from "@ember/object/events"; sendEvent();',
+
+    // checkPlainGetters = false
+    'import Component from "@ember/component"; class Foo extends Component { get foo() { this.x = 123; } }',
+    {
+      code:
+        'import Component from "@ember/component"; class Foo extends Component { get foo() { this.x = 123; } }',
+      options: [{ checkPlainGetters: false }],
+    },
+
+    // checkPlainGetters = true
+    {
+      code:
+        'import Component from "@ember/component"; class Foo extends Component { get foo() { return 123; } }',
+      options: [{ checkPlainGetters: true }],
+    },
+    {
+      code:
+        'import Component from "@ember/component"; class Foo extends Component { set foo(x) { this.x = x; } }',
+      options: [{ checkPlainGetters: true }],
+    },
+    {
+      // Not Ember class:
+      code: 'class Foo { get foo() { this.x = x; } }',
+      options: [{ checkPlainGetters: true }],
+    },
   ].map(addComputedImport),
   invalid: [
     // this.set
@@ -301,6 +326,15 @@ eslintTester.run('no-side-effects', rule, {
         'import { sendEvent as se } from "@ember/object/events"; computed(function() { se(); })',
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+
+    {
+      // checkPlainGetters = true
+      code:
+        'import Component from "@ember/component"; class Foo extends Component { get foo() { this.x = 123; } }',
+      output: null,
+      options: [{ checkPlainGetters: true }],
+      errors: [{ message: ERROR_MESSAGE, type: 'AssignmentExpression' }],
     },
   ].map(addComputedImport),
 });


### PR DESCRIPTION
Adds a new option to check for side effects in plain (non-computed) getters in Ember classes.

Example:

```js
import Component from "@ember/component";
class Foo extends Component {
  get foo() {
    this.x = 123; // side effect
  }
}
```

Fixes #958.

Will enable this option by default in next major release.