### PR TITLE
Improve robustness of classic class component body detection in `require-tagless-components` rule

### DIFF
--- a/lib/rules/require-tagless-components.js
+++ b/lib/rules/require-tagless-components.js
@@ -8,6 +8,7 @@ const {
   isObjectExpression,
   isStringLiteral,
 } = require('../utils/types');
+const { getNodeOrNodeFromVariable } = require('../utils/utils');
 
 const ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS =
   "Please switch to a tagless component by setting `tagName: ''` or converting to a Glimmer component";
@@ -101,6 +102,9 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       // Handle classic components
       'CallExpression > MemberExpression[property.name="extend"]'(node) {
@@ -116,16 +120,18 @@ module.exports = {
         }
 
         for (const arg of callExpression.arguments) {
+          const resultingNode = getNodeOrNodeFromVariable(arg, scopeManager);
+
           // Ignore anything other than an object literal, since Mixins can be in here too
-          if (!isObjectExpression(arg)) {
+          if (!isObjectExpression(resultingNode)) {
             continue;
           }
 
           let tagNameNode;
 
-          if ((tagNameNode = getNonEmptyTagNameInObjectExpression(arg))) {
+          if ((tagNameNode = getNonEmptyTagNameInObjectExpression(resultingNode))) {
             context.report(tagNameNode, ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS);
-          } else if (hasNoTagNameInObjectExpression(arg)) {
+          } else if (hasNoTagNameInObjectExpression(resultingNode)) {
             context.report(callExpression, ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS);
           }
         }

--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -93,6 +93,25 @@ ruleTester.run('require-tagless-components', rule, {
       errors: [{ message: ERROR_MESSAGE, line: 4, type: 'Property' }],
     },
     {
+      // `tagName` but not the last object argument
+      code: `
+        import Component from '@ember/component';
+        export default Component.extend({ tagName: 'span' }, SomeMixin);
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'Property' }],
+    },
+    {
+      // `tagName` but inside a variable
+      code: `
+        import Component from '@ember/component';
+        const body = { tagName: 'span' };
+        export default Component.extend(body);
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, line: 3, type: 'Property' }],
+    },
+    {
       code: `
         import Component from '@ember/component';
         export default class MyComponent extends Component {}


### PR DESCRIPTION
Related to: #1158 #1149.