### PR TITLE
Do not pass `...arguments` in autofix for attrs hooks in `require-super-in-init` rule

### DIFF
--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -93,9 +93,14 @@ module.exports = {
         node,
         message: ERROR_MESSAGE,
         fix(fixer) {
+          // attrs hooks should call super without ...arguments to satisfy ember/no-attrs-snapshot rule.
+          const replacementArgs = ['didReceiveAttrs', 'didUpdateAttrs'].includes(lifecycleHookName)
+            ? ''
+            : '...arguments';
+
           const replacement = isNativeClass
-            ? `super.${lifecycleHookName}(...arguments);`
-            : 'this._super(...arguments);';
+            ? `super.${lifecycleHookName}(${replacementArgs});`
+            : `this._super(${replacementArgs});`;
           // Insert right after function curly brace.
           const sourceCode = context.getSourceCode();
           const startOfBlockStatement = sourceCode.getFirstToken(node.value.body);

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -769,6 +769,24 @@ this._super(...arguments);
       errors: [{ message, line: 2 }],
     },
 
+    // attrs hooks should call super without ...arguments to satisfy ember/no-attrs-snapshot rule.
+    {
+      code: 'Component({ didReceiveAttrs() {} })',
+      output: `Component({ didReceiveAttrs() {
+this._super();} })`,
+      options: [{ checkInitOnly: false }],
+      errors: [{ message, line: 1 }],
+    },
+    {
+      code: `import Component from '@ember/component';
+      class Foo extends Component { didUpdateAttrs() {} }`,
+      output: `import Component from '@ember/component';
+      class Foo extends Component { didUpdateAttrs() {
+super.didUpdateAttrs();} }`,
+      options: [{ checkNativeClasses: true, checkInitOnly: false }],
+      errors: [{ message, line: 2 }],
+    },
+
     // Native classes:
     {
       code: `import Service from '@ember/service';


### PR DESCRIPTION
attrs hooks (didReceiveAttrs, didUpdateAttrs) should call super without ...arguments to satisfy the [ember/no-attrs-snapshot](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-attrs-snapshot.md) rule.

Note that this autofix only applies when the `checkInitOnly` option of the [ember/require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md) option is disabled.

