### PR TITLE
Improve detection of globals in `no-global-jquery` rule

### DIFF
--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const ember = require('../utils/ember');
-const utils = require('../utils/utils');
-const types = require('../utils/types');
+const { ReferenceTracker } = require('eslint-utils');
 
-const ALIASES = ['$', 'jQuery'];
 const ERROR_MESSAGE = 'Do not use global `$` or `jQuery`';
 
 //------------------------------------------------------------------------------
@@ -28,96 +25,18 @@ module.exports = {
   ERROR_MESSAGE,
 
   create(context) {
-    let destructuredAssignment;
-    let importAliasName;
-    let hasJqueryImport;
-    let hasEmberImport;
-
     return {
-      ImportDeclaration(node) {
-        const validImportAlias = new Set(['ember', 'jquery']);
-        // Track if the 'jquery' and/or 'ember' module (if an application
-        // is not using the new modules import syntax) is being imported.
-        // Will exclude non-ember or non-jquery imports such as:
-        //    - `import Foo from 'bar';`
-        //    - `import { readOnly } from '@ember/object/computed';`
-        if (validImportAlias.has(node.source.value)) {
-          const isJqueryImport = node.source.value === 'jquery';
-          if (isJqueryImport) {
-            hasJqueryImport = true;
-            importAliasName = node.source.value;
-          } else {
-            const emberImport = ember.getEmberImportAliasName(node);
-            if (emberImport) {
-              hasEmberImport = true;
-              importAliasName = emberImport;
-            }
-          }
-        }
-      },
+      Program() {
+        const tracker = new ReferenceTracker(context.getScope());
+        const traceMap = {
+          $: { [ReferenceTracker.CALL]: true },
+          jQuery: { [ReferenceTracker.CALL]: true },
+        };
 
-      VariableDeclarator(node) {
-        // If an application is using an older version of Ember, not using
-        // the new modules import syntax, then lets locate a destructured
-        // jQuery assignment.
-        if (hasEmberImport) {
-          // Let's verify that we are dealing with an Ember MemberExpression
-          // only to test against.
-          if (
-            node.init &&
-            types.isMemberExpression(node.init) &&
-            isEmberMemberExpression(node.init)
-          ) {
-            const isJQueryVariable = node.init.property.name === '$';
-
-            if (isJQueryVariable) {
-              // Assignment of type const $ = Ember.$;
-              destructuredAssignment = node.id.name;
-            }
-          } else {
-            // If we are not dealing with an Ember identifier, there is no need
-            // to perform the below checks/run the below code.
-            if (node.init && !isEmberIdentifier(node.init)) {
-              return;
-            }
-
-            if (!node.id.properties || !isNestedJQueryAssignment(node.id.properties)) {
-              return;
-            }
-            // Assignment of type const { $: foo } = Ember;
-            // It will grab/return "foo".
-            destructuredAssignment = utils
-              .collectObjectPatternBindings(node, {
-                [importAliasName]: ['$'],
-              })
-              .pop();
-          }
-        }
-      },
-
-      CallExpression(node) {
-        // In the event in which the jQuery module is being imported
-        // using the new modules import syntax do not report to ESLint
-        if (hasJqueryImport) {
-          return;
-        }
-
-        if (utils.isGlobalCallExpression(node, destructuredAssignment, ALIASES)) {
+        for (const { node } of tracker.iterateGlobalReferences(traceMap)) {
           context.report(node, ERROR_MESSAGE);
         }
       },
     };
   },
 };
-
-function isNestedJQueryAssignment(props) {
-  return props.filter((prop) => prop.key.name === '$').length > 0;
-}
-
-function isEmberIdentifier(init) {
-  return init.name === 'Ember';
-}
-
-function isEmberMemberExpression(init) {
-  return init.object.name === 'Ember';
-}

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -16,6 +16,8 @@ const parserOptions = {
   ecmaVersion: 6,
   sourceType: 'module',
 };
+const globals = { $: true, jQuery: true };
+
 const { ERROR_MESSAGE } = rule;
 
 ruleTester.run('no-global-jquery', rule, {
@@ -31,6 +33,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -45,6 +48,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -58,6 +62,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -73,6 +78,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -89,6 +95,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -105,6 +112,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -120,6 +128,7 @@ ruleTester.run('no-global-jquery', rule, {
         });
       `,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -135,6 +144,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -150,6 +160,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -159,6 +170,7 @@ ruleTester.run('no-global-jquery', rule, {
           },
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -168,6 +180,7 @@ ruleTester.run('no-global-jquery', rule, {
           },
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -179,6 +192,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -190,6 +204,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -203,6 +218,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -218,6 +234,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -231,6 +248,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -246,6 +264,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -261,6 +280,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -276,6 +296,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
     },
     {
       code: `
@@ -290,6 +311,37 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
+    },
+    {
+      // Function parameter:
+      code: `
+      function addClass($, selector, className) {
+        $(selector).addClass(className);
+      }`,
+      parserOptions,
+      globals,
+    },
+    {
+      // From another object:
+      code: 'Foo.$(selector).attr(attribute);',
+      parserOptions,
+      globals,
+    },
+    {
+      // From another object:
+      code: `
+      const { $ } = Foo;
+      $(selector).attr(attribute);`,
+      parserOptions,
+      globals,
+    },
+    {
+      // Without globals:
+      code: `
+        $('foo');
+        jQuery('foo');`,
+      parserOptions,
     },
   ],
   invalid: [
@@ -301,6 +353,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {
@@ -318,6 +371,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {
@@ -333,6 +387,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {
@@ -350,6 +405,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {
@@ -371,6 +427,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {
@@ -392,6 +449,7 @@ ruleTester.run('no-global-jquery', rule, {
           }
         });`,
       parserOptions,
+      globals,
       output: null,
       errors: [
         {


### PR DESCRIPTION
Eliminates all of the custom logic for detecting global usages of `$` or `jQuery` and replaces it with the [ReferenceTracker](https://eslint-utils.mysticatea.dev/api/scope-utils.html#referencetracker-class) class from eslint-utils. This will generally make the detection better and more robust.

Similar to https://github.com/ember-cli/eslint-plugin-ember/pull/1038.