### PR TITLE
Update `checkUnsafeObjects` option default to true in `no-get-with-default` rule

### DIFF
--- a/docs/rules/no-get-with-default.md
+++ b/docs/rules/no-get-with-default.md
@@ -45,7 +45,7 @@ const test = this.key || [];
 This rule takes an optional object containing:
 
 - `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `getWithDefault(person, 'name', '')` (default `true`)
-- `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `person.getWithDefault('name', '')` even though we don't know for sure if `person` is an Ember object (default `false`, TODO: enable in next major release)
+- `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `person.getWithDefault('name', '')` even though we don't know for sure if `person` is an Ember object (default `true`)
 
 ## References
 

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -27,7 +27,7 @@ module.exports = {
           },
           catchUnsafeObjects: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -39,7 +39,7 @@ module.exports = {
     let importedGetWithDefaultName;
 
     const catchSafeObjects = !context.options[0] || context.options[0].catchSafeObjects;
-    const catchUnsafeObjects = context.options[0] && context.options[0].catchUnsafeObjects;
+    const catchUnsafeObjects = !context.options[0] || context.options[0].catchUnsafeObjects;
 
     return {
       ImportDeclaration(node) {

--- a/tests/lib/rules/no-get-with-default.js
+++ b/tests/lib/rules/no-get-with-default.js
@@ -27,7 +27,6 @@ ruleTester.run('no-get-with-default', rule, {
     },
 
     // With catchUnsafeObjects: false
-    "person.getWithDefault('name', '');",
     {
       code: "person.getWithDefault('name', '');",
       options: [{ catchUnsafeObjects: false }],
@@ -151,7 +150,12 @@ import { getWithDefault } from '@ember/object'; (get(person, 'name') === undefin
       ],
     },
 
-    // With catchUnsafeObjects: true
+    // With catchUnsafeObjects: true (default)
+    {
+      code: "person.getWithDefault('name', '');",
+      output: "(person.get('name') === undefined ? '' : person.get('name'));",
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
     {
       code: "person.getWithDefault('name', '');",
       options: [{ catchUnsafeObjects: true }],


### PR DESCRIPTION
Part of #960.