### PR TITLE
Account for observer dependent keys in `no-unused-services` rule

### DIFF
--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -52,6 +52,7 @@ module.exports = {
     let importedEmberName;
     let importedGetName;
     let importedGetPropertiesName;
+    let importedObserverName;
     const macros = getMacros();
     const importedMacros = {};
 
@@ -113,6 +114,8 @@ module.exports = {
           importedGetPropertiesName =
             importedGetPropertiesName ||
             getImportIdentifier(node, '@ember/object', 'getProperties');
+          importedObserverName =
+            importedObserverName || getImportIdentifier(node, '@ember/object', 'observer');
         } else if (node.source.value === '@ember/object/computed') {
           for (const spec of node.specifiers) {
             const name = spec.imported.name;
@@ -145,24 +148,39 @@ module.exports = {
               includeMacro: true,
             })
           ) {
-            if (node.callee.property) {
-              // Ember.computed.or(), computed.or()
-              const macroName = node.callee.property.name;
-              if (macros.includes(macroName)) {
-                for (
-                  let idx = 0;
-                  idx < MACROS_TO_TRACKED_ARGUMENT_COUNT[macroName] && idx < node.arguments.length;
-                  idx++
-                ) {
-                  const elem = node.arguments[idx];
+            // Ember.computed(), Ember.computed.or(), computed.or()
+            if (types.isMemberExpression(node.callee)) {
+              if (
+                types.isIdentifier(node.callee.object) &&
+                node.callee.object.name === importedEmberName
+              ) {
+                // Ember.computed()
+                for (const elem of node.arguments) {
                   if (types.isStringLiteral(elem)) {
                     const name = splitValue(elem.value);
                     currentClass.uses.add(name);
                   }
                 }
+              } else if (types.isIdentifier(node.callee.property)) {
+                // Ember.computed.or(), computed.or()
+                const macroName = node.callee.property.name;
+                if (macros.includes(macroName)) {
+                  for (
+                    let idx = 0;
+                    idx < MACROS_TO_TRACKED_ARGUMENT_COUNT[macroName] &&
+                    idx < node.arguments.length;
+                    idx++
+                  ) {
+                    const elem = node.arguments[idx];
+                    if (types.isStringLiteral(elem)) {
+                      const name = splitValue(elem.value);
+                      currentClass.uses.add(name);
+                    }
+                  }
+                }
               }
             } else {
-              // Ember.computed(), computed()
+              // computed()
               for (const elem of node.arguments) {
                 if (types.isStringLiteral(elem)) {
                   const name = splitValue(elem.value);
@@ -221,6 +239,28 @@ module.exports = {
                   const name = splitValue(elem.value);
                   currentClass.uses.add(name);
                 }
+              }
+            } else if (calleeName === importedObserverName) {
+              // observer('foo', ...)
+              for (const elem of node.arguments) {
+                if (types.isStringLiteral(elem)) {
+                  const name = splitValue(elem.value);
+                  currentClass.uses.add(name);
+                }
+              }
+            }
+          } else if (
+            types.isMemberExpression(node.callee) &&
+            types.isIdentifier(node.callee.object) &&
+            node.callee.object.name === importedEmberName &&
+            types.isIdentifier(node.callee.property) &&
+            node.callee.property.name === 'observer'
+          ) {
+            // Ember.observer('foo', ...)
+            for (const elem of node.arguments) {
+              if (types.isStringLiteral(elem)) {
+                const name = splitValue(elem.value);
+                currentClass.uses.add(name);
               }
             }
           }


### PR DESCRIPTION
Fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1157

This PR accounts for observer dependent keys and fixes some logic within the computed prop logic.