### PR TITLE
Fix crash with dynamic/variable route name in `no-shadow-route-definition` rule (again)

### DIFF
--- a/lib/rules/no-shadow-route-definition.js
+++ b/lib/rules/no-shadow-route-definition.js
@@ -103,8 +103,16 @@ function getRouteInfo(node) {
     return null;
   }
 
-  const routeName = getRouteName(node).stringValue;
   const parentRoutes = getParentRoutesPaths(node);
+  const notSupportedParentRoutePathArguments = parentRoutes.find((routePathInfo) => {
+    return routePathInfo.stringValue === null;
+  });
+
+  if (notSupportedParentRoutePathArguments) {
+    return null;
+  }
+
+  const routeName = getRouteName(node).stringValue;
 
   // We replace "////post/something" -> "/post/something".
   // As that what nesting of / configured routes means for Ember router.

--- a/lib/rules/no-shadow-route-definition.js
+++ b/lib/rules/no-shadow-route-definition.js
@@ -12,6 +12,12 @@ function buildErrorMessage(opts) {
   )}`;
 }
 
+function buildUnsupportedArgumentsErrorMessage(routeInfo) {
+  return `Unsupported arguments at ${buildSourceLocationString(
+    routeInfo
+  )}, please open issue on Github eslint-plugin-ember repository.`;
+}
+
 function buildSourceLocationString(routeInfo) {
   return `${routeInfo.source.loc.start.line}L:${routeInfo.source.loc.start.column}C`;
 }
@@ -43,6 +49,7 @@ module.exports = {
   },
 
   buildErrorMessage,
+  buildUnsupportedArgumentsErrorMessage,
 
   create(context) {
     if (ember.isTestFile(context.getFilename())) {
@@ -58,12 +65,15 @@ module.exports = {
           return;
         }
 
-        if (node.arguments.length > 0 && node.arguments[0].type !== 'Literal') {
-          // Ignore dynamic/variable route names.
+        const routeInfo = getRouteInfo(node);
+        if (routeInfo.route.basePath === null) {
+          context.report({
+            node,
+            message: buildUnsupportedArgumentsErrorMessage(routeInfo.route),
+          });
           return;
         }
 
-        const routeInfo = getRouteInfo(node);
         if (
           routeMap.has(routeInfo.route.fullPathWithGenericParams) &&
           !isNestedRouteWithSamePath(routeInfo)
@@ -95,7 +105,7 @@ module.exports = {
 };
 
 function getRouteInfo(node) {
-  const routeName = node.arguments[0].value;
+  const routeName = getFirstArgumentValue(node);
   const basePath = getRouteBasePath(node);
   const parentRoutes = getParentRoutesPaths(node);
 
@@ -122,16 +132,14 @@ function getRouteInfo(node) {
 }
 
 function getRouteBasePath(node) {
-  let routePath = node.arguments[0].value;
-
+  let routePath = getFirstArgumentValue(node);
   if (hasPathProperty(node)) {
     const pathOptionNode = getPropertyByKeyName(node.arguments[1], 'path');
-    const pathValue = pathOptionNode.value.value;
-    if (pathValue) {
-      routePath = pathValue;
-    }
+    const pathValue = getNodeValue(pathOptionNode.value);
+    routePath = pathValue;
   }
-  if (!routePath.startsWith('/')) {
+
+  if (isString(routePath) && !routePath.startsWith('/')) {
     routePath = `/${routePath}`;
   }
   return routePath;
@@ -186,4 +194,25 @@ function convertPathToGenericForMatching(sourcePath) {
       return mappedValue;
     })
     .join('/');
+}
+
+function getFirstArgumentValue(node) {
+  const [firstArgument] = node.arguments;
+  return getNodeValue(firstArgument);
+}
+
+function getNodeValue(node) {
+  const isIdentifier = node.type === 'Identifier';
+  const isLiteral = node.type === 'Literal';
+  if (isIdentifier) {
+    return node.name;
+  }
+  if (isLiteral && isString(node.value)) {
+    return node.value;
+  }
+  return null;
+}
+
+function isString(value) {
+  return typeof value === 'string';
 }

--- a/lib/rules/no-shadow-route-definition.js
+++ b/lib/rules/no-shadow-route-definition.js
@@ -4,18 +4,16 @@ const ember = require('../utils/ember');
 const types = require('../utils/types');
 
 const ROOT_PATH_TRIM_REGEX = /\/{2,}/g;
+const SOURCE_PATH_VALUE_TYPE = {
+  DYNAMIC: 'dynamic',
+  STATIC: 'static',
+};
 
 function buildErrorMessage(opts) {
   const { leftRoute, rightRoute } = opts;
   return `Route ${buildRouteErrorInfo(leftRoute)} is shadowing route ${buildRouteErrorInfo(
     rightRoute
   )}`;
-}
-
-function buildUnsupportedArgumentsErrorMessage(routeInfo) {
-  return `Unsupported arguments at ${buildSourceLocationString(
-    routeInfo
-  )}, please open issue on Github eslint-plugin-ember repository.`;
 }
 
 function buildSourceLocationString(routeInfo) {
@@ -49,7 +47,6 @@ module.exports = {
   },
 
   buildErrorMessage,
-  buildUnsupportedArgumentsErrorMessage,
 
   create(context) {
     if (ember.isTestFile(context.getFilename())) {
@@ -66,11 +63,7 @@ module.exports = {
         }
 
         const routeInfo = getRouteInfo(node);
-        if (routeInfo.route.basePath === null) {
-          context.report({
-            node,
-            message: buildUnsupportedArgumentsErrorMessage(routeInfo.route),
-          });
+        if (!isValidRouteInfo(routeInfo)) {
           return;
         }
 
@@ -105,44 +98,48 @@ module.exports = {
 };
 
 function getRouteInfo(node) {
-  const routeName = getFirstArgumentValue(node);
   const basePath = getRouteBasePath(node);
+  if (basePath.stringValue === null) {
+    return null;
+  }
+
+  const routeName = getRouteName(node).stringValue;
   const parentRoutes = getParentRoutesPaths(node);
 
   // We replace "////post/something" -> "/post/something".
   // As that what nesting of / configured routes means for Ember router.
-  const parentRoutesFullPath = trimRootLevelNestedRoutes(parentRoutes.join(''));
-  const fullPath = trimRootLevelNestedRoutes(`${parentRoutesFullPath}${basePath}`);
-
   return {
     route: {
       name: routeName,
       basePath,
-      fullPath,
-      fullPathWithGenericParams: convertPathToGenericForMatching(fullPath),
+      fullPath: trimRootLevelNestedRoutes(`${convertPathForDisplay([...parentRoutes, basePath])}`),
+      fullPathWithGenericParams: trimRootLevelNestedRoutes(
+        convertPathToGenericForMatching([...parentRoutes, basePath])
+      ),
       source: {
         loc: node.loc,
       },
     },
     parent: {
-      fullPath: parentRoutesFullPath,
-      fullPathWithGenericParams: convertPathToGenericForMatching(parentRoutesFullPath),
+      fullPath: trimRootLevelNestedRoutes(convertPathForDisplay(parentRoutes)),
+      fullPathWithGenericParams: trimRootLevelNestedRoutes(
+        convertPathToGenericForMatching(parentRoutes)
+      ),
     },
   };
 }
 
 function getRouteBasePath(node) {
-  let routePath = getFirstArgumentValue(node);
+  let routePathInfo = getRouteName(node);
   if (hasPathProperty(node)) {
     const pathOptionNode = getPropertyByKeyName(node.arguments[1], 'path');
-    const pathValue = getNodeValue(pathOptionNode.value);
-    routePath = pathValue;
+    routePathInfo = getNodeValue(pathOptionNode.value);
   }
 
-  if (isString(routePath) && !routePath.startsWith('/')) {
-    routePath = `/${routePath}`;
+  if (isString(routePathInfo.stringValue) && !routePathInfo.stringValue.startsWith('/')) {
+    routePathInfo.stringValue = `/${routePathInfo.stringValue}`;
   }
-  return routePath;
+  return routePathInfo;
 }
 
 function getParentRoutesPaths(node) {
@@ -180,39 +177,62 @@ function trimRootLevelNestedRoutes(routesPath) {
   return routesPath.replace(ROOT_PATH_TRIM_REGEX, '/');
 }
 
-function convertPathToGenericForMatching(sourcePath) {
-  return sourcePath
-    .split('/')
-    .map((chunk) => {
-      const mappedValue = chunk.trim();
-      if (mappedValue.startsWith(':')) {
-        return ':generic-param-for-matching';
+function convertPathToGenericForMatching(routePathInfos) {
+  return routePathInfos
+    .map((routePathInfo) => {
+      const mappedValue = routePathInfo.stringValue.trim();
+      if (routePathInfo.type === SOURCE_PATH_VALUE_TYPE.STATIC) {
+        if (mappedValue.startsWith('/:')) {
+          return '/:generic-param-for-matching';
+        }
+        if (mappedValue.startsWith('/*')) {
+          return '/*generic-wildcard-for-matching';
+        }
       }
-      if (mappedValue.startsWith('*')) {
-        return '*generic-wildcard-for-matching';
+      if (routePathInfo.type === SOURCE_PATH_VALUE_TYPE.DYNAMIC) {
+        return `/variable:${mappedValue}`;
       }
       return mappedValue;
     })
-    .join('/');
+    .join('');
 }
 
-function getFirstArgumentValue(node) {
+function convertPathForDisplay(routePathInfos) {
+  return routePathInfos
+    .map((routePathInfo) => {
+      return routePathInfo.stringValue.trim();
+    })
+    .join('');
+}
+
+function getRouteName(node) {
   const [firstArgument] = node.arguments;
   return getNodeValue(firstArgument);
 }
 
 function getNodeValue(node) {
-  const isIdentifier = node.type === 'Identifier';
-  const isLiteral = node.type === 'Literal';
-  if (isIdentifier) {
-    return node.name;
+  if (types.isIdentifier(node)) {
+    return {
+      type: SOURCE_PATH_VALUE_TYPE.DYNAMIC,
+      stringValue: node.name,
+    };
   }
-  if (isLiteral && isString(node.value)) {
-    return node.value;
+  if (types.isLiteral(node)) {
+    return {
+      type: SOURCE_PATH_VALUE_TYPE.STATIC,
+      stringValue: String(node.value),
+    };
   }
-  return null;
+  return {
+    type: null,
+    stringValue: null,
+  };
 }
 
 function isString(value) {
   return typeof value === 'string';
+}
+
+function isValidRouteInfo(routeInfo) {
+  return routeInfo !== null;
 }

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -5,7 +5,7 @@
 const rule = require('../../../lib/rules/no-shadow-route-definition');
 const RuleTester = require('eslint').RuleTester;
 
-const { buildErrorMessage } = rule;
+const { buildErrorMessage, buildUnsupportedArgumentsErrorMessage } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -101,6 +101,10 @@ ruleTester.run('no-shadow-route-definition', rule, {
     // With dynamic/variable route or path name:
     'this.route(someVariable);',
     "this.route('views', { path: someVariable })",
+    `this.route(someVariable, function () {
+      this.route('route');
+    });
+    `,
 
     // Not Ember's route function:
     'test();',
@@ -705,6 +709,160 @@ ruleTester.run('no-shadow-route-definition', rule, {
                     line: 3,
                     column: 10,
                   },
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        this.route(someVariable, function() {
+          this.route("first", { path: "/" });
+          this.route("second", { path: "/" });
+        });
+      `,
+      output: null,
+      errors: [
+        {
+          message: buildErrorMessage({
+            leftRoute: {
+              name: 'second',
+              fullPath: '/someVariable/',
+              source: {
+                loc: {
+                  start: {
+                    line: 4,
+                    column: 10,
+                  },
+                },
+              },
+            },
+            rightRoute: {
+              name: 'first',
+              fullPath: '/someVariable/',
+              source: {
+                loc: {
+                  start: {
+                    line: 3,
+                    column: 10,
+                  },
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        this.route(someVariable);
+        this.route(someVariable);
+      `,
+      output: null,
+      errors: [
+        {
+          message: buildErrorMessage({
+            leftRoute: {
+              name: 'someVariable',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 3,
+                    column: 8,
+                  },
+                },
+              },
+            },
+            rightRoute: {
+              name: 'someVariable',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 8,
+                  },
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: `
+        this.route('first', { path: someVariable });
+        this.route('second', { path: someVariable });
+      `,
+      output: null,
+      errors: [
+        {
+          message: buildErrorMessage({
+            leftRoute: {
+              name: 'second',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 3,
+                    column: 8,
+                  },
+                },
+              },
+            },
+            rightRoute: {
+              name: 'first',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 8,
+                  },
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'this.route(true);',
+      output: null,
+      errors: [
+        {
+          message: buildUnsupportedArgumentsErrorMessage({
+            source: {
+              loc: {
+                start: {
+                  line: 1,
+                  column: 0,
+                },
+              },
+            },
+          }),
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'this.route("first", { path: true });',
+      output: null,
+      errors: [
+        {
+          message: buildUnsupportedArgumentsErrorMessage({
+            source: {
+              loc: {
+                start: {
+                  line: 1,
+                  column: 0,
                 },
               },
             },

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -5,7 +5,7 @@
 const rule = require('../../../lib/rules/no-shadow-route-definition');
 const RuleTester = require('eslint').RuleTester;
 
-const { buildErrorMessage, buildUnsupportedArgumentsErrorMessage } = rule;
+const { buildErrorMessage } = rule;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -105,6 +105,16 @@ ruleTester.run('no-shadow-route-definition', rule, {
       this.route('route');
     });
     `,
+    `this.route('first', { path: foo });
+    this.route('second', { path: 'foo' });
+    `,
+    `this.route(foo);
+    this.route('foo');
+    `,
+    'this.route(null)',
+    'this.route(true)',
+    // Test not crashing on unexpected values
+    'this.route({})',
 
     // Not Ember's route function:
     'test();',
@@ -834,35 +844,35 @@ ruleTester.run('no-shadow-route-definition', rule, {
       ],
     },
     {
-      code: 'this.route(true);',
+      code: `
+        this.route(null, { path: someVariable });
+        this.route(null, { path: someVariable });
+      `,
       output: null,
       errors: [
         {
-          message: buildUnsupportedArgumentsErrorMessage({
-            source: {
-              loc: {
-                start: {
-                  line: 1,
-                  column: 0,
+          message: buildErrorMessage({
+            leftRoute: {
+              name: 'null',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 3,
+                    column: 8,
+                  },
                 },
               },
             },
-          }),
-          type: 'CallExpression',
-        },
-      ],
-    },
-    {
-      code: 'this.route("first", { path: true });',
-      output: null,
-      errors: [
-        {
-          message: buildUnsupportedArgumentsErrorMessage({
-            source: {
-              loc: {
-                start: {
-                  line: 1,
-                  column: 0,
+            rightRoute: {
+              name: 'null',
+              fullPath: '/someVariable',
+              source: {
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 8,
+                  },
                 },
               },
             },

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -113,8 +113,10 @@ ruleTester.run('no-shadow-route-definition', rule, {
     `,
     'this.route(null)',
     'this.route(true)',
-    // Test not crashing on unexpected values
+    // Test not crashing on unexpected values, we bail out
     'this.route({})',
+    'this.route(getRouteName());',
+    'this.route("my-route", { path: getRoutePath() });',
 
     // Not Ember's route function:
     'test();',

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -115,8 +115,12 @@ ruleTester.run('no-shadow-route-definition', rule, {
     'this.route(true)',
     // Test not crashing on unexpected values, we bail out
     'this.route({})',
-    'this.route(getRouteName());',
-    'this.route("my-route", { path: getRoutePath() });',
+    `this.route(getRouteName(), function () {
+      this.route('route');
+    });`,
+    `this.route("my-route", { path: getRoutePath() }, function () {
+      this.route('route');
+    });`,
 
     // Not Ember's route function:
     'test();',


### PR DESCRIPTION
Update no-shadow-route-definition rule to work with dynamic route names and paths. This is naive implementation in a sense that we don't validate what is real value of `someVariable` that is used to define route or path. It only relies on the variable name itself and assumes value of `someVariable` might be conflicting.

Closes #1107 

cc @bmish 