### PR TITLE
no-settled-after-test-helper: Add missing node type check in `isAwaitSettlingTestHelper()`

### DIFF
--- a/lib/rules/no-settled-after-test-helper.js
+++ b/lib/rules/no-settled-after-test-helper.js
@@ -111,6 +111,10 @@ function isAwaitSettled(node) {
 }
 
 function isAwaitSettlingTestHelper(node, settlingTestHelpers) {
+  if (node.type !== 'ExpressionStatement') {
+    return false;
+  }
+
   const { expression } = node;
   if (expression.type !== 'AwaitExpression') {
     return false;

--- a/tests/lib/rules/no-settled-after-test-helper.js
+++ b/tests/lib/rules/no-settled-after-test-helper.js
@@ -63,6 +63,17 @@ ruleTester.run('no-settled-after-test-helper', rule, {
         await settled();
       }
     `,
+    `
+      import { settled } from '@ember/test-helpers';
+
+      export async function visit(url) {
+        try {
+          something();
+        } catch {}
+
+        await settled();
+      }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION

This should fix https://github.com/ember-cli/eslint-plugin-ember/issues/1026