### PR TITLE
no-component-lifecycle-hooks: Do not warn about Glimmer lifecycle hooks on classic components

### DIFF
--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -21,7 +21,7 @@ Examples of **incorrect** code for this rule:
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
-  // Classic Ember component lifecycle hooks:
+  // Classic Ember component lifecycle hooks (minus willDestroy which is also a Glimmer component lifecycle hook):
   didDestroyElement() {}
   didInsertElement() {}
   didReceiveAttrs() {}
@@ -29,7 +29,6 @@ export default class MyComponent extends Component {
   didUpdate() {}
   didUpdateAttrs() {}
   willClearRender() {}
-  willDestroy() {}
   willDestroyElement() {}
   willInsertElement() {}
   willRender() {}
@@ -52,6 +51,7 @@ import Component from '@ember/component';
 
 export default class MyComponent extends Component {
   init() {}
+  willDestroy() {} // Both a classic and Glimmer component lifecycle hook
 }
 ```
 

--- a/lib/rules/no-component-lifecycle-hooks.js
+++ b/lib/rules/no-component-lifecycle-hooks.js
@@ -73,7 +73,11 @@ module.exports = {
       },
 
       MethodDefinition(node) {
-        if (isComponentLifecycleHook(node) && isInsideEmberComponent) {
+        if (
+          isInsideEmberComponent &&
+          isComponentLifecycleHook(node) &&
+          !isGlimmerComponentLifecycleHook(node)
+        ) {
           // Classic Ember component using classic component lifecycle hook.
           report(context, node);
         } else if (
@@ -87,7 +91,11 @@ module.exports = {
       },
 
       Property(node) {
-        if (isComponentLifecycleHook(node) && isInsideEmberComponent) {
+        if (
+          isInsideEmberComponent &&
+          isComponentLifecycleHook(node) &&
+          !isGlimmerComponentLifecycleHook(node)
+        ) {
           report(context, node.key);
         }
       },

--- a/tests/lib/rules/no-component-lifecycle-hooks.js
+++ b/tests/lib/rules/no-component-lifecycle-hooks.js
@@ -167,41 +167,5 @@ ruleTester.run('no-component-lifecycle-hooks', rule, {
         },
       ],
     },
-    {
-      code: `
-        import Component from "@ember/component";
-
-        export const Component1 = Component.extend({
-          test: computed('', function () {}),
-          didDestroyElement() {},
-        });
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'Identifier',
-        },
-      ],
-    },
-    {
-      code: `
-        import Component from "@glimmer/component";
-
-        export default class MyComponent extends Component {
-          myMethod() {
-            class FooBarClass {}
-          }
-          didDestroyElement() {}
-        }
-      `,
-      output: null,
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-          type: 'MethodDefinition',
-        },
-      ],
-    },
   ],
 });

--- a/tests/lib/rules/no-component-lifecycle-hooks.js
+++ b/tests/lib/rules/no-component-lifecycle-hooks.js
@@ -44,6 +44,29 @@ ruleTester.run('no-component-lifecycle-hooks', rule, {
       });
     `,
 
+    // Legitimate classic component lifecycle hook:
+    `
+      import Component from '@ember/component';
+      export default Component.extend({
+        willDestroy() {},
+      });
+    `,
+    `
+      import Component from '@ember/component';
+      export const Component1 = Component.extend({
+        willDestroy() {},
+      });
+      export const Component2 = Component.extend({
+        willDestroy() {},
+      });
+    `,
+    `
+      import Component from '@ember/component';
+      export default class extends Component {
+        willDestroy() {}
+      }
+    `,
+
     // Just an EmberObject:
     `
       export default EmberObject.extend({
@@ -121,6 +144,62 @@ ruleTester.run('no-component-lifecycle-hooks', rule, {
         {
           message: ERROR_MESSAGE,
           type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from '@ember/component';
+
+        export const Component2 = Component.extend({
+          didDestroyElement() {},
+        });
+
+        export const Component1 = Component.extend({
+          willDestroy() {},
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from "@ember/component";
+
+        export const Component1 = Component.extend({
+          test: computed('', function () {}),
+          didDestroyElement() {},
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: `
+        import Component from "@glimmer/component";
+
+        export default class MyComponent extends Component {
+          myMethod() {
+            class FooBarClass {}
+          }
+          didDestroyElement() {}
+        }
+      `,
+      output: null,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          type: 'MethodDefinition',
         },
       ],
     },


### PR DESCRIPTION
This PR resolves https://github.com/ember-cli/eslint-plugin-ember/issues/1058.

As mentioned in the issue, the rule should only warn about lifecycle hooks that are not available anymore on Glimmer components, but `willDestroy()` should not be part of that list.