### PR TITLE
Handle commas inside quotes in selectors in `require-valid-css-selector-in-test-helpers` rule

### DIFF
--- a/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -4,6 +4,18 @@ const { getPropertyValue, parseCallee } = require('../utils/utils');
 const cssTree = require('css-tree');
 const emberUtils = require('../utils/ember');
 
+/**
+ * Positive lookahead regexp.
+ * Used for splitting a string only by commas that are not inside quotes.
+ * Example input string:
+ *  - [data-test-row="London, England, GB"], .foo
+ * Would match these strings:
+ *  - [data-test-row="London, England, GB"]
+ *  - .foo
+ * https://stackoverflow.com/questions/23582276/split-string-by-comma-but-ignore-commas-inside-quotes/23582323
+ */
+const REGEX_SPLIT_BY_COMMA_NOT_IN_QUOTES = /,(?=(?:(?:[^"']*["']){2})*[^"']*$)/g;
+
 const TEST_MODULE_NAMES = new Set(['module', 'describe']);
 const TEST_HELPER_IMPORTS = new Set([
   'blur',
@@ -27,12 +39,12 @@ const SELECTOR_RULES = Object.freeze({
   unclosedAttr: {
     hasError: (str) =>
       str
-        .split(',')
+        .split(REGEX_SPLIT_BY_COMMA_NOT_IN_QUOTES)
         .map((str) => str.trim())
         .some((selector) => hasMissingClosingBracket(selector)),
     fix(node, str, fixer) {
       const replacement = str
-        .split(',')
+        .split(REGEX_SPLIT_BY_COMMA_NOT_IN_QUOTES)
         .map((selector) => (hasMissingClosingBracket(selector) ? `${selector}]` : selector))
         .join(',');
       return fixer.replaceText(node.arguments[0], `'${replacement}'`);
@@ -43,7 +55,7 @@ const SELECTOR_RULES = Object.freeze({
   idStartsWithNumber: {
     hasError: (str) =>
       str
-        .split(',')
+        .split(REGEX_SPLIT_BY_COMMA_NOT_IN_QUOTES)
         .map((str) => str.trim())
         .some((selector) => selector.match(/^#\d/)),
     fix() {},
@@ -52,7 +64,7 @@ const SELECTOR_RULES = Object.freeze({
   other: {
     hasError: (str) =>
       str
-        .split(',')
+        .split(REGEX_SPLIT_BY_COMMA_NOT_IN_QUOTES)
         .map((str) => str.trim())
         .some((selector) => !_isValidSelector(selector)),
     fix() {},

--- a/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -252,6 +252,20 @@ ruleTester.run('require-valid-css-selector-in-test-helpers', rule, {
       `,
       filename: 'components/foobar-test.js',
     },
+
+    // With comma(s) inside quotes in a selector:
+    {
+      code: `
+        import { module, test } from 'qunit';
+
+        module('foo', function() {
+          test('foo', function(assert) {
+            assert.dom('[data-test-row="London, England, GB"], .foo').exists();
+          });
+        });
+      `,
+      filename: 'components/foobar-test.js',
+    },
   ],
   invalid: [
     {
@@ -724,7 +738,7 @@ ruleTester.run('require-valid-css-selector-in-test-helpers', rule, {
 
         module('foo', function() {
           test('foo', function(assert) {
-            assert.dom('.foo, [data-test, .bar');
+            assert.dom('.foo, [data-test-row="London, England, GB", .bar');
           });
         });
         `,
@@ -733,7 +747,7 @@ ruleTester.run('require-valid-css-selector-in-test-helpers', rule, {
 
         module('foo', function() {
           test('foo', function(assert) {
-            assert.dom('.foo, [data-test], .bar');
+            assert.dom('.foo, [data-test-row="London, England, GB"], .bar');
           });
         });
         `,


### PR DESCRIPTION
Fixes #1049.