### PR TITLE
Avoid false positives and properly check imports in `no-observers` rule

### DIFF
--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -2,6 +2,7 @@
 
 const ember = require('../utils/ember');
 const types = require('../utils/types');
+const { getImportIdentifier } = require('../utils/import');
 
 //------------------------------------------------------------------------------
 // General rule - Don't use observers
@@ -30,40 +31,67 @@ module.exports = {
       context.report(node, ERROR_MESSAGE);
     };
 
+    let importedEmberName = undefined;
+    let importedObserverName = undefined;
+    let importedObservesName = undefined;
+    let importedAddObserverName = undefined;
+
     return {
       CallExpression(node) {
-        if (ember.isModule(node, 'observer')) {
-          report(node);
-        }
-
         const { callee } = node;
-
         if (
-          (types.isThisExpression(callee.object) || types.isMemberExpression(callee)) &&
+          // observer();
+          types.isIdentifier(callee) &&
+          callee.name === importedObserverName
+        ) {
+          report(node);
+        } else if (
+          // Ember.observer();
+          types.isMemberExpression(callee) &&
+          types.isIdentifier(callee.object) &&
+          callee.object.name === importedEmberName &&
+          types.isIdentifier(callee.property) &&
+          callee.property.name === 'observer'
+        ) {
+          report(node);
+        } else if (
+          // this.addObserver();
+          // Ember.addObserver();
+          // foo.addObserver();
+          types.isMemberExpression(callee) &&
           types.isIdentifier(callee.property) &&
           callee.property.name === 'addObserver'
+        ) {
+          report(node);
+        } else if (
+          // addObserver();
+          types.isIdentifier(callee) &&
+          callee.name === importedAddObserverName
         ) {
           report(node);
         }
       },
 
       Decorator(node) {
-        if (ember.isObserverDecorator(node)) {
+        if (ember.isObserverDecorator(node, importedObservesName)) {
           report(node);
         }
       },
 
       ImportDeclaration(node) {
-        const importSource = node.source.value;
-
-        if (
-          (importSource === '@ember/object' &&
-            node.specifiers.some(
-              (s) => (s.imported ? s.imported.name : s.local.name) === 'observer'
-            )) ||
-          importSource === '@ember/object/observers'
-        ) {
-          report(node);
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        } else if (node.source.value === '@ember/object') {
+          importedObserverName =
+            importedObserverName || getImportIdentifier(node, '@ember/object', 'observer');
+        } else if (node.source.value === '@ember-decorators/object') {
+          importedObservesName =
+            importedObservesName ||
+            getImportIdentifier(node, '@ember-decorators/object', 'observes');
+        } else if (node.source.value === '@ember/object/observers') {
+          importedAddObserverName =
+            importedAddObserverName ||
+            getImportIdentifier(node, '@ember/object/observers', 'addObserver');
         }
       },
     };

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -655,12 +655,12 @@ function isEmberObjectImplementingUnknownProperty(node) {
   return false;
 }
 
-function isObserverDecorator(node) {
+function isObserverDecorator(node, importedObservesName) {
   assert(types.isDecorator(node), 'Should only call this function on a Decorator');
   return (
     types.isDecorator(node) &&
     types.isCallExpression(node.expression) &&
     types.isIdentifier(node.expression.callee) &&
-    node.expression.callee.name === 'observes'
+    node.expression.callee.name === importedObservesName
   );
 }

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -27,59 +27,31 @@ eslintTester.run('no-observers', rule, {
     'export default Controller.extend();',
     'export default Controller.extend({actions: {},});',
 
-    // Unrelated import statements:
-    "import EmberObject from '@ember/object';",
-    "import { run } from '@ember/runloop';",
-    "import { run as renamedRun } from '@ember/runloop';",
-
     `
     import { action } from '@ember/object';
     class FooComponent extends Component {
       @action
       clickHandler() {}
     }`,
+
+    // Not an Ember observer:
+    'import { observer } from "@ember/object"; observer.foo();',
+    'import { observer } from "@ember/object"; foo.observer();',
+    'import { observer } from "@ember/object"; foo.observer.bar()',
+    'import { observer } from "@ember/object"; foo()',
+    'import Ember from "ember"; import { observer } from "@ember/object"; Ember.foo()',
+
+    // Import missing:
+    'observer();',
+    'Ember.observer();',
+    'observes();',
+    'addObserver();',
+
+    // removeObserver is allowed (we only need to report addObserver).
+    'import { removeObserver } from "@ember/object/observers"; removeObserver();',
+    'import Ember from "ember"; Ember.removeObserver();',
   ],
   invalid: [
-    {
-      code: "import { observer, computed } from '@ember/object';",
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'ImportDeclaration',
-        },
-      ],
-    },
-    {
-      code: "import { observer as foo } from '@ember/object';",
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'ImportDeclaration',
-        },
-      ],
-    },
-    {
-      code: "import { addObserver } from '@ember/object/observers';",
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'ImportDeclaration',
-        },
-      ],
-    },
-    {
-      code: "import { removeObserver } from '@ember/object/observers';",
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'ImportDeclaration',
-        },
-      ],
-    },
     {
       code: `
         export default Component.extend({
@@ -129,7 +101,7 @@ eslintTester.run('no-observers', rule, {
       ],
     },
     {
-      code: 'Ember.addObserver("foo", this, "rerun");',
+      code: 'import Ember from "ember"; Ember.addObserver("foo", this, "rerun");',
       output: null,
       errors: [
         {
@@ -139,7 +111,22 @@ eslintTester.run('no-observers', rule, {
       ],
     },
     {
-      code: 'Ember.observer("text", function() {});',
+      code: 'import { addObserver } from "@ember/object/observers"; addObserver();',
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: 'import Ember from "ember"; Ember.observer("text", function() {});',
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'import { observer } from "@ember/object"; observer("text", function() {});',
       output: null,
       errors: [
         {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -1451,7 +1451,17 @@ describe('isObserverDecorator', () => {
       @observes('baz')
       bar() {}
     }`).body[1].body.body[0].decorators[0];
-    expect(emberUtils.isObserverDecorator(node)).toBeTruthy();
+    expect(emberUtils.isObserverDecorator(node, 'observes')).toBeTruthy();
+  });
+
+  it('should be true for an observer decorator with renamed import', () => {
+    const node = babelEslint.parse(`
+    import { observes as observesRenamed } from '@ember-decorators/object';
+    class FooComponent extends Component {
+      @observesRenamed('baz')
+      bar() {}
+    }`).body[1].body.body[0].decorators[0];
+    expect(emberUtils.isObserverDecorator(node, 'observesRenamed')).toBeTruthy();
   });
 
   it('should be false for another type of decorator', () => {
@@ -1461,12 +1471,12 @@ describe('isObserverDecorator', () => {
       @action
       clickHandler() {}
     }`).body[1].body.body[0].decorators[0];
-    expect(emberUtils.isObserverDecorator(node)).toBeFalsy();
+    expect(emberUtils.isObserverDecorator(node, 'observes')).toBeFalsy();
   });
 
   it('throws when called on a non-decorator', () => {
     const node = babelEslint.parse('const x = 123;').body[0];
-    expect(() => emberUtils.isObserverDecorator(node)).toThrow(
+    expect(() => emberUtils.isObserverDecorator(node, 'observes')).toThrow(
       'Should only call this function on a Decorator'
     );
   });


### PR DESCRIPTION
It's not necessary to report the import statement anymore as a result of this change.

Fixes #859.