### PR TITLE
Add new rule `require-valid-css-selector-in-test-helpers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |  | [no-test-support-import](./docs/rules/no-test-support-import.md) | disallow importing of "test-support" files in production code. |
 | :white_check_mark: | [no-test-this-render](./docs/rules/no-test-this-render.md) | disallow usage of the `this.render` in tests, recommending to use @ember/test-helpers' `render` instead. |
 | :white_check_mark: | [prefer-ember-test-helpers](./docs/rules/prefer-ember-test-helpers.md) | enforce usage of `@ember/test-helpers` methods over native window methods |
+| :wrench: | [require-valid-css-selector-in-test-helpers](./docs/rules/require-valid-css-selector-in-test-helpers.md) | disallow using invalid CSS selectors in test helpers |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/require-valid-css-selector-in-test-helpers.md
+++ b/docs/rules/require-valid-css-selector-in-test-helpers.md
@@ -1,0 +1,91 @@
+# require-valid-css-selector-in-test-helpers
+
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+Test helpers and querySelector methods should be called with valid CSS selectors. Most of the time invalid selectors will result in a failing test but that is not always the case.
+
+One example of invalid CSS selectors which do not cause failing tests is when using unclosed attribute selector blocks. Tests happen to pass today in this case due to a quirk in the CSS selector spec which is marked as [WontFix by Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=460399#c6).
+
+## Rule Details
+
+This rule requires the use of valid CSS selectors in test helpers and querySelector methods.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { test } from 'qunit';
+
+test('foo', function (assert) {
+  assert.dom('[data-test-foobar'); // qunit-dom
+});
+```
+
+```js
+import { test } from 'qunit';
+
+test('foo', function () {
+  document.querySelector('#1234');
+});
+```
+
+```js
+import { test } from 'qunit';
+
+test('foo', function () {
+  this.element.querySelectorAll('..foobar');
+});
+```
+
+```js
+import { find, click, fillIn, findAll, focus } from '@ember/test-helpers';
+import { test } from 'qunit';
+
+test('foo', function () {
+  find('[data-test-foobar');
+  findAll('[data-test-foobar');
+  fillIn('[data-test-foobar');
+  click('[data-test-foobar');
+  focus('[data-test-foobar');
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { test } from 'qunit';
+
+test('foo', function () {
+  assert.dom('[data-test-foobar]'); // qunit-dom
+});
+```
+
+```js
+import { test } from 'qunit';
+
+test('foo', function () {
+  document.querySelector('#abcd');
+});
+```
+
+```js
+import { test } from 'qunit';
+
+test('foo', function () {
+  this.element.querySelectorAll('.foobar');
+});
+```
+
+```js
+import { find, click, fillIn, findAll, focus } from '@ember/test-helpers';
+import { test } from 'qunit';
+
+test('foo', function () {
+  find('[data-test-foobar]');
+  findAll('[data-test-foobar]');
+  fillIn('[data-test-foobar]');
+  click('[data-test-foobar]');
+  focus('[data-test-foobar]');
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ module.exports = {
     'require-return-from-computed': require('./rules/require-return-from-computed'),
     'require-super-in-init': require('./rules/require-super-in-init'),
     'require-tagless-components': require('./rules/require-tagless-components'),
+    'require-valid-css-selector-in-test-helpers': require('./rules/require-valid-css-selector-in-test-helpers'),
     'route-path-style': require('./rules/route-path-style'),
     'routes-segments-snake-case': require('./rules/routes-segments-snake-case'),
     'use-brace-expansion': require('./rules/use-brace-expansion'),

--- a/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const { getPropertyValue, parseCallee } = require('../utils/utils');
+const cssTree = require('css-tree');
+const emberUtils = require('../utils/ember');
+
+const TEST_MODULE_NAMES = new Set(['module', 'describe']);
+const TEST_HELPER_IMPORTS = new Set([
+  'fillIn',
+  'findAll',
+  'find',
+  'click',
+  'focus',
+  'blur',
+  'doubleClick',
+  'scrollTo',
+  'select',
+  'tap',
+  'triggerEvent',
+  'triggerKeyEvent',
+  'typeIn',
+  'waitFor',
+]);
+const QUERY_SELECTOR_METHODS = new Set(['querySelectorAll', 'querySelector']);
+const PARENT_NODE_NAMES = new Set(['element', 'document']);
+const SELECTOR_RULES = Object.freeze({
+  unclosedAttr: {
+    hasError: (selector) => selector.includes('[') && !selector.includes(']'),
+    fix(node, selector, fixer) {
+      return fixer.replaceText(node.arguments[0], `'${selector}]'`);
+    },
+    errorMessage:
+      'Syntax error, you used an unclosed attribute selector: "{{selector}}", should be: "{{selector}}]"',
+  },
+  idStartsWithNumber: {
+    hasError: (selector) => selector.match(/^#\d/),
+    fix() {},
+    errorMessage: 'Syntax error, ids cannot start with a number: "{{selector}}"',
+  },
+  other: {
+    hasError: (selector) => !_isValidSelector(selector),
+    fix() {},
+    errorMessage: 'Syntax error, "{{selector}}" is not a valid selector',
+  },
+});
+
+function _isValidSelector(selector) {
+  try {
+    cssTree.parse(selector, {
+      context: 'selector',
+    });
+  } catch {
+    return false;
+  }
+
+  return true;
+}
+
+function _isAssertDomCall(node, assertIdentifierName) {
+  const calleeName = parseCallee(node) || [];
+
+  if (calleeName[1] !== 'dom' || !assertIdentifierName) {
+    return false;
+  }
+
+  return calleeName[0] === assertIdentifierName;
+}
+
+function _isQuerySelectorCall(node, testModuleSpecifier) {
+  const calleeName = parseCallee(node);
+
+  // only validate querySelector calls in the test module context
+  if (!testModuleSpecifier) {
+    return false;
+  }
+
+  return QUERY_SELECTOR_METHODS.has(calleeName[1]) && PARENT_NODE_NAMES.has(calleeName[0]);
+}
+
+function _isTestHelperCall(node, hasTestHelperImport, localImportNames) {
+  const calleeName = parseCallee(node) || [];
+
+  return hasTestHelperImport && localImportNames.includes(calleeName[0]);
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow using invalid CSS selectors in test helpers',
+      category: 'Testing',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-valid-css-selector-in-test-helpers.md',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: Object.keys(SELECTOR_RULES).reduce((accumulator, currentVal) => {
+      const _accumulator = accumulator || {};
+      _accumulator[currentVal] = SELECTOR_RULES[currentVal].errorMessage;
+
+      return _accumulator;
+    }, null),
+  },
+  create(context) {
+    if (!emberUtils.isTestFile(context.getFilename())) {
+      // This rule does not apply to test files.
+      return {};
+    }
+    let hasTestHelperImport = false;
+    let localImportNames = [];
+    let testImportLocalName = '';
+    let testModuleSpecifier = '';
+    let assertIdentifierName = '';
+
+    return {
+      'ImportDeclaration[source.value="@ember/test-helpers"]'(node) {
+        hasTestHelperImport = getPropertyValue(node, 'specifiers').find((specifier) =>
+          TEST_HELPER_IMPORTS.has(getPropertyValue(specifier, 'imported.name'))
+        );
+
+        localImportNames = getPropertyValue(node, 'specifiers')
+          .filter((specifier) =>
+            TEST_HELPER_IMPORTS.has(getPropertyValue(specifier, 'imported.name'))
+          )
+          .map((specifier) => getPropertyValue(specifier, 'local.name'));
+      },
+      ImportDeclaration(node) {
+        if (!node.source.value === 'qunit' && !node.source.value === 'mocha') {
+          return;
+        }
+
+        const testImportSpecifier = getPropertyValue(node, 'specifiers').find(
+          (specifier) => getPropertyValue(specifier, 'imported.name') === 'test'
+        );
+
+        if (!testModuleSpecifier) {
+          testModuleSpecifier = getPropertyValue(node, 'specifiers').find((specifier) =>
+            TEST_MODULE_NAMES.has(getPropertyValue(specifier, 'imported.name'))
+          );
+        }
+
+        if (testImportSpecifier) {
+          testImportLocalName = getPropertyValue(testImportSpecifier, 'local.name');
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.name === testImportLocalName) {
+          const [, testFn] = node.arguments || [];
+
+          if (testFn) {
+            assertIdentifierName = getPropertyValue(testFn, 'params.0.name');
+          }
+        }
+        const value = getPropertyValue(node, 'arguments.0.value');
+
+        if (
+          typeof value !== 'string' ||
+          (!_isAssertDomCall(node, assertIdentifierName) &&
+            !_isTestHelperCall(node, hasTestHelperImport, localImportNames) &&
+            !_isQuerySelectorCall(node, testModuleSpecifier))
+        ) {
+          return;
+        }
+
+        const failureRule = Object.keys(SELECTOR_RULES).find((invalidSelectorKey) =>
+          SELECTOR_RULES[invalidSelectorKey].hasError(value)
+        );
+
+        if (failureRule) {
+          context.report({
+            node,
+            messageId: failureRule,
+            data: { selector: value },
+            fix: SELECTOR_RULES[failureRule].fix.bind(null, node, value),
+          });
+        }
+      },
+      'CallExpression:exit'(node) {
+        if (node.callee.name === testImportLocalName) {
+          assertIdentifierName = '';
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -6,13 +6,13 @@ const emberUtils = require('../utils/ember');
 
 const TEST_MODULE_NAMES = new Set(['module', 'describe']);
 const TEST_HELPER_IMPORTS = new Set([
-  'fillIn',
-  'findAll',
-  'find',
-  'click',
-  'focus',
   'blur',
+  'click',
   'doubleClick',
+  'fillIn',
+  'find',
+  'findAll',
+  'focus',
   'scrollTo',
   'select',
   'tap',

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
+    "css-tree": "^1.0.0-alpha.39",
     "ember-rfc176-data": "^0.3.15",
     "lodash.kebabcase": "^4.1.1",
     "snake-case": "^3.0.3"

--- a/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -301,64 +301,7 @@ ruleTester.run('require-valid-css-selector-in-test-helpers', rule, {
           });
         });
         `,
-      errors: [
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-        {
-          type: 'CallExpression',
-          messageId: 'unclosedAttr',
-        },
-      ],
+      errors: new Array(14).fill({ type: 'CallExpression', messageId: 'unclosedAttr' }),
       filename: 'components/foobar-test.js',
     },
 

--- a/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -1,0 +1,721 @@
+const rule = require('../../../lib/rules/require-valid-css-selector-in-test-helpers');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('require-valid-css-selector-in-test-helpers', rule, {
+  valid: [
+    {
+      code: `
+        import { find } from '@ember/test-helpers';
+        find('[data-test-pizza]')`,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { find } from '@ember/test-helpers';
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            find('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            assert.dom('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            fooBar.dom('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+      import { find } from '@ember/test-helpers';
+      import { module } from 'qunit';
+
+      module('foo', function() {});
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+      import { find as module } from '@ember/test-helpers';
+      module('[data-test-foo]');
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        const assert = { dom() {} };
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            assert.dom('.classname');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            this.element.querySelector('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelector('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            this.element.querySelectorAll('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelectorAll('[data-test-pizza]');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelectorAll('#foobar');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelectorAll('.foobar');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelectorAll('div');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            document.querySelectorAll('.foo\\+bar');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        this.click('.foobar');
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { fillIn } from '@ember/test-helpers';
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            fillIn('.foobar', 'Jeff Sturgis');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { fillIn, visit } from '@ember/test-helpers';
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            visit('/foobar');
+            fillIn('.foobar', 'Jeff Sturgis');
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            this.element.querySelectorAll('[data-test-foo-bar');
+          });
+        });
+      `,
+      filename: 'components/foobar.js',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            assert.dom('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            assert.dom('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { find, click, fillIn, findAll, focus, blur, doubleClick, scrollTo, select, tap, triggerEvent, triggerKeyEvent, typeIn, waitFor } from '@ember/test-helpers';
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            find('[data-test-pizza');
+            findAll('[data-test-pizza');
+            fillIn('[data-test-pizza');
+            click('[data-test-pizza');
+            focus('[data-test-pizza');
+            blur('[data-test-pizza');
+            doubleClick('[data-test-pizza');
+            scrollTo('[data-test-pizza');
+            select('[data-test-pizza');
+            tap('[data-test-pizza');
+            triggerEvent('[data-test-pizza');
+            triggerKeyEvent('[data-test-pizza');
+            typeIn('[data-test-pizza');
+            waitFor('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { find, click, fillIn, findAll, focus, blur, doubleClick, scrollTo, select, tap, triggerEvent, triggerKeyEvent, typeIn, waitFor } from '@ember/test-helpers';
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            find('[data-test-pizza]');
+            findAll('[data-test-pizza]');
+            fillIn('[data-test-pizza]');
+            click('[data-test-pizza]');
+            focus('[data-test-pizza]');
+            blur('[data-test-pizza]');
+            doubleClick('[data-test-pizza]');
+            scrollTo('[data-test-pizza]');
+            select('[data-test-pizza]');
+            tap('[data-test-pizza]');
+            triggerEvent('[data-test-pizza]');
+            triggerKeyEvent('[data-test-pizza]');
+            typeIn('[data-test-pizza]');
+            waitFor('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { find } from '@ember/test-helpers';
+        find('[data-test-pizza');`,
+      output: `
+        import { find } from '@ember/test-helpers';
+        find('[data-test-pizza]');`,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            this.element.querySelector('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            this.element.querySelector('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelector('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelector('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            this.element.querySelectorAll('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            this.element.querySelectorAll('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelectorAll('[data-test-pizza');
+          });
+        });
+        `,
+      output: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelectorAll('[data-test-pizza]');
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelectorAll('#1234');
+          });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'idStartsWithNumber',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        test('foo', function(fooBar) {
+          document.querySelectorAll('..foobar');
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(fooBar) {
+            document.querySelectorAll('##foobar');
+          });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { find as findRenamed } from '@ember/test-helpers';
+
+        findRenamed('[data-foo')
+        `,
+      output: `
+        import { find as findRenamed } from '@ember/test-helpers';
+
+        findRenamed('[data-foo]')
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test as testRenamed } from 'qunit';
+
+        module('foo', function() {
+          testRenamed('foo', function() {
+            document.querySelectorAll('[data-foo')
+          });
+        });
+        `,
+      output: `
+        import { module, test as testRenamed } from 'qunit';
+
+        module('foo', function() {
+          testRenamed('foo', function() {
+            document.querySelectorAll('[data-foo]')
+          });
+        });
+        `,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'unclosedAttr',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function() {
+            document.querySelectorAll('data-test]')
+          });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { expect } from 'chai';
+        import { describe, it } from 'mocha';
+        import { setupTest } from 'ember-mocha';
+
+        describe('foo', function() {
+          setupTest();
+
+          beforeEach(function() {
+            this.elem = this.element.querySelectorAll('data-test]');
+          });
+
+          it('exists', function() {
+            expect(this.elem).to.be.ok;
+          });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { expect } from 'chai';
+        import { describe, it } from 'mocha';
+        import { setupTest } from 'ember-mocha';
+
+        describe('foo', function() {
+          setupTest();
+
+          afterEach(function() {
+            this.elem = this.element.querySelectorAll('data-test]');
+          });
+
+          it('exists', function() {
+            expect(this.elem).to.be.ok;
+          });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('Acceptance | foo', function (hooks) {
+          hooks.beforeEach(function () {
+            this.elem = this.element.querySelectorAll('data-test]');
+          });
+            test('foo', function(assert) {
+              assert.ok(this.elem);
+            });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('Acceptance | foo', function (hooks) {
+          hooks.afterEach(function () {
+            this.elem = this.element.querySelectorAll('data-test]');
+          });
+            test('foo', function(assert) {
+              assert.ok(this.elem);
+            });
+        });
+        `,
+      output: null,
+      errors: [
+        {
+          type: 'CallExpression',
+          messageId: 'other',
+        },
+      ],
+      filename: 'components/foobar-test.js',
+    },
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,14 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-tree@^1.0.0-alpha.39:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.39.tgz#2bff3ffe1bb3f776cf7eefd91ee5cba77a149eeb"
+  integrity sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==
+  dependencies:
+    mdn-data "2.0.6"
+    source-map "^0.6.1"
+
 cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
@@ -3650,6 +3658,11 @@ markdownlint@~0.21.0:
   integrity sha512-rTxr0fbCFmS65oxXBD0HNy3/+PSukLS+b7Z6rGDWbjdRJp/e2dKj538r3KTn8oXrusx+ZtuYOozV2Knpnn0pkQ==
   dependencies:
     markdown-it "11.0.0"
+
+mdn-data@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
+  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
 
 mdurl@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Tests which use test-helpers that rely on querySelector or querySelectorAll to
lookup an element in the dom are able to use invlid attribute selectors which do not have a closing bracket.
This happens to work today due to a quirk in the CSS selector spec and is marked as WontFix by Chromium.
We should be preventing invalid selectors from being used in test-helpers as they are likely to stop working
at some point and are not valid selector syntax.

fixes #979