### PR TITLE
Fix autofix for array element access at beginning of path string in `no-get` rule

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -63,15 +63,16 @@ function fixGet({
   let replacementPath = isInLeftSideOfAssignmentExpression ? path : path.replace(/\./g, '?.');
 
   // Replace any array element access (foo.1 => foo[1] or foo?.[1]).
-  replacementPath = replacementPath.replace(
-    /\.(\d+)/g,
-    isInLeftSideOfAssignmentExpression ? '[$1]' : '.[$1]'
-  );
+  replacementPath = replacementPath
+    .replace(/\.(\d+)/g, isInLeftSideOfAssignmentExpression ? '[$1]' : '.[$1]') // Usages in middle of path.
+    .replace(/^(\d+)\?\./, isInLeftSideOfAssignmentExpression ? '[$1]' : '[$1]?.'); // Usage at beginning of path.
 
   // Add parenthesis around the object text in case of something like this: get(foo || {}, 'bar')
   const objectTextSafe = isValidJSPath(objectText) ? objectText : `(${objectText})`;
 
-  return fixer.replaceText(node, `${objectTextSafe}.${replacementPath}`);
+  const objectPathSeparator = replacementPath.startsWith('[') ? '' : '.';
+
+  return fixer.replaceText(node, `${objectTextSafe}${objectPathSeparator}${replacementPath}`);
 }
 
 module.exports = {

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -437,6 +437,18 @@ ruleTester.run('no-get', rule, {
       ],
     },
     {
+      // Handle array element access at beginning of string, with optional chaining.
+      code: "this.get('0.foo')",
+      options: [{ useOptionalChaining: true }],
+      output: 'this[0]?.foo',
+      errors: [
+        {
+          message: ERROR_MESSAGE_GET,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
       // Handle array element access (left side of an assignment).
       code: "this.get('foo.0.bar')[123] = 'hello world';",
       output: "this.foo[0].bar[123] = 'hello world';",


### PR DESCRIPTION
Fixes #997.

Before:

```js
this.get('0.foo')
```

After (old incorrect autofix):

```js
this.0?.foo
```

After (fixed autofix):

```js
this[0]?.foo
```

CC: @mongoose700