### PR TITLE
`willDestroy` should be considered a classic component lifecycle hook in `require-super-in-lifecycle-hooks` and `no-component-lifecycle-hooks` rules

### DIFF
--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -8,20 +8,8 @@ Disallow usage of "classic" ember component lifecycle hooks.
 
 As most component lifecycle hooks are gone in glimmer components, this rule aims to:
 
-- remind the developer that those hooks no longer exist in glimmer components
-- encourage migrating away from those hooks in classic ember components
-
-Effectively, this rule disallows following lifecycle hooks in components:
-
-- `didDestroyElement`
-- `didInsertElement`
-- `didReceiveAttrs`
-- `didRender`
-- `didUpdate`
-- `didUpdateAttrs`
-- `willClearRender`
-- `willDestroyElement`
-- `willRender`
+- remind the developer that classic Ember component lifecycle hooks no longer exist in glimmer components
+- encourage migrating away from classic Ember component lifecycle hooks in classic ember components
 
 Custom functional modifiers or @ember/render-modifiers should be used instead.
 
@@ -30,7 +18,10 @@ Custom functional modifiers or @ember/render-modifiers should be used instead.
 Examples of **incorrect** code for this rule:
 
 ```js
+import Component from '@ember/component';
+
 export default class MyComponent extends Component {
+  // Classic Ember component lifecycle hooks:
   didDestroyElement() {}
   didInsertElement() {}
   didReceiveAttrs() {}
@@ -38,42 +29,47 @@ export default class MyComponent extends Component {
   didUpdate() {}
   didUpdateAttrs() {}
   willClearRender() {}
+  willDestroy() {}
   willDestroyElement() {}
+  willInsertElement() {}
   willRender() {}
+  willUpdate() {}
 }
 ```
 
 ```js
-export default Component.extend({
-  didDestroyElement() {},
-  didInsertElement() {},
-  didReceiveAttrs() {},
-  didRender() {},
-  didUpdate() {},
-  didUpdateAttrs() {},
-  willClearRender() {},
-  willDestroyElement() {},
-  willRender() {}
-});
+import GlimmerComponent from '@glimmer/component';
+
+export default class MyComponent extends GlimmerComponent {
+  didInsertElement() {} // This is a classic Ember component lifecycle hook which can't be used in a Glimmer component.
+}
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+import Component from '@ember/component';
+
 export default class MyComponent extends Component {
   init() {}
-  willDestroy() {}
 }
 ```
 
 ```js
-export default Component.extend({
-  init() {},
+import GlimmerComponent from '@glimmer/component';
+
+export default class MyComponent extends GlimmerComponent {
+  // Glimmer component lifecycle hooks:
+  constructor() {
+    super();
+  }
   willDestroy() {}
-});
+}
 ```
 
 ## Further Reading
 
 - [`@ember/render-modifiers`](https://github.com/emberjs/ember-render-modifiers)
 - [Blog post about modifiers](https://blog.emberjs.com/2019/03/06/coming-soon-in-ember-octane-part-4.html)
+- [Classic component lifecycle hooks](https://guides.emberjs.com/v3.4.0/components/the-component-lifecycle/#toc_order-of-lifecycle-hooks-called)
+- [Glimmer component lifecycle hooks](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/#toc_lifecycle-and-properties)

--- a/lib/rules/no-component-lifecycle-hooks.js
+++ b/lib/rules/no-component-lifecycle-hooks.js
@@ -2,7 +2,12 @@
 
 const emberUtils = require('../utils/ember');
 
-const { isComponentLifecycleHook, isEmberComponent, isGlimmerComponent } = emberUtils;
+const {
+  isComponentLifecycleHook,
+  isGlimmerComponentLifecycleHook,
+  isEmberComponent,
+  isGlimmerComponent,
+} = emberUtils;
 
 const ERROR_MESSAGE_NO_COMPONENT_LIFECYCLE_HOOKS =
   'Do not use classic ember components lifecycle hooks. Prefer using "@ember/render-modifiers" or custom functional modifiers.';
@@ -29,49 +34,60 @@ module.exports = {
 
   create(context) {
     let isInsideEmberComponent = false;
-    let currentEmberComponent = null;
-
-    const isAClassicLifecycleHook = (node) => {
-      return isComponentLifecycleHook(node) && isInsideEmberComponent;
-    };
+    let isInsideGlimmerComponent = false;
+    let currentComponentNode = null;
 
     return {
+      // Native class.
       ClassDeclaration(node) {
-        if (isEmberComponent(context, node) || isGlimmerComponent(context, node)) {
-          currentEmberComponent = node;
+        if (isEmberComponent(context, node)) {
+          currentComponentNode = node;
           isInsideEmberComponent = true;
+        } else if (isGlimmerComponent(context, node)) {
+          currentComponentNode = node;
+          isInsideGlimmerComponent = true;
         }
       },
 
+      // Classic class (not used by Glimmer components).
       CallExpression(node) {
         if (isEmberComponent(context, node)) {
-          currentEmberComponent = node;
+          currentComponentNode = node;
           isInsideEmberComponent = true;
         }
       },
 
       'ClassDeclaration:exit'(node) {
-        if (currentEmberComponent === node) {
-          currentEmberComponent = null;
+        if (currentComponentNode === node) {
+          currentComponentNode = null;
           isInsideEmberComponent = false;
+          isInsideGlimmerComponent = false;
         }
       },
 
       'CallExpression:exit'(node) {
-        if (currentEmberComponent === node) {
-          currentEmberComponent = null;
+        if (currentComponentNode === node) {
+          currentComponentNode = null;
           isInsideEmberComponent = false;
         }
       },
 
       MethodDefinition(node) {
-        if (isAClassicLifecycleHook(node)) {
+        if (isComponentLifecycleHook(node) && isInsideEmberComponent) {
+          // Classic Ember component using classic component lifecycle hook.
+          report(context, node);
+        } else if (
+          isInsideGlimmerComponent &&
+          isComponentLifecycleHook(node) &&
+          !isGlimmerComponentLifecycleHook(node)
+        ) {
+          // Glimmer component using classic component lifecycle hook.
           report(context, node);
         }
       },
 
       Property(node) {
-        if (isAClassicLifecycleHook(node)) {
+        if (isComponentLifecycleHook(node) && isInsideEmberComponent) {
           report(context, node.key);
         }
       },

--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -47,8 +47,6 @@ function isNativeSuper(node, hook) {
   );
 }
 
-const GLIMMER_COMPONENT_HOOKS = new Set(['willDestroy']);
-
 //----------------------------------------------
 // General rule - Call super in lifecycle hooks
 //----------------------------------------------
@@ -119,7 +117,7 @@ module.exports = {
           (!checkInitOnly &&
             (node.key.name === 'init' ||
               (!isGlimmerComponent && ember.isComponentLifecycleHook(node)) ||
-              (isGlimmerComponent && GLIMMER_COMPONENT_HOOKS.has(node.key.name)))))
+              (isGlimmerComponent && ember.isGlimmerComponentLifecycleHook(node)))))
       );
     }
 

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -49,6 +49,7 @@ module.exports = {
   isRelation,
 
   isComponentLifecycleHook,
+  isGlimmerComponentLifecycleHook,
 
   isRoute,
   isRouteDefaultProp,
@@ -423,6 +424,7 @@ function isComponentLifecycleHookName(name) {
     'didUpdate',
     'didUpdateAttrs',
     'willClearRender',
+    'willDestroy',
     'willDestroyElement',
     'willInsertElement',
     'willRender',
@@ -430,8 +432,18 @@ function isComponentLifecycleHookName(name) {
   ].includes(name);
 }
 
+function isGlimmerComponentLifecycleHookName(name) {
+  return ['willDestroy'].includes(name);
+}
+
 function isComponentLifecycleHook(property) {
   return isFunctionExpression(property.value) && isComponentLifecycleHookName(property.key.name);
+}
+
+function isGlimmerComponentLifecycleHook(property) {
+  return (
+    isFunctionExpression(property.value) && isGlimmerComponentLifecycleHookName(property.key.name)
+  );
 }
 
 function isRoute(node) {

--- a/tests/lib/rules/no-component-lifecycle-hooks.js
+++ b/tests/lib/rules/no-component-lifecycle-hooks.js
@@ -11,43 +11,47 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-component-lifecycle-hooks', rule, {
   valid: [
+    // Legitimate Glimmer component lifecycle hooks:
     `
       import Component from '@glimmer/component';
       export default class MyComponent extends Component {
+        constructor() {}
         willDestroy() {}
+        foo() {}
       }
     `,
+
+    // Not extending from the component:
     `
       import Component from '@glimmer/component';
       export default class MyClass {
         didUpdate() {}
       }
     `,
+
+    // Just an object:
     `
       export default {
         didUpdate() {},
       }
     `,
+
+    // Not a lifecycle hook:
     `
       import Component from '@ember/component';
       export default Component.extend({
-        willDestroy() {},
+        foo() {},
       });
     `,
+
+    // Just an EmberObject:
     `
       export default EmberObject.extend({
         didUpdate() {},
       });
     `,
-    `
-      import Component from '@ember/component';
-      export const Component1 = Component.extend({
-        willDestroy() {},
-      });
-      export const Component2 = Component.extend({
-        willDestroy() {},
-      });
-    `,
+
+    // Hooks in a random object after a component class:
     `
       import Component from '@ember/component';
       export default class MyComponent extends Component {}
@@ -63,92 +67,10 @@ ruleTester.run('no-component-lifecycle-hooks', rule, {
   ],
 
   invalid: [
+    // Glimmer component using classic Ember component lifecycle hook:
     {
       code: `
         import Component from '@glimmer/component';
-        export default class MyComponent extends Component {
-          didDestroyElement() {}
-        }
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'MethodDefinition',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from '@ember/component';
-        export default class MyComponent extends Component {
-          didDestroyElement() {}
-        }
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'MethodDefinition',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from '@ember/component';
-        export default Component.extend({
-          didDestroyElement() {}
-        })
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'Identifier',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from '@ember/component';
-
-        export const Component2 = Component.extend({
-          didDestroyElement() {},
-        });
-
-        export const Component1 = Component.extend({
-          willDestroy() {},
-        });
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'Identifier',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from "@ember/component";
-
-        export const Component1 = Component.extend({
-          test: computed('', function () {}),
-          didDestroyElement() {},
-        });
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'Identifier',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from "@glimmer/component";
-
         export default class MyComponent extends Component {
           myMethod() {
             class FooBarClass {}
@@ -161,6 +83,44 @@ ruleTester.run('no-component-lifecycle-hooks', rule, {
         {
           message: ERROR_MESSAGE,
           type: 'MethodDefinition',
+        },
+      ],
+    },
+
+    // Classic component using classic Ember component lifecycle hook (native class):
+    {
+      code: `
+        import Component from '@ember/component';
+        export default class MyComponent extends Component {
+          myMethod() {
+            class FooBarClass {}
+          }
+          didDestroyElement() {}
+        }
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'MethodDefinition',
+        },
+      ],
+    },
+
+    // Classic component using classic Ember component lifecycle hook (classic class):
+    {
+      code: `
+        import Component from '@ember/component';
+        export default Component.extend({
+          test: computed('', function () {}),
+          didDestroyElement() {}
+        })
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'Identifier',
         },
       ],
     },

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -231,9 +231,6 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
       options: [{ checkNativeClasses: true }],
     },
 
-    // Regular component allows glimmer hook to be used without super:
-    "import Component from '@ember/component'; class Foo extends Component { willDestroy() {} }",
-
     // Glimmer component allows non-glimmer hook to be used without super:
     "import Component from '@glimmer/component'; class Foo extends Component { init() {} }",
     "import Component from '@glimmer/component'; class Foo extends Component { didInsertElement() {} }",


### PR DESCRIPTION
Fixes part of #1035.