### PR TITLE
Fix typo in `require-valid-css-selector-in-test-helpers` rule doc

### DIFF
--- a/docs/rules/require-valid-css-selector-in-test-helpers.md
+++ b/docs/rules/require-valid-css-selector-in-test-helpers.md
@@ -56,7 +56,7 @@ Examples of **correct** code for this rule:
 ```js
 import { test } from 'qunit';
 
-test('foo', function () {
+test('foo', function (assert) {
   assert.dom('[data-test-foobar]'); // qunit-dom
 });
 ```


### PR DESCRIPTION
Add missing `assert` argument in one of the `correct` code examples.