### PR TITLE
fix: ignore mirage directory for avoid-leaking-state-in-ember-objects

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -2,6 +2,8 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
+In addition, all files in the `mirage` directory will be excluded from this rule.
+
 Don't use arrays and objects as default properties. More info here: <https://dockyard.com/blog/2015/09/18/ember-best-practices-avoid-leaking-state-into-factories>
 
 ## Examples

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -70,6 +70,13 @@ module.exports = {
   DEFAULT_IGNORED_PROPERTIES,
 
   create(context) {
+    const filename = context.getFilename();
+
+    // Skip mirage directory
+    if (ember.isMirageDirectory(filename)) {
+      return {};
+    }
+
     const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
 
     const report = function (node) {

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -66,6 +66,14 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     'export default Foo.extend({ foo: condition ? "foo" : "bar" });',
     'export default Foo.extend({ foo: "foo" && "bar" });',
     'export default Foo.extend({ foo: "foo" || "bar" });',
+    {
+      filename: 'example-app/mirage/models/foo.js',
+      code: 'export default Model.extend({bar: belongsTo()});',
+    },
+    {
+      filename: 'example-app/mirage/factories/foo.js',
+      code: 'export default Factory.extend({bar: []});',
+    },
   ],
   invalid: [
     {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -113,12 +113,17 @@ describe('isMirageDirectory', () => {
   it('detects the mirage directory', () => {
     expect(emberUtils.isMirageDirectory('example-app/mirage/config.js')).toBeTruthy();
     expect(emberUtils.isMirageDirectory('example-app/mirage/scenarios/foo.js')).toBeTruthy();
+    expect(emberUtils.isMirageDirectory('example-addon/tests/dummy/mirage/config.js')).toBeTruthy();
+    expect(
+      emberUtils.isMirageDirectory('example-addon/tests/dummy/mirage/scenarios/foo.js')
+    ).toBeTruthy();
   });
 
   it('does not detect other directories', () => {
     expect(emberUtils.isMirageDirectory('example-app/app/app.js')).toBeFalsy();
     expect(emberUtils.isMirageDirectory('example-app/tests/test.js')).toBeFalsy();
     expect(emberUtils.isMirageDirectory('example-addon/addon/addon.js')).toBeFalsy();
+    expect(emberUtils.isMirageDirectory('example-addon/tests/dummy/app/app.js')).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
Unsure if this is the right approach for mirage.. but I thought I'd see what others think 💭 

This code in mirage..

```js
import { Factory } from 'ember-cli-mirage'

export default Factory.extend({
  foo: []
})
```

..has the same issues as the similar code in ember that this rule is trying to prevent..

```js
export default Foo.extend({
  items: [],
});
```

..but the consequences aren't as bad, as mirage isn't normally run in production.

Though there is still the risk of leaking state in tests?

Fixes #202 
Fixes #214 