### PR TITLE
Catch `willDestroy` Glimmer component hook in `require-super-in-life-cycle-hooks` rule

### DIFF
--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -47,6 +47,8 @@ function isNativeSuper(node, hook) {
   );
 }
 
+const GLIMMER_COMPONENT_HOOKS = new Set(['willDestroy']);
+
 //----------------------------------------------
 // General rule - Call super in lifecycle hooks
 //----------------------------------------------
@@ -109,12 +111,15 @@ module.exports = {
       });
     }
 
-    function isLifecycleHook(node) {
+    function isLifecycleHook(node, isGlimmerComponent) {
       return (
         types.isIdentifier(node.key) &&
         types.isFunctionExpression(node.value) &&
         ((checkInitOnly && node.key.name === 'init') ||
-          (!checkInitOnly && (node.key.name === 'init' || ember.isComponentLifecycleHook(node))))
+          (!checkInitOnly &&
+            (node.key.name === 'init' ||
+              (!isGlimmerComponent && ember.isComponentLifecycleHook(node)) ||
+              (isGlimmerComponent && GLIMMER_COMPONENT_HOOKS.has(node.key.name)))))
       );
     }
 
@@ -125,6 +130,7 @@ module.exports = {
       isInEmberRoute,
       isInEmberMixin,
       isInEmberService,
+      isInGlimmerComponent,
       isNativeClass
     ) {
       const hookName = node.key.name;
@@ -139,7 +145,12 @@ module.exports = {
       ) {
         // Checking `init` hook but not inside any Ember class.
         return;
-      } else if (hookName !== 'init' && !isInEmberComponent && !isInEmberMixin) {
+      } else if (
+        hookName !== 'init' &&
+        !isInEmberComponent &&
+        !isInEmberMixin &&
+        !isInGlimmerComponent
+      ) {
         // Checking a component lifecycle hook but not inside a component/mixin which could have them.
         return;
       }
@@ -158,6 +169,7 @@ module.exports = {
     let currentEmberRoute = null;
     let currentEmberMixin = null;
     let currentEmberService = null;
+    let currentGlimmerComponent = null;
 
     return {
       ClassDeclaration(node) {
@@ -171,6 +183,8 @@ module.exports = {
           currentEmberMixin = node;
         } else if (ember.isEmberService(context, node)) {
           currentEmberService = node;
+        } else if (ember.isGlimmerComponent(context, node)) {
+          currentGlimmerComponent = node;
         }
       },
 
@@ -185,6 +199,8 @@ module.exports = {
           currentEmberMixin = null;
         } else if (currentEmberService === node) {
           currentEmberService = null;
+        } else if (currentGlimmerComponent === node) {
+          currentGlimmerComponent = null;
         }
       },
 
@@ -194,7 +210,7 @@ module.exports = {
           return;
         }
 
-        if (!isLifecycleHook(node)) {
+        if (!isLifecycleHook(node, currentGlimmerComponent)) {
           return;
         }
 
@@ -205,6 +221,7 @@ module.exports = {
           currentEmberRoute,
           currentEmberMixin,
           currentEmberService,
+          currentGlimmerComponent,
           true
         );
       },
@@ -227,6 +244,7 @@ module.exports = {
           ember.isEmberRoute(context, parentParent),
           ember.isEmberMixin(context, parentParent),
           ember.isEmberService(context, parentParent),
+          false,
           false
         );
       },

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -144,6 +144,9 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
         init
       });`,
 
+    // Properly-used glimmer hook:
+    "import Component from '@glimmer/component'; class Foo extends Component { willDestroy() { super.willDestroy(); }}",
+
     // Non-init hooks should not be checked when checkInitOnly = true
     {
       code: 'export default Component({ didInsertElement() {} });',
@@ -153,6 +156,11 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
       code:
         "import Component from '@ember/component'; class Foo extends Component { didInsertElement() {} }",
       options: [{ checkNativeClasses: true, checkInitOnly: true }],
+    },
+    {
+      code:
+        "import Component from '@glimmer/component'; class Foo extends Component { willDestroy() {} }",
+      options: [{ checkInitOnly: true }],
     },
 
     // Native classes should not be checked when checkNativeClasses = false
@@ -222,6 +230,13 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
         "import Mixin from '@ember/object/mixin'; class Foo extends Mixin { init() { super.init(...arguments); }}",
       options: [{ checkNativeClasses: true }],
     },
+
+    // Regular component allows glimmer hook to be used without super:
+    "import Component from '@ember/component'; class Foo extends Component { willDestroy() {} }",
+
+    // Glimmer component allows non-glimmer hook to be used without super:
+    "import Component from '@glimmer/component'; class Foo extends Component { init() {} }",
+    "import Component from '@glimmer/component'; class Foo extends Component { didInsertElement() {} }",
   ],
   invalid: [
     {
@@ -263,6 +278,13 @@ this._super(...arguments);},
       });`,
       options: [{ checkInitOnly: false }],
       errors: [{ message, line: 2 }],
+    },
+    {
+      code:
+        'import Component from "@glimmer/component"; class Foo extends Component { willDestroy() {} }',
+      output: `import Component from "@glimmer/component"; class Foo extends Component { willDestroy() {
+super.willDestroy(...arguments);} }`,
+      errors: [{ message, type: 'MethodDefinition' }],
     },
 
     {


### PR DESCRIPTION
Fixes #1035.