### PR TITLE
docs: switch javascript code fences in doc code samples to js

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save-dev eslint-plugin-ember
 
 ### 2. Modify your `.eslintrc.js`
 
-```javascript
+```js
 // .eslintrc.js
 module.exports = {
   plugins: ['ember'],

--- a/docs/rules/alias-model-in-controller.md
+++ b/docs/rules/alias-model-in-controller.md
@@ -8,7 +8,7 @@ We can do this in two ways:
 
 - Alias the model to another property name in the Controller:
 
-  ```javascript
+  ```js
   import Controller from '@ember/controller';
   import { alias } from '@ember/object/computed';
 
@@ -19,7 +19,7 @@ We can do this in two ways:
 
 - Set it as a property in the Route's `setupController` method:
 
-  ```javascript
+  ```js
   import Route from '@ember/routing/route';
 
   export default Route.extend({
@@ -31,7 +31,7 @@ We can do this in two ways:
 
 If you're passing [multiple models](https://guides.emberjs.com/v2.13.0/routing/specifying-a-routes-model/#toc_multiple-models) as an [`RSVP.hash`](https://emberjs.com/api/classes/RSVP.html#method_hash), you can also alias nested properties:
 
-```javascript
+```js
 import Controller from '@ember/controller';
 import { reads } from '@ember/object/computed';
 

--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -8,7 +8,7 @@ Don't use arrays and objects as default properties in classic classes or mixins.
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default Foo.extend({
   items: [],
 
@@ -20,7 +20,7 @@ export default Foo.extend({
 });
 ```
 
-```javascript
+```js
 import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
@@ -30,7 +30,7 @@ export default Mixin.create({
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 export default Foo.extend({
   init(...args) {
     this._super(...args);
@@ -46,7 +46,7 @@ export default Foo.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 

--- a/docs/rules/avoid-using-needs-in-controllers.md
+++ b/docs/rules/avoid-using-needs-in-controllers.md
@@ -8,7 +8,7 @@ Avoid using `needs` to load other controllers. Inject the required controller in
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default Controller.extend({
   needs: ['comments'],
   newComments: alias('controllers.comments.newest')
@@ -17,7 +17,7 @@ export default Controller.extend({
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Controller, { inject as controller } from '@ember/controller';
 
 export default Component.extend({

--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -10,7 +10,7 @@ Additionally, non-classic classes may not use `destroy`.
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default class MyService extends Service {
   init() {
     // ...
@@ -22,7 +22,7 @@ export default class MyService extends Service {
 }
 ```
 
-```javascript
+```js
 @classic
 export default class MyService extends Service {
   constructor() {
@@ -34,7 +34,7 @@ export default class MyService extends Service {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 @classic
 export default class MyService extends Service {
   init() {
@@ -47,7 +47,7 @@ export default class MyService extends Service {
 }
 ```
 
-```javascript
+```js
 export default class MyService extends Service {
   constructor() {
     super();

--- a/docs/rules/classic-decorator-no-classic-methods.md
+++ b/docs/rules/classic-decorator-no-classic-methods.md
@@ -26,7 +26,7 @@ Non-method versions of them can still be used, e.g. `@ember/object#get` and
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default class MyService extends Service {
   constructor(...args) {
     super(...args);
@@ -37,7 +37,7 @@ export default class MyService extends Service {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 @classic
 export default class MyService extends Service {
   constructor(...args) {
@@ -47,7 +47,7 @@ export default class MyService extends Service {
 }
 ```
 
-```javascript
+```js
 import { set } from '@ember/object';
 
 export default class MyService extends Service {
@@ -58,7 +58,7 @@ export default class MyService extends Service {
 }
 ```
 
-```javascript
+```js
 import { tracked } from '@glimmer/tracking';
 
 export default class MyService extends Service {

--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -6,7 +6,7 @@ Always use closure actions (according to DDAU convention). Exception: only when 
 
 ## Examples
 
-```javascript
+```js
 export default Controller.extend({
   actions: {
     detonate() {
@@ -22,7 +22,7 @@ Examples of **incorrect** code for this rule:
 {{awful-component detonate='detonate'}}
 ```
 
-```javascript
+```js
 // awful-component.js
 export default Component.extend({
   actions: {
@@ -39,7 +39,7 @@ Examples of **correct** code for this rule:
 {{pretty-component boom=(action 'detonate')}}
 ```
 
-```javascript
+```js
 // pretty-component.js
 export default Component.extend({
   actions: {

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -19,7 +19,7 @@ String option:
 
 ### always-with-setter
 
-```javascript
+```js
 import EmberObject, { computed } from '@ember/object';
 
 // BAD
@@ -53,7 +53,7 @@ EmberObject.extend({
 
 ### always
 
-```javascript
+```js
 import EmberObject, { computed } from '@ember/object';
 
 // GOOD
@@ -75,7 +75,7 @@ EmberObject.extend({
 
 ### never
 
-```javascript
+```js
 import EmberObject, { computed } from '@ember/object';
 
 // GOOD

--- a/docs/rules/jquery-ember-run.md
+++ b/docs/rules/jquery-ember-run.md
@@ -20,7 +20,7 @@ $('#something-rendered-by-jquery-plugin').on('click', () => {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import $ from 'jquery';
 import { bind } from '@ember/runloop';
 

--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -6,7 +6,7 @@ When you use promises and its handlers, use named functions defined on parent ob
 
 ## Examples
 
-```javascript
+```js
 export default Component.extend({
   actions: {
     // BAD
@@ -54,7 +54,7 @@ export default Component.extend({
 
 And then you can make simple unit tests for handlers:
 
-```javascript
+```js
 test('it reloads user in promise handler', function (assert) {
   const component = this.subject();
   // assuming that you have `user` defined with kind of sinon spy on its reload method

--- a/docs/rules/new-module-imports.md
+++ b/docs/rules/new-module-imports.md
@@ -26,7 +26,7 @@ Ember.inject.service('foo');
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
 import Service, { inject } from '@ember/service';

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -14,14 +14,14 @@ This rule aims to ensure that you do not use a "classic" Ember class where a nat
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 // Extending an Ember class using the "classic" class pattern is not OK
 import Component from '@ember/component';
 
 export default Component.extend({});
 ```
 
-```javascript
+```js
 // With option: additionalClassImports = ['my-custom-addon']
 import CustomClass from 'my-custom-addon';
 
@@ -30,14 +30,14 @@ export default CustomClass.extend({});
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 // Extending using a native JS class is OK
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {}
 ```
 
-```javascript
+```js
 // Including a Mixin is OK
 import Component from '@ember/component';
 import Evented from '@ember/object/evented';

--- a/docs/rules/no-ember-super-in-es-classes.md
+++ b/docs/rules/no-ember-super-in-es-classes.md
@@ -12,7 +12,7 @@ While `this._super()` is the only way to invoke an overridden method in an `Embe
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
@@ -25,7 +25,7 @@ export default class MyComponent extends Component {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
@@ -36,7 +36,7 @@ export default class MyComponent extends Component {
 }
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/docs/rules/no-ember-testing-in-module-scope.md
+++ b/docs/rules/no-ember-testing-in-module-scope.md
@@ -49,7 +49,7 @@ const { testing } = Ember;
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Ember from 'ember';
 import Component from '@ember/component';
 

--- a/docs/rules/no-empty-attrs.md
+++ b/docs/rules/no-empty-attrs.md
@@ -20,7 +20,7 @@ export default Model.extend({
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 const { Model, attr } = DS;
 
 export default Model.extend({

--- a/docs/rules/no-function-prototype-extensions.md
+++ b/docs/rules/no-function-prototype-extensions.md
@@ -10,7 +10,7 @@ Use computed property syntax, observer syntax or module hooks instead of `.prope
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default Component.extend({
   abc: function () {
     /* custom logic */

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -14,7 +14,7 @@ This rule disallows importing a mixin. This is different than [no-new-mixins](no
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 // my-octane-component.js
 import Component from '@ember/component';
 import FooMixin from '../utils/mixins/foo';
@@ -24,7 +24,7 @@ export default class FooComponent extends Component.extend(FooMixin) {
 }
 ```
 
-```javascript
+```js
 // my-component.js
 import myMixin from 'my-mixin';
 
@@ -37,7 +37,7 @@ export default Component.extend(myMixin, {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 // my-utils.js
 export function isValidClassName(classname) {
   return Boolean(className.match('-class'));
@@ -48,7 +48,7 @@ export function hideModal(obj, value) {
 }
 ```
 
-```javascript
+```js
 // my-component.js
 import { isValidClassName } from 'my-utils';
 

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -15,7 +15,7 @@ For more details and examples of how mixins create problems down-the-line, see t
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 // my-mixin.js
 export default Mixin.create({
   isValidClassName(classname) {
@@ -28,7 +28,7 @@ export default Mixin.create({
 });
 ```
 
-```javascript
+```js
 // my-component.js
 import myMixin from 'my-mixin';
 
@@ -41,7 +41,7 @@ export default Component.extend(myMixin, {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 // my-utils.js
 export function isValidClassName(classname) {
   return Boolean(className.match('-class'));
@@ -52,7 +52,7 @@ export function hideModal(obj, value) {
 }
 ```
 
-```javascript
+```js
 // my-component.js
 import { isValidClassName } from 'my-utils';
 

--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -79,7 +79,7 @@ class FooComponent extends Component {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 export default Controller.extend({
   actions: {
     change() {

--- a/docs/rules/no-old-shims.md
+++ b/docs/rules/no-old-shims.md
@@ -26,7 +26,7 @@ import inject from 'ember-service/inject';
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
 import Service, { inject } from '@ember/service';

--- a/docs/rules/no-on-calls-in-components.md
+++ b/docs/rules/no-on-calls-in-components.md
@@ -10,7 +10,7 @@ The order of execution for `on()` is not deterministic.
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 export default Component.extend({
   abc: on('didInsertElement', function () {
     /* custom logic */

--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -14,7 +14,7 @@ There has been a public `router` service since Ember 2.16 and using the private 
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
@@ -23,7 +23,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
@@ -31,7 +31,7 @@ export default class MyComponent extends Component {
 }
 ```
 
-```javascript
+```js
 // When `catchRouterMicrolib` option is enabled.
 
 import Component from '@ember/component';
@@ -45,7 +45,7 @@ export default class MyComponent extends Component {
 }
 ```
 
-```javascript
+```js
 // When `catchRouterMain` option is enabled.
 
 import Component from '@ember/component';
@@ -61,7 +61,7 @@ export default class MyComponent extends Component {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
@@ -70,7 +70,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -14,7 +14,7 @@ Note that other side effects like network requests should be avoided as well.
 
 ## Examples
 
-```javascript
+```js
 import Component from '@ember/component';
 import { alias, filterBy } from '@ember/object/computed';
 

--- a/docs/rules/no-test-import-export.md
+++ b/docs/rules/no-test-import-export.md
@@ -12,33 +12,33 @@ Due to how qunit unloads a test module, importing a test file will cause any mod
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 import setupModule from './some-other-test';
 import { module, test } from 'qunit';
 
 module('Acceptance | module', setupModule());
 ```
 
-```javascript
+```js
 import { beforeEachSetup, testMethod } from './some-other-test';
 import { module, test } from 'qunit';
 
 module('Acceptance | module', beforeEachSetup());
 ```
 
-```javascript
+```js
 import testModule from '../../test-dir/another-test';
 import { module, test } from 'qunit';
 
 module('Acceptance | module', testModule());
 ```
 
-```javascript
+```js
 // some-test.js
 export function beforeEachSetup() {}
 ```
 
-```javascript
+```js
 // some-test.js
 function beforeEachSetup() {}
 
@@ -47,33 +47,33 @@ export default { beforeEachSetup };
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import setupModule from './some-test-helper';
 import { module, test } from 'qunit';
 
 module('Acceptance | module', setupModule());
 ```
 
-```javascript
+```js
 // some-test-helper.js
 export function beforeEachSetup() {
   // ...
 }
 ```
 
-```javascript
+```js
 // some-test-helper.js
 function beforeEachSetup() {}
 
 export default { beforeEachSetup };
 ```
 
-```javascript
+```js
 // Any imports from `tests/helpers` are allowed.
 import { setupApplicationTest } from 'tests/helpers/setup-application-test';
 ```
 
-```javascript
+```js
 // Any exports from `tests/helpers` are allowed.
 // tests/helpers/setup-application-test.js
 export default function setupApplicationTest() {}

--- a/docs/rules/no-test-support-import.md
+++ b/docs/rules/no-test-support-import.md
@@ -12,7 +12,7 @@ Examples of **incorrect** code for this rule:
 
 > app/routes/index.js
 
-```javascript
+```js
 import doSomething from '../test-support/some-other-test';
 
 import Route from '@ember/routing/route';
@@ -30,7 +30,7 @@ Examples of **correct** code for this rule:
 
 > tests/unit/foo-test.js
 
-```javascript
+```js
 import setupModule from '../test-support/setup-module';
 import { module, test } from 'qunit';
 
@@ -39,7 +39,7 @@ module('Acceptance | module', setupModule());
 
 > addon-test-support/setupApplication.js
 
-```javascript
+```js
 import setupModule from '../test-support/setup-module';
 
 export default function setupApplicationTest(hooks) {

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -85,7 +85,7 @@ You should write code grouped and ordered in this way:
 
 ## Examples
 
-```javascript
+```js
 const {
   Component,
   computed,

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -63,7 +63,7 @@ You should write code grouped and ordered in this way:
 
 ## Examples
 
-```javascript
+```js
 const {
   Controller,
   computed,

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -53,7 +53,7 @@ You should write code grouped and ordered in this way:
 
 ## Examples
 
-```javascript
+```js
 // GOOD
 export default Model.extend({
   // 1. Attributes
@@ -70,7 +70,7 @@ export default Model.extend({
 });
 ```
 
-```javascript
+```js
 // BAD
 export default Model.extend({
   mood: computed('health', 'hunger', function () {

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -82,7 +82,7 @@ You should write code grouped and ordered in this way:
 
 ## Examples
 
-```javascript
+```js
 const {
   Route,
   inject: { service }

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -10,7 +10,7 @@ Note that this rule applies only to computed properties in classic classes (i.e.
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 /* eslint "consistent-return": "off" */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
@@ -42,7 +42,7 @@ export default Component.extend({
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -12,7 +12,7 @@ When overriding lifecycle hooks inside Ember Components, Controllers, Routes, Mi
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -22,7 +22,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -32,7 +32,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 class Foo extends Component {
@@ -44,7 +44,7 @@ class Foo extends Component {
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -55,7 +55,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -66,7 +66,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 class Foo extends Component {
@@ -77,7 +77,7 @@ class Foo extends Component {
 }
 ```
 
-```javascript
+```js
 import Component from '@ember/component';
 
 class Foo extends Component {

--- a/docs/rules/require-tagless-components.md
+++ b/docs/rules/require-tagless-components.md
@@ -14,14 +14,14 @@ Instead of having the wrapper element implicitly defined by the component, all D
 
 Examples of **incorrect** code for this rule:
 
-```javascript
+```js
 // "Classic"-class Ember components that have the default `tagName` of `div`
 import Component from '@ember/component';
 
 export default Component.extend({});
 ```
 
-```javascript
+```js
 // "Classic"-class Ember components that have a `tagName` configured to something besides `''`
 import Component from '@ember/component';
 
@@ -30,14 +30,14 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 // "Native"-class Ember components that have the default `tagName` of `div`
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {}
 ```
 
-```javascript
+```js
 // "Native"-class Ember components that have a `tagName` configured to something besides `''`
 import Component from '@ember/component';
 
@@ -46,7 +46,7 @@ export default class MyComponent extends Component {
 }
 ```
 
-```javascript
+```js
 // "Native"-class Ember components that use the `@tagName` decorator configured to something besides `''`
 import Component from '@ember/component';
 import { tagName } from '@ember-decorators/component';
@@ -57,7 +57,7 @@ export default class MyComponent extends Component {}
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 // "Class"-class Ember components that have a `tagName` configured to `''`
 import Component from '@ember/component';
 
@@ -66,7 +66,7 @@ export default Component.extend({
 });
 ```
 
-```javascript
+```js
 // "Native"-class Ember components that have a `tagName` configured to `''`
 import Component from '@ember/component';
 
@@ -75,7 +75,7 @@ export default class MyComponent extends Component {
 }
 ```
 
-```javascript
+```js
 // "Native"-class Ember components that use the `@tagName` decorator configured `''`
 import Component from '@ember/component';
 import { tagName } from '@ember-decorators/component';
@@ -84,7 +84,7 @@ import { tagName } from '@ember-decorators/component';
 export default class MyComponent extends Component {}
 ```
 
-```javascript
+```js
 // Glimmer components never have a `tagName` and are always valid
 import Component from '@glimmer/component';
 

--- a/docs/rules/routes-segments-snake-case.md
+++ b/docs/rules/routes-segments-snake-case.md
@@ -14,7 +14,7 @@ this.route('tree', { path: ':treeId' });
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 this.route('tree', { path: ':tree_id' });
 ```
 

--- a/docs/rules/use-brace-expansion.md
+++ b/docs/rules/use-brace-expansion.md
@@ -20,7 +20,7 @@ export default Component.extend({
 
 Examples of **correct** code for this rule:
 
-```javascript
+```js
 export default Component.extend({
   fullName: computed('user.{firstName,lastName}', {
     // Code

--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -15,7 +15,7 @@ Ideally, you should also be using [new-module-imports](./new-module-imports.md);
 
 ## Examples
 
-```javascript
+```js
 // Not recommended
 this.get('fooProperty');
 this.set('fooProperty', 'bar');
@@ -25,7 +25,7 @@ object.getProperties('foo', 'bar');
 object.setProperties({ foo: 'bar', baz: 'qux' });
 ```
 
-```javascript
+```js
 // Recommended
 import { get, set, getWithDefault, getProperties, setProperties } from '@ember/object';
 


### PR DESCRIPTION
eslint-plugin-markdown v2 has trouble with the `javascript` ones.

https://github.com/eslint/eslint-plugin-markdown/issues/176