### PR TITLE
Fix path checks for Windows in `no-test-import-export` and `no-test-support-import` rules

### DIFF
--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -48,7 +48,7 @@ module.exports = {
 
         if (
           importSource.endsWith('-test') &&
-          !isTestHelperImportSource(path.resolve(path.dirname(context.getFilename()), importSource))
+          !isTestHelperFilename(path.resolve(path.dirname(context.getFilename()), importSource))
         ) {
           context.report({
             message: NO_IMPORT_MESSAGE,
@@ -66,15 +66,12 @@ module.exports = {
   },
 };
 
-function isTestHelperImportSource(importSource) {
-  return (
-    importSource.startsWith('tests/helpers/') ||
-    importSource.includes('/tests/helpers/') ||
-    importSource.endsWith('/tests/helpers') ||
-    importSource === 'tests/helpers'
-  );
-}
-
 function isTestHelperFilename(filename) {
-  return filename.startsWith('tests/helpers/') || filename.includes('/tests/helpers/');
+  const filenameParts = path.normalize(filename).split(path.sep);
+  for (let i = 0; i < filenameParts.length - 1; ++i) {
+    if (filenameParts[i] === 'tests' && filenameParts[i + 1] === 'helpers') {
+      return true;
+    }
+  }
+  return false;
 }

--- a/lib/rules/no-test-support-import.js
+++ b/lib/rules/no-test-support-import.js
@@ -26,12 +26,12 @@ module.exports = {
 
   create: function create(context) {
     const fileName = context.getFilename();
-    const fileNameParts = fileName.split(path.sep);
+    const fileNameParts = path.normalize(fileName).split(path.sep);
 
     return {
       ImportDeclaration(node) {
         const importSource = node.source.value;
-        const importSourceParts = importSource.split(path.sep);
+        const importSourceParts = path.normalize(importSource).split(path.sep);
 
         if (
           importSourceParts.includes('test-support') &&

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -162,8 +162,9 @@ function isModuleByFilePath(filePath, module) {
   const expectedFileNameTs = `${module}.ts`;
   const expectedFolderName = `${module}s`;
 
-  const actualFolders = path.dirname(filePath).split(path.sep);
-  const actualFileName = path.basename(filePath);
+  const normalized = path.normalize(filePath);
+  const actualFolders = path.dirname(normalized).split(path.sep);
+  const actualFileName = path.basename(normalized);
 
   /* Check both folder and filename to support both classic and POD's structure */
   return (
@@ -178,12 +179,12 @@ function isTestFile(fileName) {
 }
 
 function isMirageDirectory(fileName) {
-  const pathParts = fileName.split(path.sep);
+  const pathParts = path.normalize(fileName).split(path.sep);
   return pathParts.includes('mirage');
 }
 
 function isMirageConfig(fileName) {
-  return fileName.endsWith(path.join('mirage', 'config.js'));
+  return path.normalize(fileName).endsWith(path.join('mirage', 'config.js'));
 }
 
 function isExtendObject(node) {


### PR DESCRIPTION
The `no-test-import-export` rule incorrectly reported failures on Windows.
Also there were some misc test failures due to `path.sep` usage, which is `\` on Windows while most of the tests use `/` in paths.

I'll update Github actions to run against Windows too if there is any interest in merging it.