### PR TITLE
Handle path separators for different platforms in `no-test-support-import` rule

### DIFF
--- a/lib/rules/no-test-support-import.js
+++ b/lib/rules/no-test-support-import.js
@@ -4,16 +4,10 @@
 
 'use strict';
 
+const path = require('path');
+
 const ERROR_MESSAGE_NO_IMPORT =
   'Do not import a file from test-support into production code, only into test files.';
-
-function hasTestSupportDirectory(importSource) {
-  return (
-    importSource.startsWith('test-support/') ||
-    importSource.endsWith('/test-support') ||
-    importSource.includes('/test-support/')
-  );
-}
 
 module.exports = {
   ERROR_MESSAGE_NO_IMPORT,
@@ -32,17 +26,19 @@ module.exports = {
 
   create: function create(context) {
     const fileName = context.getFilename();
+    const fileNameParts = fileName.split(path.sep);
 
     return {
       ImportDeclaration(node) {
         const importSource = node.source.value;
+        const importSourceParts = importSource.split(path.sep);
 
         if (
-          hasTestSupportDirectory(importSource) &&
+          importSourceParts.includes('test-support') &&
           !(
-            fileName.includes('/tests/') ||
-            fileName.includes('/addon-test-support/') ||
-            fileName.includes('/test-support/')
+            fileNameParts.includes('tests') ||
+            fileNameParts.includes('addon-test-support') ||
+            fileNameParts.includes('test-support')
           )
         ) {
           context.report({


### PR DESCRIPTION
This should allow the rule to work on Windows in addition to Mac/Linux.

Unfortunately, I don't think I can write a test for this since I can't mock the path separator in an eslint test.

Fixes #970.