### PR TITLE
Allow using string functions directly from Ember in `no-string-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-string-prototype-extensions.js
+++ b/lib/rules/no-string-prototype-extensions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getImportIdentifier } = require('../utils/import');
+
 const ERROR_MESSAGE = 'Do not using `String` prototype extension methods.';
 
 const EXTENSION_METHODS = new Set([
@@ -31,6 +33,8 @@ module.exports = {
   ERROR_MESSAGE,
 
   create(context) {
+    let importedEmberName;
+
     return {
       CallExpression(node) {
         const { callee } = node;
@@ -46,8 +50,25 @@ module.exports = {
           return;
         }
 
+        if (
+          object.type === 'MemberExpression' &&
+          object.object.type === 'Identifier' &&
+          object.object.name === importedEmberName &&
+          object.property.type === 'Identifier' &&
+          object.property.name === 'String'
+        ) {
+          // Using functions directly from "Ember.String..." is allowed.
+          return;
+        }
+
         if (EXTENSION_METHODS.has(property.name)) {
           context.report({ node: property, message: ERROR_MESSAGE });
+        }
+      },
+
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
         }
       },
     };

--- a/tests/lib/rules/no-string-prototype-extensions.js
+++ b/tests/lib/rules/no-string-prototype-extensions.js
@@ -12,13 +12,17 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-string-prototype-extensions', rule, {
   valid: [
-    "dasherize('myString')",
-    'capitalize(someString)',
-    "htmlSafe('<b>foo</b>')",
+    "import { dasherize } from '@ember/string'; dasherize('myString')",
+    "import { capitalize } from '@ember/string'; capitalize(someString)",
+    "import { htmlSafe } from '@ember/template'; htmlSafe('<b>foo</b>')",
     "someString['foo']()",
     'something.foo()',
     'dasherize.foo()',
     'this.dasherize()',
+
+    // Still allowed to use directly from Ember:
+    "import Ember from 'ember'; Ember.String.htmlSafe('foo');",
+    "import Ember from 'ember'; Ember.String.dasherize('foo');",
   ],
 
   invalid: [


### PR DESCRIPTION
Using string functions directly from Ember is allowed:

```js
import Ember from 'ember';
Ember.String.htmlSafe('foo');
```

This is the old module import style that some older Ember applications might still be using.