### PR TITLE
Improve robustness of classic class controller body detection in `no-controllers` rule

### DIFF
--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -2,8 +2,7 @@
 
 const { getSourceModuleNameForIdentifier } = require('../utils/import');
 const { startsWithThisExpression } = require('../utils/utils');
-const { isObjectExpression } = require('../utils/types');
-const { findVariable } = require('eslint-utils');
+const { getNodeOrNodeFromVariable } = require('../utils/utils');
 
 const ERROR_MESSAGE_NO_CLASSIC_CLASSES =
   'Native JS classes should be used instead of classic classes';
@@ -14,27 +13,8 @@ function hasNoArguments(node) {
 
 function hasObjectArgument(node, scopeManager) {
   return node.arguments.some((arg) => {
-    if (isObjectExpression(arg)) {
-      return true;
-    }
-
-    if (arg.type === 'Identifier') {
-      // Check if a variable is provided that was initialized as an object.
-      const variable = findVariable(scopeManager.acquire(arg) || scopeManager.globalScope, arg);
-      if (
-        variable &&
-        variable.defs &&
-        variable.defs[0] &&
-        variable.defs[0].node &&
-        variable.defs[0].node.type === 'VariableDeclarator' &&
-        variable.defs[0].node.init &&
-        variable.defs[0].node.init.type === 'ObjectExpression'
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    const resultingNode = getNodeOrNodeFromVariable(arg, scopeManager);
+    return resultingNode && resultingNode.type === 'ObjectExpression';
   });
 }
 

--- a/lib/rules/no-controllers.js
+++ b/lib/rules/no-controllers.js
@@ -1,5 +1,6 @@
 const ember = require('../utils/ember');
 const types = require('../utils/types');
+const utils = require('../utils/utils');
 const assert = require('assert');
 
 const ERROR_MESSAGE = 'Avoid using controllers except for specifying `queryParams`';
@@ -20,6 +21,9 @@ module.exports = {
   },
 
   create: (context) => {
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       ClassDeclaration(node) {
         if (
@@ -33,7 +37,8 @@ module.exports = {
       CallExpression(node) {
         if (
           ember.isEmberController(context, node) &&
-          (node.arguments.length === 0 || !callExpressionClassHasProperty(node, 'queryParams'))
+          (node.arguments.length === 0 ||
+            !callExpressionClassHasProperty(node, 'queryParams', scopeManager))
         ) {
           context.report(node, ERROR_MESSAGE);
         }
@@ -55,13 +60,19 @@ function classDeclarationHasProperty(classDeclaration, propertyName) {
   );
 }
 
-function callExpressionClassHasProperty(callExpression, propertyName) {
+function callExpressionClassHasProperty(callExpression, propertyName, scopeManager) {
   assert(types.isCallExpression(callExpression));
   return (
     callExpression.arguments.length > 0 &&
-    types.isObjectExpression(callExpression.arguments[callExpression.arguments.length - 1]) &&
-    callExpression.arguments[callExpression.arguments.length - 1].properties.some(
-      (prop) => types.isIdentifier(prop.key) && prop.key.name === propertyName
-    )
+    callExpression.arguments.some((arg) => {
+      const resultingNode = utils.getNodeOrNodeFromVariable(arg, scopeManager);
+      return (
+        resultingNode &&
+        resultingNode.type === 'ObjectExpression' &&
+        resultingNode.properties.some(
+          (prop) => types.isIdentifier(prop.key) && prop.key.name === propertyName
+        )
+      );
+    })
   );
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -12,6 +12,7 @@ const {
   isOptionalMemberExpression,
   isThisExpression,
 } = require('../utils/types');
+const { findVariable } = require('eslint-utils');
 
 module.exports = {
   collectObjectPatternBindings,
@@ -19,6 +20,7 @@ module.exports = {
   findUnorderedProperty,
   getAncestor,
   getName,
+  getNodeOrNodeFromVariable,
   getPropertyValue,
   getSize,
   isEmptyMethod,
@@ -226,6 +228,39 @@ function getName(node) {
     return `${getName(node.object)}.${getName(node.property)}`;
   }
   return undefined;
+}
+
+/**
+ * Return the passed in node, or if the node is a variable, return the value of this variable.
+ *
+ * Example:
+ *   Calling the function on `{ foo: true }` will return the same node.
+ * Example:
+ *   const x = { foo: true };
+ *   Calling the function on `x` will return the ObjectExpression value.
+ *
+ * @param {Node} node
+ * @param {ScopeManager} scopeManager
+ * @returns {Node | null}
+ */
+function getNodeOrNodeFromVariable(node, scopeManager) {
+  if (node.type === 'Identifier') {
+    // Find the definition of this variable.
+    const variable = findVariable(scopeManager.acquire(node) || scopeManager.globalScope, node);
+    if (
+      variable &&
+      variable.defs &&
+      variable.defs[0] &&
+      variable.defs[0].node &&
+      variable.defs[0].node.type === 'VariableDeclarator' &&
+      variable.defs[0].node.init
+    ) {
+      return variable.defs[0].node.init;
+    }
+  }
+
+  // If the node isn't a variable or we can't find the initialized value of it, just return the node itself.
+  return node;
 }
 
 /**

--- a/tests/lib/rules/no-controllers.js
+++ b/tests/lib/rules/no-controllers.js
@@ -17,6 +17,7 @@ const ruleTester = new RuleTester({
 });
 ruleTester.run('no-controllers', rule, {
   valid: [
+    // Classic class with queryParams.
     `
       import Controller from '@ember/controller';
       export default Controller.extend({
@@ -27,6 +28,18 @@ ruleTester.run('no-controllers', rule, {
         queryParams: ['query', 'sortType', 'sortOrder']
       });
     `,
+    // Classic class with queryParams: checks object argument from variable.
+    `
+      import Controller from '@ember/controller';
+      const body = { queryParams: ['query'] };
+      export default Controller.extend(body);
+    `,
+    // Classic class with queryParams: checks any object argument.
+    `
+      import Controller from '@ember/controller';
+      export default Controller.extend({ queryParams: ['query'] }, {});
+    `,
+    // Native class with queryParams.
     `
       import Controller from '@ember/controller';
       export default class ArticlesController extends Controller {


### PR DESCRIPTION
Reduces false positives.

Ensures that controllers defining queryParams are ignored from the rule when:
* The body of the classic class controller is passed as a variable
* The body of the classic class controller is passed as not the last argument