### PR TITLE
Update `checkNativeClasses` option default to true in `require-super-in-init` rule

### DIFF
--- a/docs/rules/require-super-in-init.md
+++ b/docs/rules/require-super-in-init.md
@@ -33,7 +33,6 @@ export default Component.extend({
 ```
 
 ```javascript
-// With: checkNativeClasses = true
 import Component from '@ember/component';
 
 class Foo extends Component {
@@ -94,4 +93,4 @@ class Foo extends Component {
 This rule takes an optional object containing:
 
 * `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `false`)
-* `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `false`, TODO: change default to `true` in next major release)
+* `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `true`)

--- a/lib/rules/require-super-in-init.js
+++ b/lib/rules/require-super-in-init.js
@@ -76,7 +76,7 @@ module.exports = {
           },
           checkNativeClasses: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -86,7 +86,7 @@ module.exports = {
 
   create(context) {
     const checkInitOnly = context.options[0] && context.options[0].checkInitOnly;
-    const checkNativeClasses = context.options[0] && context.options[0].checkNativeClasses;
+    const checkNativeClasses = !context.options[0] || context.options[0].checkNativeClasses;
 
     function report(node, isNativeClass, lifecycleHookName) {
       context.report({

--- a/tests/lib/rules/require-super-in-init.js
+++ b/tests/lib/rules/require-super-in-init.js
@@ -155,9 +155,7 @@ eslintTester.run('require-super-in-init', rule, {
       options: [{ checkNativeClasses: true, checkInitOnly: true }],
     },
 
-    // Native classes should not be checked when checkNativeClasses = false (default)
-    `import Component from '@ember/component';
-     class Foo extends Component { init() { } }`,
+    // Native classes should not be checked when checkNativeClasses = false
     {
       code: `import Component from '@ember/component';
      class Foo extends Component { init() { } }`,
@@ -801,6 +799,12 @@ super.didUpdateAttrs();} }`,
     },
 
     // Native classes:
+    {
+      code: "import Service from '@ember/service'; class Foo extends Service { init() {} }",
+      output: `import Service from '@ember/service'; class Foo extends Service { init() {
+super.init(...arguments);} }`,
+      errors: [{ message, type: 'MethodDefinition' }],
+    },
     {
       code: `import Service from '@ember/service';
       class Foo extends Service {


### PR DESCRIPTION
Part of #960.