### PR TITLE
Handle comma-separated selectors in `require-valid-css-selector-in-test-helpers` rule

### DIFF
--- a/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -25,24 +25,44 @@ const QUERY_SELECTOR_METHODS = new Set(['querySelectorAll', 'querySelector']);
 const PARENT_NODE_NAMES = new Set(['element', 'document']);
 const SELECTOR_RULES = Object.freeze({
   unclosedAttr: {
-    hasError: (selector) => selector.includes('[') && !selector.includes(']'),
-    fix(node, selector, fixer) {
-      return fixer.replaceText(node.arguments[0], `'${selector}]'`);
+    hasError: (str) =>
+      str
+        .split(',')
+        .map((str) => str.trim())
+        .some((selector) => hasMissingClosingBracket(selector)),
+    fix(node, str, fixer) {
+      const replacement = str
+        .split(',')
+        .map((selector) => (hasMissingClosingBracket(selector) ? `${selector}]` : selector))
+        .join(',');
+      return fixer.replaceText(node.arguments[0], `'${replacement}'`);
     },
     errorMessage:
       'Syntax error, you used an unclosed attribute selector: "{{selector}}", should be: "{{selector}}]"',
   },
   idStartsWithNumber: {
-    hasError: (selector) => selector.match(/^#\d/),
+    hasError: (str) =>
+      str
+        .split(',')
+        .map((str) => str.trim())
+        .some((selector) => selector.match(/^#\d/)),
     fix() {},
     errorMessage: 'Syntax error, ids cannot start with a number: "{{selector}}"',
   },
   other: {
-    hasError: (selector) => !_isValidSelector(selector),
+    hasError: (str) =>
+      str
+        .split(',')
+        .map((str) => str.trim())
+        .some((selector) => !_isValidSelector(selector)),
     fix() {},
     errorMessage: 'Syntax error, "{{selector}}" is not a valid selector',
   },
 });
+
+function hasMissingClosingBracket(selector) {
+  return selector.includes('[') && !selector.includes(']');
+}
 
 function _isValidSelector(selector) {
   try {


### PR DESCRIPTION
You can have comma-separated selectors passed to qunit-dom `assert.dom()` or `this.element.querySelectorAll()`, so this PR updates the [require-valid-css-selector-in-test-helpers](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-valid-css-selector-in-test-helpers.md) rule to validate each separator in the list separately instead of immediately assuming all selectors with commas in them are invalid (since css-tree's validate() function throws an exception for comma-separated selectors).

```js
import { module, test } from 'qunit';

module('foo', function() {
    test('foo', function(assert) {
        assert.dom('.foo, .bar').exists(); // Checks if either of these exists
    });
});
```

CC: @jsturgis