### PR TITLE
Implement `require-fetch-import` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 | :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
 | :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
 |  | [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |
+|  | [require-fetch-import](./docs/rules/require-fetch-import.md) | enforce explicit import for `fetch()` |
 
 ### Routes
 

--- a/docs/rules/require-fetch-import.md
+++ b/docs/rules/require-fetch-import.md
@@ -1,0 +1,38 @@
+# require-fetch-import
+
+Using `fetch()` without importing it causes the browser to use the native,
+non-wrapped `window.fetch()`. This is generally fine, but makes testing harder
+because this non-wrapped version does not have a built-in test waiter. Because
+of this it is generally better to use [ember-fetch] and explicitly
+`import fetch from 'fetch'`.
+
+## Rule Details
+
+The rule looks for `fetch()` calls and reports them as issues if no
+corresponding import declaration is found.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+const result = fetch('/something');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import fetch from 'fetch';
+
+const result = fetch('/something');
+```
+
+## Migration
+
+* Add `import fetch from 'fetch';` to all files that need it
+
+## References
+
+* [@ember/test-waiters](https://github.com/emberjs/ember-test-waiters) addon
+
+[ember-fetch]: https://github.com/ember-cli/ember-fetch/

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ module.exports = {
     'prefer-ember-test-helpers': require('./rules/prefer-ember-test-helpers'),
     'require-computed-macros': require('./rules/require-computed-macros'),
     'require-computed-property-dependencies': require('./rules/require-computed-property-dependencies'),
+    'require-fetch-import': require('./rules/require-fetch-import'),
     'require-return-from-computed': require('./rules/require-return-from-computed'),
     'require-super-in-lifecycle-hooks': require('./rules/require-super-in-lifecycle-hooks'),
     'require-tagless-components': require('./rules/require-tagless-components'),

--- a/lib/rules/require-fetch-import.js
+++ b/lib/rules/require-fetch-import.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { ReferenceTracker } = require('eslint-utils');
+
 const ERROR_MESSAGE = 'Explicitly import `fetch` instead of using `window.fetch`';
 
 module.exports = {
@@ -19,35 +21,16 @@ module.exports = {
   ERROR_MESSAGE,
 
   create(context) {
-    let fetchImportFound = false;
-    const fetchCalls = [];
-
     return {
-      ImportDeclaration(node) {
-        // search for a `fetch` import
-        for (const specifier of node.specifiers) {
-          if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportSpecifier') {
-            if (specifier.local.type === 'Identifier' && specifier.local.name === 'fetch') {
-              fetchImportFound = true;
-            }
-          }
-        }
-      },
-
-      CallExpression(node) {
-        // save all `fetch()` calls for later
-        const { callee } = node;
-        if (callee.type === 'Identifier' && callee.name === 'fetch') {
-          fetchCalls.push(node);
-        }
-      },
-
       'Program:exit'() {
-        // if there was no `fetch` import in the file, report all of the `fetch()` calls
-        if (!fetchImportFound) {
-          for (const node of fetchCalls) {
-            context.report(node, ERROR_MESSAGE);
-          }
+        const tracker = new ReferenceTracker(context.getScope());
+
+        const traceMap = {
+          fetch: { [ReferenceTracker.CALL]: true },
+        };
+
+        for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
+          context.report(node, ERROR_MESSAGE);
         }
       },
     };

--- a/lib/rules/require-fetch-import.js
+++ b/lib/rules/require-fetch-import.js
@@ -4,7 +4,7 @@ const ERROR_MESSAGE = 'Explicitly import `fetch` instead of using `window.fetch`
 
 module.exports = {
   meta: {
-    type: 'problem',
+    type: 'suggestion',
     docs: {
       description: 'enforce explicit import for `fetch()`',
       category: 'Miscellaneous',

--- a/lib/rules/require-fetch-import.js
+++ b/lib/rules/require-fetch-import.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const ERROR_MESSAGE = 'Explicitly import `fetch` instead of using `window.fetch`';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'enforce explicit import for `fetch()`',
+      category: 'Miscellaneous',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/require-fetch-import.md',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  ERROR_MESSAGE,
+
+  create(context) {
+    let fetchImportFound = false;
+    const fetchCalls = [];
+
+    return {
+      ImportDeclaration(node) {
+        // search for a `fetch` import
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportSpecifier') {
+            if (specifier.local.type === 'Identifier' && specifier.local.name === 'fetch') {
+              fetchImportFound = true;
+            }
+          }
+        }
+      },
+
+      CallExpression(node) {
+        // save all `fetch()` calls for later
+        const { callee } = node;
+        if (callee.type === 'Identifier' && callee.name === 'fetch') {
+          fetchCalls.push(node);
+        }
+      },
+
+      'Program:exit'() {
+        // if there was no `fetch` import in the file, report all of the `fetch()` calls
+        if (!fetchImportFound) {
+          for (const node of fetchCalls) {
+            context.report(node, ERROR_MESSAGE);
+          }
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/require-fetch-import.js
+++ b/tests/lib/rules/require-fetch-import.js
@@ -7,6 +7,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  env: { browser: true },
 });
 
 ruleTester.run('require-fetch-import', rule, {

--- a/tests/lib/rules/require-fetch-import.js
+++ b/tests/lib/rules/require-fetch-import.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const rule = require('../../../lib/rules/require-fetch-import');
+const RuleTester = require('eslint').RuleTester;
+
+const { ERROR_MESSAGE } = rule;
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
+ruleTester.run('require-fetch-import', rule, {
+  valid: [
+    `
+      import fetch from 'fetch';
+
+      fetch('/something');
+    `,
+    `
+      fetch('/something');
+
+      import fetch from 'fetch';
+    `,
+    `
+      import { default as fetch } from 'fetch';
+
+      fetch('/something');
+    `,
+    "foo('/something');",
+  ],
+
+  invalid: [
+    {
+      code: "fetch('/something');",
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/require-fetch-import.js
+++ b/tests/lib/rules/require-fetch-import.js
@@ -33,11 +33,7 @@ ruleTester.run('require-fetch-import', rule, {
     {
       code: "fetch('/something');",
       output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-        },
-      ],
+      errors: [{ message: ERROR_MESSAGE, type: 'CallExpression', line: 1, column: 1 }],
     },
   ],
 });


### PR DESCRIPTION

Resolves #1053 

---

# require-fetch-import

Using `fetch()` without importing it causes the browser to use the native,
non-wrapped `window.fetch()`. This is generally fine, but makes testing harder
because this non-wrapped version does not have a built-in test waiter. Because
of this it is generally better to use [ember-fetch] and explicitly
`import fetch from 'fetch'`.

## Rule Details

The rule looks for `fetch()` calls and reports them as issues if no
corresponding import declaration is found.

## Examples

Examples of **incorrect** code for this rule:

```js
const result = fetch('/something');
```

Examples of **correct** code for this rule:

```js
import fetch from 'fetch';

const result = fetch('/something');
```

## Migration

* Add `import fetch from 'fetch';` to all files that need it

## References

* [@ember/test-waiters](https://github.com/emberjs/ember-test-waiters) addon

[ember-fetch]: https://github.com/ember-cli/ember-fetch/
