### PR TITLE
`no-get` rule should ignore proxy classes that look like `ObjectProxy.extend(SomeMixin)`

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -207,13 +207,26 @@ function isEmberCoreModule(context, node, moduleName) {
     return isClassicEmberCoreModule(node, moduleName, context.getFilename());
   } else if (types.isClassDeclaration(node)) {
     // native classes
-    if (!node.superClass || !types.isIdentifier(node.superClass)) {
+    if (
+      // class Foo extends Component
+      !node.superClass ||
+      // class Foo extends Component.extend(SomeMixin)
+      !(
+        types.isIdentifier(node.superClass) ||
+        (types.isCallExpression(node.superClass) &&
+          types.isMemberExpression(node.superClass.callee) &&
+          types.isIdentifier(node.superClass.callee.property) &&
+          node.superClass.callee.property.name === 'extend')
+      )
+    ) {
       return false;
     }
-    const superClassImportPath = importUtils.getSourceModuleNameForIdentifier(
-      context,
-      node.superClass
-    );
+
+    const superClass = types.isIdentifier(node.superClass)
+      ? node.superClass
+      : node.superClass.callee.object;
+
+    const superClassImportPath = importUtils.getSourceModuleNameForIdentifier(context, superClass);
 
     if (superClassImportPath === CORE_MODULE_IMPORT_PATHS[moduleName]) {
       return true;

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -162,6 +162,15 @@ ruleTester.run('no-get', rule, {
       }
     }
     `,
+    `
+    import ArrayProxy from '@ember/array/proxy';
+    class MyProxy extends ArrayProxy.extend(SomeMixin) {
+      someFunction() {
+        test();
+        console.log(this.get('propertyInsideProxyObject'));
+      }
+    }
+    `,
 
     // Ignores `get()` inside classes with `unknownProperty`:
     `

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -204,6 +204,15 @@ describe('isEmberCoreModule', () => {
     expect(emberUtils.isEmberCoreModule(context, node, 'Route')).toBeTruthy();
   });
 
+  it('should handle native class with mixin', () => {
+    const context = new FauxContext(
+      "import Route from '@ember/routing/route'; class MyRoute extends Route.extend(SomeMixin) {}",
+      'example-app/routes/path/to/some-route.js'
+    );
+    const node = context.ast.body[1];
+    expect(emberUtils.isEmberCoreModule(context, node, 'Route')).toBeTruthy();
+  });
+
   it('should check if current file is a route with native class', () => {
     const context = new FauxContext(
       "import Route from '@ember/routing/route'; class MyRoute extends Route {}",
@@ -735,6 +744,24 @@ describe('isEmberProxy', () => {
       class MyProxy extends ObjectProxy {}
     `);
     const node = context.ast.body[1];
+    expect(emberUtils.isEmberProxy(context, node)).toBeTruthy();
+  });
+
+  it('should detect ObjectProxy with mixin', () => {
+    const context = new FauxContext(`
+      import ObjectProxy from '@ember/object/proxy';
+      class MyProxy extends ObjectProxy.extend(SomeMixin) {}
+    `);
+    const node = context.ast.body[1];
+    expect(emberUtils.isEmberProxy(context, node)).toBeTruthy();
+  });
+
+  it('should detect ObjectProxy with classic class', () => {
+    const context = new FauxContext(`
+      import ObjectProxy from '@ember/object/proxy';
+      ObjectProxy.extend({});
+    `);
+    const node = context.ast.body[1].expression;
     expect(emberUtils.isEmberProxy(context, node)).toBeTruthy();
   });
 


### PR DESCRIPTION
Fixes #1141.

@rogeraraujo90