### PR TITLE
Improve detection of global window methods in `prefer-ember-test-helpers` rule

### DIFF
--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -1,31 +1,7 @@
 'use strict';
 
 const emberUtils = require('../utils/ember');
-const assert = require('assert');
-
-/**
- * Check if an identifier is being imported from an ImportDeclaration node.
- *
- * Examples where the identifier name 'foo' is being imported from the ImportDeclaration node:
- * * import foo from 'bar';
- * * import { foo } from 'bar';
- * * import { something as foo } from 'bar';
- *
- * @param {node} importDeclaration - the ImportDeclaration node to check
- * @param {string} identifierName - the identifier name we are checking for
- */
-function hasImportedIdentifier(importDeclaration, identifierName) {
-  assert(
-    importDeclaration.type === 'ImportDeclaration',
-    'parameter should be an ImportDeclaration'
-  );
-  assert(typeof identifierName === 'string', 'parameter should be a string');
-  return (
-    importDeclaration.specifiers.find((specifier) => {
-      return specifier.local.name === identifierName;
-    }) !== undefined
-  );
-}
+const { ReferenceTracker } = require('eslint-utils');
 
 //-------------------------------------------------------------------------------------
 // Rule Definition
@@ -49,20 +25,6 @@ module.exports = {
       return {};
     }
 
-    let hasDefinedBlurFunction = false;
-    let hasDefinedFindFunction = false;
-    let hasDefinedFocusFunction = false;
-
-    const markMethodsAsPresent = (fnName) => {
-      if (fnName === 'blur') {
-        hasDefinedBlurFunction = true;
-      } else if (fnName === 'find') {
-        hasDefinedFindFunction = true;
-      } else if (fnName === 'focus') {
-        hasDefinedFocusFunction = true;
-      }
-    };
-
     const showErrorMessage = (node, methodName) => {
       context.report({
         data: { methodName },
@@ -72,74 +34,18 @@ module.exports = {
     };
 
     return {
-      ImportDeclaration(node) {
-        if (hasImportedIdentifier(node, 'blur')) {
-          hasDefinedBlurFunction = true;
-        }
+      Program() {
+        const tracker = new ReferenceTracker(context.getScope());
+        const traceMap = {
+          blur: { [ReferenceTracker.CALL]: true },
+          find: { [ReferenceTracker.CALL]: true },
+          focus: { [ReferenceTracker.CALL]: true },
+        };
 
-        if (hasImportedIdentifier(node, 'find')) {
-          hasDefinedFindFunction = true;
-        }
-
-        if (hasImportedIdentifier(node, 'focus')) {
-          hasDefinedFocusFunction = true;
-        }
-      },
-      FunctionDeclaration(node) {
-        const fnName = node.id.name;
-
-        markMethodsAsPresent(fnName);
-      },
-      FunctionExpression(node) {
-        const nodeParent = node.parent;
-
-        if (nodeParent && nodeParent.type === 'VariableDeclarator') {
-          const fnName = nodeParent.id.name;
-
-          markMethodsAsPresent(fnName);
-        }
-      },
-      ArrowFunctionExpression(node) {
-        const nodeParent = node.parent;
-
-        if (nodeParent && nodeParent.type === 'VariableDeclarator') {
-          const fnName = nodeParent.id.name;
-
-          markMethodsAsPresent(fnName);
-        }
-      },
-      CallExpression(node) {
-        if (node.callee.type !== 'Identifier') {
-          return;
-        }
-
-        if (isGlobalFunctionCall(node.callee.name, 'blur', hasDefinedBlurFunction)) {
-          showErrorMessage(node, 'blur');
-        }
-
-        if (isGlobalFunctionCall(node.callee.name, 'find', hasDefinedFindFunction)) {
-          showErrorMessage(node, 'find');
-        }
-
-        if (isGlobalFunctionCall(node.callee.name, 'focus', hasDefinedFocusFunction)) {
-          showErrorMessage(node, 'focus');
+        for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
+          showErrorMessage(node, node.callee.name);
         }
       },
     };
   },
 };
-
-/**
- * Check to see if a function call is calling a specific global function.
- * (i.e. `blur` not imported nor defined, but `blur` function called)
- *
- * @param {string} currentFnName - the name of the current function call
- * @param {string} targetFnName - name of relevant function we're checking for
- * @param {boolean} hasDefinedTargetFunction - whether we have seen the target function defined or imported
- */
-function isGlobalFunctionCall(currentFnName, targetFnName, hasDefinedTargetFunction) {
-  assert(typeof currentFnName === 'string', 'parameter should be a string');
-  assert(typeof targetFnName === 'string', 'parameter should be a string');
-  assert(typeof hasDefinedTargetFunction === 'boolean', 'parameter should be a boolean');
-  return currentFnName === targetFnName && !hasDefinedTargetFunction;
-}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^1.0.0-alpha.39",
     "ember-rfc176-data": "^0.3.15",
+    "eslint-utils": "^2.1.0",
     "lodash.kebabcase": "^4.1.1",
     "snake-case": "^3.0.3"
   },

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -27,19 +27,23 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     {
       filename: REGULAR_FILE_NAME,
       code: "blur('.some-element');",
+      globals: { blur: true, find: true, focus: true },
     },
     {
       filename: REGULAR_FILE_NAME,
       code: "find('.some-element');",
+      globals: { blur: true, find: true, focus: true },
     },
     {
       filename: REGULAR_FILE_NAME,
       code: "focus('.some-element');",
+      globals: { blur: true, find: true, focus: true },
     },
 
     // Ember test helper method properly imported
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { blur } from '@ember/test-helpers';
       import foo1, { foo2 } from 'bar';
@@ -50,6 +54,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { find } from '@ember/test-helpers';
       import foo1, { foo2 } from 'bar';
@@ -60,6 +65,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { focus } from '@ember/test-helpers';
       import foo1, { foo2 } from 'bar';
@@ -72,6 +78,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Wrong method on import from Ember test helpers
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { blur } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -80,6 +87,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { find } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -88,6 +96,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { focus } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -98,6 +107,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Method on unrelated object called
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { blur } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -106,6 +116,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { find } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -114,6 +125,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { focus } from '@ember/test-helpers';
 
       test('foo', async (assert) => {
@@ -124,18 +136,21 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Method properly imported from Ember test helpers with aliased name
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { blur as myBlurName } from '@ember/test-helpers';
 
       myBlurName();`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { find as myFindName } from '@ember/test-helpers';
 
       myFindName();`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { focus as myFocusName } from '@ember/test-helpers';
 
       myFocusName();`,
@@ -144,46 +159,55 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Method imported from any source
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import blur from 'irrelevant-import-path';
       blur('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { blur } from 'irrelevant-import-path';
       blur('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { something as blur } from 'irrelevant-import-path';
       blur('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import find from 'irrelevant-import-path';
       find('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { find } from 'irrelevant-import-path';
       find('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { something as find } from 'irrelevant-import-path';
       find('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import focus from 'irrelevant-import-path';
       focus('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { focus } from 'irrelevant-import-path';
       focus('.some-element');`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `import { something as focus } from 'irrelevant-import-path';
       focus('.some-element');`,
     },
@@ -191,18 +215,21 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Function declaration within test file
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `function blur(el) { console.log('blurring from element!'); }
 
       blur('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `function find(el) { console.log('finding element!'); }
 
       find('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `function focus(el) { console.log('focusing element!'); }
 
       focus('.some-element')`,
@@ -211,18 +238,21 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Function expression within test file
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const blur = function(el) { console.log('blurring from element!'); }
 
       blur('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const find = function(el) { console.log('finding element!'); }
 
       find('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const focus = function(el) { console.log('focusing element!'); }
 
       focus('.some-element')`,
@@ -231,27 +261,41 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     // Arrow Function declaration within test file
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const blur = (el) => { console.log('blurring from element!'); }
 
       blur('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const find = (el) => { console.log('finding element!'); }
 
       find('.some-element')`,
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `const focus = (el) => { console.log('focusing element!'); }
 
       focus('.some-element')`,
+    },
+
+    // Without globals:
+    {
+      filename: TEST_FILE_NAME,
+      code: "focus('.some-element');",
+    },
+    {
+      filename: TEST_FILE_NAME,
+      code: "const focus = () => {}; focus('.some-element');",
     },
   ],
 
   invalid: [
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `test('foo', async (assert) => {
         await blur('.some-element');
       });`,
@@ -265,6 +309,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `test('foo', async (assert) => {
         await find('.some-element');
       });`,
@@ -278,6 +323,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     },
     {
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `test('foo', async (assert) => {
         await focus('.some-element');
       });`,
@@ -293,6 +339,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     {
       // Aliased relevant import but didn't use it.
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { blur as myBlurName } from '@ember/test-helpers';
       test('foo', async (assert) => {
@@ -309,6 +356,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     {
       // Aliased relevant import but didn't use it.
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { find as myFindName } from '@ember/test-helpers';
       test('foo', async (assert) => {
@@ -325,6 +373,7 @@ ruleTester.run('prefer-ember-test-helpers', rule, {
     {
       // Aliased relevant import but didn't use it.
       filename: TEST_FILE_NAME,
+      globals: { blur: true, find: true, focus: true },
       code: `
       import { focus as myFocusName } from '@ember/test-helpers';
       test('foo', async (assert) => {


### PR DESCRIPTION
Eliminates all of the custom logic in the rule for detecting if the `blur` / `find` / `focus` window functions are defined locally and replaces it with the [ReferenceTracker](https://eslint-utils.mysticatea.dev/api/scope-utils.html#referencetracker-class) class from eslint-utils.

There was no specific known bug with the rule before, but this refactor will make the rule more robust in its ability to detect calls to the global window functions that we are trying to disallow.

CC: @fierysunset