### PR TITLE
Implement `no-current-route-name` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
+|  | [no-current-route-name](./docs/rules/no-current-route-name.md) | disallow usage of the `currentRouteName()` test helper |
 | :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope |
 | :white_check_mark: | [no-invalid-test-waiters](./docs/rules/no-invalid-test-waiters.md) | disallow incorrect usage of test waiter APIs |
 | :white_check_mark: | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs |

--- a/docs/rules/no-current-route-name.md
+++ b/docs/rules/no-current-route-name.md
@@ -1,0 +1,34 @@
+# no-current-route-name
+
+The route name is something which is not visible to the user, so it can be
+considered an implementation detail. The URL however is visible to the user, so
+when writing tests it makes much more sense to assert against `currentURL()`
+instead of `currentRouteName()`.
+
+## Rule Details
+
+This rule warns about any usage of the `currentRouteName()` test helper.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+assert.equal(currentRouteName(), 'foo');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+assert.equal(currentURL(), '/foo');
+```
+
+## Migration
+
+* Replace `currentRouteName()` with `currentURL()` and adjust
+  the assertion expectations
+
+## References
+
+* [currentRouteName()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename) documentation
+* [currentURL()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl) documentation

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'no-computed-properties-in-native-classes': require('./rules/no-computed-properties-in-native-classes'),
     'no-controller-access-in-routes': require('./rules/no-controller-access-in-routes'),
     'no-controllers': require('./rules/no-controllers'),
+    'no-current-route-name': require('./rules/no-current-route-name'),
     'no-deeply-nested-dependent-keys-with-each': require('./rules/no-deeply-nested-dependent-keys-with-each'),
     'no-duplicate-dependent-keys': require('./rules/no-duplicate-dependent-keys'),
     'no-ember-super-in-es-classes': require('./rules/no-ember-super-in-es-classes'),

--- a/lib/rules/no-current-route-name.js
+++ b/lib/rules/no-current-route-name.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const ERROR_MESSAGE = 'Use currentURL() instead of currentRouteName()';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow usage of the `currentRouteName()` test helper',
+      category: 'Testing',
+      recommended: false,
+      url:
+        'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-current-route-name.md',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  ERROR_MESSAGE,
+
+  create(context) {
+    const importAliases = [];
+
+    return {
+      ImportSpecifier(node) {
+        const { imported, local } = node;
+        if (
+          imported.type === 'Identifier' &&
+          imported.name === 'currentRouteName' &&
+          local.type === 'Identifier'
+        ) {
+          importAliases.push(node.local.name);
+        }
+      },
+
+      CallExpression(node) {
+        const { callee } = node;
+        if (callee.type === 'Identifier' && importAliases.includes(callee.name)) {
+          context.report(node, ERROR_MESSAGE);
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/no-current-route-name.js
+++ b/tests/lib/rules/no-current-route-name.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const rule = require('../../../lib/rules/no-current-route-name');
+const RuleTester = require('eslint').RuleTester;
+
+const { ERROR_MESSAGE } = rule;
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+});
+
+ruleTester.run('no-current-route-name', rule, {
+  valid: [
+    "assert.equal(currentURL(), '/foo');",
+    "assert.equal(currentRouteName(), '/foo');",
+
+    `
+      import { currentURL } from '@ember/test-helpers';
+
+      assert.equal(currentURL(), '/foo');
+    `,
+
+    // who knows...
+    `
+      import { currentURL as currentRouteName } from '@ember/test-helpers';
+
+      assert.equal(currentRouteName(), '/foo');
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        import { currentRouteName } from '@ember/test-helpers';
+
+        assert.equal(currentRouteName(), '/foo');
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 4, column: 22 }],
+    },
+    {
+      code: `
+        import { currentRouteName as foo } from '@ember/test-helpers';
+
+        assert.equal(foo(), '/foo');
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 4, column: 22 }],
+    },
+  ],
+});


### PR DESCRIPTION
Resolves https://github.com/ember-cli/eslint-plugin-ember/issues/1050

---

# no-current-route-name

The route name is something which is not visible to the user, so it can be
considered an implementation detail. The URL however is visible to the user, so
when writing tests it makes much more sense to assert against `currentURL()`
instead of `currentRouteName()`.

## Rule Details

This rule warns about any usage of the `currentRouteName()` test helper. 

## Examples

Examples of **incorrect** code for this rule:

```js
assert.equal(currentRouteName(), 'foo');
```

Examples of **correct** code for this rule:

```js
assert.equal(currentURL(), '/foo');
```

## Migration

* Replace `currentRouteName()` with `currentURL()` and adjust
  the assertion expectations

## References

* [currentRouteName()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename) documentation
* [currentURL()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl) documentation
