### PR TITLE
Rename `require-super-in-init` rule to `require-super-in-lifecycle-hooks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 ## v9.1.1 (2020-09-27)
 
 #### :bug: Bug Fix
-* [#962](https://github.com/ember-cli/eslint-plugin-ember/pull/962) Do not pass `...arguments` in autofix for attrs hooks in [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md) rule ([@bmish](https://github.com/bmish))
+* [#962](https://github.com/ember-cli/eslint-plugin-ember/pull/962) Do not pass `...arguments` in autofix for attrs hooks in [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-lifecycle-hooks.md) rule ([@bmish](https://github.com/bmish))
 
 #### Committers: 1
 - Bryan Mishkin ([@bmish](https://github.com/bmish))
@@ -74,8 +74,8 @@
 
 #### :rocket: Enhancement
 * [#961](https://github.com/ember-cli/eslint-plugin-ember/pull/961) Add `checkPlainGetters` option (default false) to [no-side-effects](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-side-effects.md) rule ([@bmish](https://github.com/bmish))
-* [#957](https://github.com/ember-cli/eslint-plugin-ember/pull/957) Add `checkInitOnly` (default true) and `checkNativeClasses` (default false) options to [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md) rule ([@bmish](https://github.com/bmish))
-* [#950](https://github.com/ember-cli/eslint-plugin-ember/pull/950) Add autofixer to [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md) rule ([@bmish](https://github.com/bmish))
+* [#957](https://github.com/ember-cli/eslint-plugin-ember/pull/957) Add `checkInitOnly` (default true) and `checkNativeClasses` (default false) options to [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-lifecycle-hooks.md) rule ([@bmish](https://github.com/bmish))
+* [#950](https://github.com/ember-cli/eslint-plugin-ember/pull/950) Add autofixer to [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-lifecycle-hooks.md) rule ([@bmish](https://github.com/bmish))
 
 #### :memo: Documentation
 * [#956](https://github.com/ember-cli/eslint-plugin-ember/pull/956) Add imports in [no-test-module-for](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-test-module-for.md) rule doc ([@bmish](https://github.com/bmish))
@@ -110,7 +110,7 @@
 
 #### :rocket: Enhancement
 * [#934](https://github.com/ember-cli/eslint-plugin-ember/pull/934) Add support and enforcement for spread syntax in `order-in-*` rules ([@bmish](https://github.com/bmish))
-* [#928](https://github.com/ember-cli/eslint-plugin-ember/pull/928) Refactor [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-init.md) rule to improve performance ([@bmish](https://github.com/bmish))
+* [#928](https://github.com/ember-cli/eslint-plugin-ember/pull/928) Refactor [require-super-in-init](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-super-in-lifecycle-hooks.md) rule to improve performance ([@bmish](https://github.com/bmish))
 
 #### :bug: Bug Fix
 * [#933](https://github.com/ember-cli/eslint-plugin-ember/pull/933) Fix spread syntax crash in [routes-segments-snake-case](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/routes-segments-snake-case.md) rule ([@bmish](https://github.com/bmish))

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 | :white_check_mark::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
 |  | [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |
 |  | [no-try-invoke](./docs/rules/no-try-invoke.md) | disallow usage of the Ember's `tryInvoke` util |
-| :white_check_mark::wrench: | [require-super-in-init](./docs/rules/require-super-in-init.md) | require super to be called in lifecycle hooks |
+| :white_check_mark::wrench: | [require-super-in-lifecycle-hooks](./docs/rules/require-super-in-lifecycle-hooks.md) | require super to be called in lifecycle hooks |
 | :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
 
 ### Ember Octane

--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -1,4 +1,4 @@
-# require-super-in-init
+# require-super-in-lifecycle-hooks
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ module.exports = {
     'require-computed-macros': require('./rules/require-computed-macros'),
     'require-computed-property-dependencies': require('./rules/require-computed-property-dependencies'),
     'require-return-from-computed': require('./rules/require-return-from-computed'),
-    'require-super-in-init': require('./rules/require-super-in-init'),
+    'require-super-in-lifecycle-hooks': require('./rules/require-super-in-lifecycle-hooks'),
     'require-tagless-components': require('./rules/require-tagless-components'),
     'require-valid-css-selector-in-test-helpers': require('./rules/require-valid-css-selector-in-test-helpers'),
     'route-path-style': require('./rules/route-path-style'),

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -51,7 +51,7 @@ module.exports = {
   "ember/require-computed-macros": "error",
   "ember/require-computed-property-dependencies": "error",
   "ember/require-return-from-computed": "error",
-  "ember/require-super-in-init": "error",
+  "ember/require-super-in-lifecycle-hooks": "error",
   "ember/routes-segments-snake-case": "error",
   "ember/use-brace-expansion": "error",
   "ember/use-ember-data-rfc-395-imports": "error"

--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -63,7 +63,7 @@ module.exports = {
       category: 'Ember Object',
       recommended: true,
       url:
-        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-init.md',
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-super-in-lifecycle-hooks.md',
     },
     fixable: 'code',
     schema: [

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -48,7 +48,7 @@ Array [
   "require-computed-macros",
   "require-computed-property-dependencies",
   "require-return-from-computed",
-  "require-super-in-init",
+  "require-super-in-lifecycle-hooks",
   "routes-segments-snake-case",
   "use-brace-expansion",
   "use-ember-data-rfc-395-imports",

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -2,7 +2,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const rule = require('../../../lib/rules/require-super-in-init');
+const rule = require('../../../lib/rules/require-super-in-lifecycle-hooks');
 const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE: message } = rule;
@@ -16,7 +16,7 @@ const eslintTester = new RuleTester({
   parser: require.resolve('babel-eslint'),
 });
 
-eslintTester.run('require-super-in-init', rule, {
+eslintTester.run('require-super-in-lifecycle-hooks', rule, {
   valid: [
     `export default Component.extend({
         init() {


### PR DESCRIPTION
Part of #960.