### PR TITLE
Add `additionalClassImports` option to `no-classic-classes` rule

### DIFF
--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -38,13 +38,19 @@ import Evented from '@ember/object/evented';
 export default class MyComponent extends Component.extend(Evented) {}
 ```
 
+## Configuration
+
+This rule takes an optional object containing:
+
+- `array` -- `additionalInvalidImports` -- Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`.
+
 ## When Not To Use It
 
-* If you are not ready to transition completely to native JS classes, you should not enable this rule
+- If you are not ready to transition completely to native JS classes, you should not enable this rule
 
 ## Further Reading
 
-* [Ember Octane Release Plan](https://blog.emberjs.com/2019/08/15/octane-release-plan.html)
-  * Includes advice on transition Components to use native, rather than classic, classes
-* [Ember.js Native Class Update - 2019 Edition](https://blog.emberjs.com/2019/01/26/emberjs-native-class-update-2019-edition.html)
-  * **Note:** some of the recommendations made in this blog post are longer relevant, such as using `.extend` when defining a computed property
+- [Ember Octane Release Plan](https://blog.emberjs.com/2019/08/15/octane-release-plan.html)
+  - Includes advice on transition Components to use native, rather than classic, classes
+- [Ember.js Native Class Update - 2019 Edition](https://blog.emberjs.com/2019/01/26/emberjs-native-class-update-2019-edition.html)
+  - **Note:** some of the recommendations made in this blog post are longer relevant, such as using `.extend` when defining a computed property

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -22,7 +22,7 @@ export default Component.extend({});
 ```
 
 ```javascript
-// With option: additionalInvalidImports = ['my-custom-addon']
+// With option: additionalClassImports = ['my-custom-addon']
 import CustomClass from 'my-custom-addon';
 
 export default CustomClass.extend({});

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -21,6 +21,13 @@ import Component from '@ember/component';
 export default Component.extend({});
 ```
 
+```javascript
+// With option: additionalInvalidImports = ['my-custom-addon']
+import CustomClass from 'my-custom-addon';
+
+export default CustomClass.extend({});
+```
+
 Examples of **correct** code for this rule:
 
 ```javascript
@@ -42,7 +49,7 @@ export default class MyComponent extends Component.extend(Evented) {}
 
 This rule takes an optional object containing:
 
-- `array` -- `additionalInvalidImports` -- Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`.
+- `string[]` -- `additionalClassImports` -- Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`.
 
 ## When Not To Use It
 

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -48,8 +48,13 @@ module.exports = {
       {
         type: 'object',
         properties: {
-          additionalInvalidImports: {
+          additionalClassImports: {
             type: 'array',
+            uniqueItems: true,
+            minItems: 1,
+            items: {
+              type: 'string',
+            },
           },
         },
         additionalProperties: false,
@@ -59,7 +64,7 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {};
-    const additionalInvalidImports = options.additionalInvalidImports || [];
+    const additionalClassImports = options.additionalClassImports || [];
 
     function reportNode(node) {
       context.report(node, ERROR_MESSAGE_NO_CLASSIC_CLASSES);
@@ -76,7 +81,7 @@ module.exports = {
           const classImportedFrom = getSourceModuleNameForIdentifier(context, node.object);
           if (
             isEmberImport(classImportedFrom) ||
-            additionalInvalidImports.includes(classImportedFrom)
+            additionalClassImports.includes(classImportedFrom)
           ) {
             reportNode(callExpression);
           }

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -44,10 +44,23 @@ module.exports = {
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-classic-classes.md',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          additionalInvalidImports: {
+            type: 'array',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {
+    const options = context.options[0] || {};
+    const additionalInvalidImports = options.additionalInvalidImports || [];
+
     function reportNode(node) {
       context.report(node, ERROR_MESSAGE_NO_CLASSIC_CLASSES);
     }
@@ -61,7 +74,10 @@ module.exports = {
         // Still allows `.extend` if some other identifier is passed, like a Mixin
         if (hasNoArguments(callExpression) || hasObjectArgument(callExpression)) {
           const classImportedFrom = getSourceModuleNameForIdentifier(context, node.object);
-          if (isEmberImport(classImportedFrom)) {
+          if (
+            isEmberImport(classImportedFrom) ||
+            additionalInvalidImports.includes(classImportedFrom)
+          ) {
             reportNode(callExpression);
           }
         }

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -117,20 +117,5 @@ ruleTester.run('no-classic-classes', rule, {
       output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
-    {
-      code: `
-        import CustomClass from 'my-custom-addon';
-        const CustomSub = CustomClass.extend({});
-
-        export default CustomSub;
-      `,
-      options: [
-        {
-          additionalClassImports: ['my-custom-addon'],
-        },
-      ],
-      output: null,
-      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
-    },
   ],
 });

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -104,5 +104,33 @@ ruleTester.run('no-classic-classes', rule, {
       output: null,
       errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
     },
+    {
+      code: `
+        import CustomClass from 'my-custom-addon';
+        export default CustomClass.extend({});
+      `,
+      options: [
+        {
+          additionalInvalidImports: ['my-custom-addon'],
+        },
+      ],
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import CustomClass from 'my-custom-addon';
+        const CustomSub = CustomClass.extend({});
+
+        export default CustomSub;
+      `,
+      options: [
+        {
+          additionalInvalidImports: ['my-custom-addon'],
+        },
+      ],
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'CallExpression' }],
+    },
   ],
 });

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -111,7 +111,7 @@ ruleTester.run('no-classic-classes', rule, {
       `,
       options: [
         {
-          additionalInvalidImports: ['my-custom-addon'],
+          additionalClassImports: ['my-custom-addon'],
         },
       ],
       output: null,
@@ -126,7 +126,7 @@ ruleTester.run('no-classic-classes', rule, {
       `,
       options: [
         {
-          additionalInvalidImports: ['my-custom-addon'],
+          additionalClassImports: ['my-custom-addon'],
         },
       ],
       output: null,


### PR DESCRIPTION
In some cases it's necessary to allow users to specify any additional import paths that would trigger a violation of the `no-classic-classes` rule. This allows for the identification of custom, internal paths that should be flagged when a class is being extended using `extend`.