### PR TITLE
Update `avoid-leaking-state-in-ember-objects` rule to apply to mixins

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -2,7 +2,7 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
-Don't use arrays and objects as default properties. More info here: <https://dockyard.com/blog/2015/09/18/ember-best-practices-avoid-leaking-state-into-factories>
+Don't use arrays and objects as default properties in classic classes or mixins. In native classes, it is safe to assign objects to fields.
 
 ## Examples
 
@@ -17,6 +17,14 @@ export default Foo.extend({
       this.items.pushObject(item);
     }
   }
+});
+```
+
+```javascript
+import Mixin from '@ember/object/mixin';
+
+export default Mixin.create({
+  items: []
 });
 ```
 
@@ -36,6 +44,20 @@ export default Foo.extend({
     }
   }
 });
+```
+
+```javascript
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class FooComponent extends Component {
+  items = [];
+
+  @action
+  addItem(item) {
+    this.items = [...this.items, item];
+  }
+}
 ```
 
 ## Configuration
@@ -60,3 +82,9 @@ module.exports = {
   }
 };
 ```
+
+## References
+
+- [Dockyard blog](https://dockyard.com/blog/2015/09/18/ember-best-practices-avoid-leaking-state-into-factories)
+- [Ember native classes guides](https://guides.emberjs.com/release/upgrading/current-edition/native-classes/)
+- [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -80,7 +80,13 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!(ember.isExtendObject(node) || ember.isReopenObject(node))) {
+        if (
+          !(
+            ember.isExtendObject(node) ||
+            ember.isReopenObject(node) ||
+            ember.isEmberMixin(context, node)
+          )
+        ) {
           return;
         }
 

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -26,10 +26,8 @@ describe('imports', () => {
 });
 
 const eslintTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 2018,
-    sourceType: 'module',
-  },
+  parser: require.resolve('babel-eslint'),
+  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
   valid: [
@@ -66,6 +64,13 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     'export default Foo.extend({ foo: condition ? "foo" : "bar" });',
     'export default Foo.extend({ foo: "foo" && "bar" });',
     'export default Foo.extend({ foo: "foo" || "bar" });',
+    'export default Mixin.create({});',
+    'export default Mixin.create({ harmlessProp: "foo" });',
+    'export default Mixin.create(NestedMixin, {});',
+    'import Mixin from "@ember/object/mixin";',
+    'export default class MyNativeClassComponent extends Component { someArrayField = []; }',
+    'export default class MyNativeClassComponent extends Component { someObjectField = {}; }',
+    'import EmberObject from "@ember/object"; export default class MyNativeClassComponentWithAMixin extends EmberObject.extend(MyMixin) { someArrayField = []; }',
   ],
   invalid: [
     {
@@ -221,6 +226,26 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     },
     {
       code: 'export default Foo.extend({ foo: {} || false });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Mixin.create({ anArray: [] });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      code: 'export default Ember.Mixin.create({ anObject: {} });',
       output: null,
       errors: [
         {

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -64,12 +64,12 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     'export default Foo.extend({ foo: condition ? "foo" : "bar" });',
     'export default Foo.extend({ foo: "foo" && "bar" });',
     'export default Foo.extend({ foo: "foo" || "bar" });',
-    'export default Mixin.create({});',
-    'export default Mixin.create({ harmlessProp: "foo" });',
-    'export default Mixin.create(NestedMixin, {});',
+    'import Mixin from "@ember/object/mixin"; export default Mixin.create({});',
+    'import Mixin from "@ember/object/mixin"; export default Mixin.create({ harmlessProp: "foo" });',
+    'import Mixin from "@ember/object/mixin"; export default Mixin.create(NestedMixin, {});',
     'import Mixin from "@ember/object/mixin";',
-    'export default class MyNativeClassComponent extends Component { someArrayField = []; }',
-    'export default class MyNativeClassComponent extends Component { someObjectField = {}; }',
+    'import Component from "@ember/component"; export default class MyNativeClassComponent extends Component { someArrayField = []; }',
+    'import Component from "@ember/component"; export default class MyNativeClassComponent extends Component { someObjectField = {}; }',
     'import EmberObject from "@ember/object"; export default class MyNativeClassComponentWithAMixin extends EmberObject.extend(MyMixin) { someArrayField = []; }',
   ],
   invalid: [
@@ -235,7 +235,8 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
       ],
     },
     {
-      code: 'export default Mixin.create({ anArray: [] });',
+      code:
+        'import Mixin from "@ember/object/mixin"; export default Mixin.create({ anArray: [] });',
       output: null,
       errors: [
         {
@@ -245,7 +246,7 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
       ],
     },
     {
-      code: 'export default Ember.Mixin.create({ anObject: {} });',
+      code: 'import Ember from "ember"; export default Ember.Mixin.create({ anObject: {} });',
       output: null,
       errors: [
         {


### PR DESCRIPTION
## What

- applies `avoid-leaking-state` rule to Ember Mixins as well
- updates the docfile a bit with more references & to mention native classes

### Why

- fixes #219 