### PR TITLE
Fix false positive in `no-shadow-route-definition` rule

### DIFF
--- a/lib/rules/no-shadow-route-definition.js
+++ b/lib/rules/no-shadow-route-definition.js
@@ -20,6 +20,10 @@ function buildRouteErrorInfo(routeInfo) {
   return `"${routeInfo.name}" (${routeInfo.fullPath}, ${buildSourceLocationString(routeInfo)})`;
 }
 
+function isNestedRouteWithSamePath(routeInfo) {
+  return routeInfo.parent.fullPathWithGenericParams === routeInfo.route.fullPathWithGenericParams;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -56,7 +60,7 @@ module.exports = {
         const routeInfo = getRouteInfo(node);
         if (
           routeMap.has(routeInfo.route.fullPathWithGenericParams) &&
-          !routeMap.has(routeInfo.parent.fullPathWithGenericParams)
+          !isNestedRouteWithSamePath(routeInfo)
         ) {
           const existingRouteInfo = routeMap.get(routeInfo.route.fullPathWithGenericParams);
           context.report({
@@ -76,8 +80,9 @@ module.exports = {
           });
           return;
         }
-
-        routeMap.set(routeInfo.route.fullPathWithGenericParams, routeInfo);
+        if (!routeMap.has(routeInfo.route.fullPathWithGenericParams)) {
+          routeMap.set(routeInfo.route.fullPathWithGenericParams, routeInfo);
+        }
       },
     };
   },
@@ -85,18 +90,13 @@ module.exports = {
 
 function getRouteInfo(node) {
   const routeName = node.arguments[0].value;
-  let basePath = getRouteBasePath(node);
+  const basePath = getRouteBasePath(node);
   const parentRoutes = getParentRoutesPaths(node);
-
-  // If top-level route, prepend "/" to indicate that.
-  if (parentRoutes.length === 0 && !basePath.startsWith('/')) {
-    basePath = `/${basePath}`;
-  }
 
   // We replace "////post/something" -> "/post/something".
   // As that what nesting of / configured routes means for Ember router.
   const parentRoutesFullPath = trimRootLevelNestedRoutes(parentRoutes.join(''));
-  const fullPath = `${parentRoutesFullPath}${basePath}`;
+  const fullPath = trimRootLevelNestedRoutes(`${parentRoutesFullPath}${basePath}`);
 
   return {
     route: {
@@ -124,6 +124,9 @@ function getRouteBasePath(node) {
     if (pathValue) {
       routePath = pathValue;
     }
+  }
+  if (!routePath.startsWith('/')) {
+    routePath = `/${routePath}`;
   }
   return routePath;
 }

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -92,6 +92,11 @@ ruleTester.run('no-shadow-route-definition', rule, {
       this.route("post");
     });
     this.route("post");`,
+    // Test nested routes without leading slash (/) in path configuration.
+    `this.route('edit', { path: ':experienceId' }, function () {
+      this.route('views', { path: 'views/:viewId' });
+      this.route('viewcollections', { path: 'viewcollections/:viewCollectionId' });
+    });`,
 
     // Not Ember's route function:
     'test();',
@@ -354,6 +359,35 @@ ruleTester.run('no-shadow-route-definition', rule, {
                   start: {
                     line: 2,
                     column: 8,
+                  },
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+        {
+          message: buildErrorMessage({
+            leftRoute: {
+              name: 'post',
+              fullPath: '/post',
+              source: {
+                loc: {
+                  start: {
+                    line: 8,
+                    column: 10,
+                  },
+                },
+              },
+            },
+            rightRoute: {
+              name: 'post',
+              fullPath: '/post',
+              source: {
+                loc: {
+                  start: {
+                    line: 4,
+                    column: 12,
                   },
                 },
               },
@@ -648,7 +682,7 @@ ruleTester.run('no-shadow-route-definition', rule, {
           message: buildErrorMessage({
             leftRoute: {
               name: 'second',
-              fullPath: 'main/',
+              fullPath: '/main/',
               source: {
                 loc: {
                   start: {
@@ -660,7 +694,7 @@ ruleTester.run('no-shadow-route-definition', rule, {
             },
             rightRoute: {
               name: 'first',
-              fullPath: 'main/',
+              fullPath: '/main/',
               source: {
                 loc: {
                   start: {


### PR DESCRIPTION
This PR fixes false positive example from issue #1037.

Closes #1037 