### PR TITLE
Detect classic classes which have object variables passed to them in `no-classic-classes` rule

### DIFF
--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -3,6 +3,7 @@
 const { getSourceModuleNameForIdentifier } = require('../utils/import');
 const { startsWithThisExpression } = require('../utils/utils');
 const { isObjectExpression } = require('../utils/types');
+const { findVariable } = require('eslint-utils');
 
 const ERROR_MESSAGE_NO_CLASSIC_CLASSES =
   'Native JS classes should be used instead of classic classes';
@@ -11,8 +12,30 @@ function hasNoArguments(node) {
   return node.arguments.length === 0;
 }
 
-function hasObjectArgument(node) {
-  return node.arguments.some(isObjectExpression);
+function hasObjectArgument(node, scopeManager) {
+  return node.arguments.some((arg) => {
+    if (isObjectExpression(arg)) {
+      return true;
+    }
+
+    if (arg.type === 'Identifier') {
+      // Check if a variable is provided that was initialized as an object.
+      const variable = findVariable(scopeManager.acquire(arg) || scopeManager.globalScope, arg);
+      if (
+        variable &&
+        variable.defs &&
+        variable.defs[0] &&
+        variable.defs[0].node &&
+        variable.defs[0].node.type === 'VariableDeclarator' &&
+        variable.defs[0].node.init &&
+        variable.defs[0].node.init.type === 'ObjectExpression'
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  });
 }
 
 function isEmberImport(classImportedFrom) {
@@ -64,6 +87,8 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
     const options = context.options[0] || {};
     const additionalClassImports = options.additionalClassImports || [];
 
@@ -79,7 +104,7 @@ module.exports = {
         // Invalid with an object as an argument because that logic needs conversion to a native class
         // Still allows `.extend` if some other identifier is passed, like a Mixin
         if (
-          (hasNoArguments(callExpression) || hasObjectArgument(callExpression)) &&
+          (hasNoArguments(callExpression) || hasObjectArgument(callExpression, scopeManager)) &&
           ['Identifier', 'MemberExpression'].includes(node.object.type) &&
           !startsWithThisExpression(node)
         ) {

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -26,13 +26,19 @@ ruleTester.run('no-classic-classes', rule, {
     `,
     `
       import Component from '@ember/component';
+      import Evented from '@ember/object/Evented'; // This is a mixin.
 
-      export default class MyRoute extends Route.extend(SomeMixin) {}
+      export default class MyComponent extends Component.extend(Evented) {} // Allowed to extend from mixins only.
     `,
     `
       import SomeOtherThing from 'some-other-library';
 
       export default SomeOtherThing.extend({});
+    `,
+    `
+      import Component from '@ember/component';
+      const notAnObject = 123;
+      export default Component.extend(notAnObject); // Unexpected variable type passed.
     `,
     'export default Component.extend({});', // No import
 
@@ -61,8 +67,17 @@ ruleTester.run('no-classic-classes', rule, {
     {
       code: `
         import Component from '@ember/component';
-        import Evented from '@ember/object/Evented';
+        import Evented from '@ember/object/Evented'; // This is a mixin.
         export default Component.extend(Evented, {});
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Component from '@ember/component';
+        const myMockComponent = {};
+        export default Component.extend(myMockComponent); // Object variable provided.
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],
@@ -86,8 +101,8 @@ ruleTester.run('no-classic-classes', rule, {
     {
       code: `
         import Component from '@ember/component';
-        import Evented from '@ember/object/evented';
-        export default class MyComponent extends Component.extend(Evented, {}) {};
+        import Evented from '@ember/object/evented'; // This is a mixin.
+        export default class MyComponent extends Component.extend(Evented, {}) {}; // Disallowed because an object is extended from.
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'CallExpression' }],


### PR DESCRIPTION
Fixes #1126.