### PR TITLE
Update several rules to check imports when checking for Ember service injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |  | [no-html-safe](./docs/rules/no-html-safe.md) | disallow the use of `htmlSafe` |
 | :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
 | :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
-|  | [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |
 |  | [require-fetch-import](./docs/rules/require-fetch-import.md) | enforce explicit import for `fetch()` |
 
 ### Routes
@@ -175,6 +174,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
+|  | [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |
 | :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |
 |  | [no-unused-services](./docs/rules/no-unused-services.md) | disallow unused service injections |
 

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -3,6 +3,7 @@
 const emberUtils = require('../utils/ember');
 const decoratorUtils = require('../utils/decorators');
 const types = require('../utils/types');
+const { getImportIdentifier } = require('../utils/import');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -57,10 +58,22 @@ module.exports = {
     const catchRouterMicrolib = context.options[0] ? context.options[0].catchRouterMicrolib : true;
     const catchRouterMain = context.options[0] ? context.options[0].catchRouterMain : true;
 
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       Property(node) {
         if (
-          emberUtils.isInjectedServiceProp(node) &&
+          emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName) &&
           node.value.arguments.length > 0 &&
           node.value.arguments[0].value === ROUTING_SERVICE_NAME
         ) {

--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -4,6 +4,7 @@ const kebabCase = require('lodash.kebabcase');
 const assert = require('assert');
 const emberUtils = require('../utils/ember');
 const decoratorUtils = require('../utils/decorators');
+const { getImportIdentifier } = require('../utils/import');
 
 const DEFAULT_ERROR_MESSAGE = 'Injecting this service is not allowed from this file.';
 
@@ -12,7 +13,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'disallow injecting certain services under certain paths',
-      category: 'Miscellaneous',
+      category: 'Services',
       url:
         'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-restricted-service-injections.md',
     },
@@ -87,12 +88,24 @@ module.exports = {
       }
     }
 
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       // Handles:
       // * myService: service()
       // * propertyName: service('myService')
       Property(node) {
-        if (!emberUtils.isInjectedServiceProp(node)) {
+        if (!emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
           return;
         }
 
@@ -120,7 +133,7 @@ module.exports = {
       // * @service() myService
       // * @service('myService') propertyName
       ClassProperty(node) {
-        if (!emberUtils.isInjectedServiceProp(node)) {
+        if (!emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
           return;
         }
 

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -2,6 +2,7 @@
 
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
+const { getImportIdentifier } = require('../utils/import');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,10 +28,22 @@ module.exports = {
   ERROR_MESSAGE,
 
   create(context) {
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       Property(node) {
         if (
-          !emberUtils.isInjectedServiceProp(node) ||
+          !emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName) ||
           node.value.arguments.length !== 1 ||
           !types.isStringLiteral(node.value.arguments[0])
         ) {
@@ -53,7 +66,7 @@ module.exports = {
 
       ClassProperty(node) {
         if (
-          !emberUtils.isInjectedServiceProp(node) ||
+          !emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName) ||
           node.decorators.length !== 1 ||
           !types.isCallExpression(node.decorators[0].expression) ||
           node.decorators[0].expression.arguments.length !== 1 ||

--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -123,7 +123,8 @@ module.exports = {
             }
           }
         } else if (node.source.value === '@ember/service') {
-          importedInjectName = importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
         } else if (node.source.value === 'ember') {
           importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
         }
@@ -249,7 +250,10 @@ module.exports = {
         }
 
         const currentClass = classStack.peek();
-        if (currentClass && emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
+        if (
+          currentClass &&
+          emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)
+        ) {
           const name = node.key.name;
           currentClass.services[name] = node;
         }
@@ -262,7 +266,10 @@ module.exports = {
         }
 
         const currentClass = classStack.peek();
-        if (currentClass && emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
+        if (
+          currentClass &&
+          emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)
+        ) {
           const name = node.key.name;
           currentClass.services[name] = node;
         }

--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -74,7 +74,7 @@ module.exports = {
     function reportInstances() {
       const currentClass = classStack.pop();
       const { services, uses } = currentClass;
-      if (!services || !uses) {
+      if (Object.keys(services).length === 0) {
         return;
       }
 

--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -52,6 +52,7 @@ module.exports = {
     let importedEmberName;
     let importedGetName;
     let importedGetPropertiesName;
+    let importedInjectName;
     const macros = getMacros();
     const importedMacros = {};
 
@@ -121,6 +122,8 @@ module.exports = {
               importedMacros[localName] = name;
             }
           }
+        } else if (node.source.value === '@ember/service') {
+          importedInjectName = importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
         } else if (node.source.value === 'ember') {
           importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
         }
@@ -240,16 +243,26 @@ module.exports = {
       },
       // foo: service(...)
       Property(node) {
+        // If Ember and Ember.inject weren't imported, skip out early
+        if (!importedEmberName && !importedInjectName) {
+          return;
+        }
+
         const currentClass = classStack.peek();
-        if (currentClass && emberUtils.isInjectedServiceProp(node)) {
+        if (currentClass && emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
           const name = node.key.name;
           currentClass.services[name] = node;
         }
       },
       // @service(...) foo;
       ClassProperty(node) {
+        // If Ember and Ember.inject weren't imported, skip out early
+        if (!importedEmberName && !importedInjectName) {
+          return;
+        }
+
         const currentClass = classStack.peek();
-        if (currentClass && emberUtils.isInjectedServiceProp(node)) {
+        if (currentClass && emberUtils.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
           const name = node.key.name;
           currentClass.services[name] = node;
         }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -2,6 +2,7 @@
 
 const ember = require('../utils/ember');
 const propOrder = require('../utils/property-order');
+const { getImportIdentifier } = require('../utils/import');
 
 const reportUnorderedProperties = propOrder.reportUnorderedProperties;
 const addBackwardsPosition = propOrder.addBackwardsPosition;
@@ -85,13 +86,32 @@ module.exports = {
       ]);
     }
 
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       CallExpression(node) {
         if (!ember.isEmberComponent(context, node)) {
           return;
         }
 
-        reportUnorderedProperties(node, context, 'component', order);
+        reportUnorderedProperties(
+          node,
+          context,
+          'component',
+          order,
+          importedEmberName,
+          importedInjectName
+        );
       },
     };
   },

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -2,6 +2,7 @@
 
 const ember = require('../utils/ember');
 const propOrder = require('../utils/property-order');
+const { getImportIdentifier } = require('../utils/import');
 
 const reportUnorderedProperties = propOrder.reportUnorderedProperties;
 const addBackwardsPosition = propOrder.addBackwardsPosition;
@@ -57,13 +58,32 @@ module.exports = {
       ? addBackwardsPosition(options.order, 'empty-method', 'method')
       : ORDER;
 
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       CallExpression(node) {
         if (!ember.isEmberController(context, node)) {
           return;
         }
 
-        reportUnorderedProperties(node, context, 'controller', order);
+        reportUnorderedProperties(
+          node,
+          context,
+          'controller',
+          order,
+          importedEmberName,
+          importedInjectName
+        );
       },
     };
   },

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -98,7 +98,14 @@ module.exports = {
         if (!ember.isEmberRoute(context, node)) {
           return;
         }
-        reportUnorderedProperties(node, context, 'route', order, importedEmberName, importedInjectName);
+        reportUnorderedProperties(
+          node,
+          context,
+          'route',
+          order,
+          importedEmberName,
+          importedInjectName
+        );
       },
     };
   },

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -2,6 +2,7 @@
 
 const ember = require('../utils/ember');
 const propOrder = require('../utils/property-order');
+const { getImportIdentifier } = require('../utils/import');
 
 const reportUnorderedProperties = propOrder.reportUnorderedProperties;
 const addBackwardsPosition = propOrder.addBackwardsPosition;
@@ -80,12 +81,24 @@ module.exports = {
       ]);
     }
 
+    let importedInjectName;
+    let importedEmberName;
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(node, 'ember');
+        }
+        if (node.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(node, '@ember/service', 'inject');
+        }
+      },
       CallExpression(node) {
         if (!ember.isEmberRoute(context, node)) {
           return;
         }
-        reportUnorderedProperties(node, context, 'route', order);
+        reportUnorderedProperties(node, context, 'route', order, importedEmberName, importedInjectName);
       },
     };
   },

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -137,11 +137,23 @@ function findEmberGetCalls(node, importedNames) {
 function findInjectedServiceNames(node) {
   const results = [];
 
+  let importedEmberName;
+  let importedInjectName;
+
   new Traverser().traverse(node, {
     enter(child) {
+      if (types.isImportDeclaration(child)) {
+        if (child.source.value === 'ember') {
+          importedEmberName = importedEmberName || getImportIdentifier(child, 'ember');
+        }
+        if (child.source.value === '@ember/service') {
+          importedInjectName =
+            importedInjectName || getImportIdentifier(child, '@ember/service', 'inject');
+        }
+      }
       if (
         (types.isProperty(child) || types.isClassProperty(child)) &&
-        emberUtils.isInjectedServiceProp(child) &&
+        emberUtils.isInjectedServiceProp(child, importedEmberName, importedInjectName) &&
         types.isIdentifier(child.key)
       ) {
         results.push(child.key.name);

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -299,8 +299,20 @@ function isEmberProxy(context, node) {
   return isEmberArrayProxy(context, node) || isEmberObjectProxy(context, node);
 }
 
-function isInjectedServiceProp(node) {
-  return isPropOfType(node, 'service') || isPropOfType(node, 'inject');
+function isInjectedServiceProp(node, importedEmberName, importedInjectName) {
+  return (
+    isPropOfType(node, importedInjectName) ||
+    (types.isProperty(node) &&
+      types.isCallExpression(node.value) &&
+      types.isMemberExpression(node.value.callee) &&
+      types.isMemberExpression(node.value.callee.object) &&
+      types.isIdentifier(node.value.callee.object.object) &&
+      node.value.callee.object.object.name === importedEmberName &&
+      types.isIdentifier(node.value.callee.object.property) &&
+      node.value.callee.object.property.name === 'inject' &&
+      types.isIdentifier(node.value.callee.property) &&
+      node.value.callee.property.name === 'service')
+  );
 }
 
 function isInjectedControllerProp(node) {

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -299,6 +299,15 @@ function isEmberProxy(context, node) {
   return isEmberArrayProxy(context, node) || isEmberObjectProxy(context, node);
 }
 
+/**
+ * Checks if a node is a service injection. Looks for:
+ * * service()
+ * * Ember.inject.service()
+ * @param {node} node
+ * @param {string} importedEmberName name that `Ember` is imported under
+ * @param {string} importedInjectName name that `inject` is imported under
+ * @returns
+ */
 function isInjectedServiceProp(node, importedEmberName, importedInjectName) {
   return (
     isPropOfType(node, importedInjectName) ||

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -188,7 +188,14 @@ function getName(type, node) {
   return prefix ? `"${prefix}" ${typeDescription}` : typeDescription;
 }
 
-function reportUnorderedProperties(node, context, parentType, ORDER, importedEmberName, importedInjectName) {
+function reportUnorderedProperties(
+  node,
+  context,
+  parentType,
+  ORDER,
+  importedEmberName,
+  importedInjectName
+) {
   let maxOrder = -1;
   const firstPropertyOfType = {};
   let firstPropertyOfNextType;
@@ -198,7 +205,13 @@ function reportUnorderedProperties(node, context, parentType, ORDER, importedEmb
     : ember.getModuleProperties(node);
 
   for (const property of properties) {
-    const type = determinePropertyType(property, parentType, ORDER, importedEmberName, importedInjectName);
+    const type = determinePropertyType(
+      property,
+      parentType,
+      ORDER,
+      importedEmberName,
+      importedInjectName
+    );
     const order = getOrder(ORDER, type);
 
     const info = {

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -52,8 +52,8 @@ const NAMES = {
 };
 
 // eslint-disable-next-line complexity
-function determinePropertyType(node, parentType, ORDER) {
-  if (ember.isInjectedServiceProp(node)) {
+function determinePropertyType(node, parentType, ORDER, importedEmberName, importedInjectName) {
+  if (ember.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
     return 'service';
   }
 
@@ -188,7 +188,7 @@ function getName(type, node) {
   return prefix ? `"${prefix}" ${typeDescription}` : typeDescription;
 }
 
-function reportUnorderedProperties(node, context, parentType, ORDER) {
+function reportUnorderedProperties(node, context, parentType, ORDER, importedEmberName, importedInjectName) {
   let maxOrder = -1;
   const firstPropertyOfType = {};
   let firstPropertyOfNextType;
@@ -198,7 +198,7 @@ function reportUnorderedProperties(node, context, parentType, ORDER) {
     : ember.getModuleProperties(node);
 
   for (const property of properties) {
-    const type = determinePropertyType(property, parentType, ORDER);
+    const type = determinePropertyType(property, parentType, ORDER, importedEmberName, importedInjectName);
     const order = getOrder(ORDER, type);
 
     const info = {

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -11,6 +11,7 @@ const {
   ROUTER_MAIN_ERROR_MESSAGE,
 } = rule;
 
+const EMBER_IMPORT = "import Ember from 'ember';";
 const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 
 //------------------------------------------------------------------------------
@@ -32,6 +33,10 @@ ruleTester.run('no-private-routing-service', rule, {
     `${SERVICE_IMPORT} export default Component.extend({ someService: service('-router') });`,
     `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('routing') });`,
     `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('-router') });`,
+    `${EMBER_IMPORT} export default Component.extend({ someService: Ember.inject.service('routing') });`,
+    `${EMBER_IMPORT} export default Component.extend({ someService: Ember.inject.service('-router') });`,
+    `${EMBER_IMPORT} export default Component.extend({ '-routing': Ember.inject.service('routing') });`,
+    `${EMBER_IMPORT} export default Component.extend({ '-routing': Ember.inject.service('-router') });`,
     "Component.extend({ routing: someOtherFunction('-routing') });",
     `${SERVICE_IMPORT} export default Component.extend({ someService: service() });`,
     'export default Component.extend({ notAService: "a value" });',

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -11,6 +11,8 @@ const {
   ROUTER_MAIN_ERROR_MESSAGE,
 } = rule;
 
+const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -26,20 +28,20 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-private-routing-service', rule, {
   valid: [
     // Classic
-    "export default Component.extend({ someService: service('routing') });",
-    "export default Component.extend({ someService: service('-router') });",
-    "export default Component.extend({ '-routing': service('routing') });",
-    "export default Component.extend({ '-routing': service('-router') });",
-    "Component.extend({ routing: someOtherFunction('-routing') });",
-    'export default Component.extend({ someService: service() });',
-    'export default Component.extend({ notAService: "a value" });',
-    'export default Component.extend({ anInt: 25 });',
+    `${SERVICE_IMPORT} export default Component.extend({ someService: service('routing') });`,
+    `${SERVICE_IMPORT} export default Component.extend({ someService: service('-router') });`,
+    `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('routing') });`,
+    `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('-router') });`,
+    `Component.extend({ routing: someOtherFunction('-routing') });`,
+    `${SERVICE_IMPORT} export default Component.extend({ someService: service() });`,
+    `export default Component.extend({ notAService: "a value" });`,
+    `export default Component.extend({ anInt: 25 });`,
 
     // Octane
-    'export default class MyComponent extends Component { @service router; }',
-    "export default class MyComponent extends Component { @service('router') routing; }",
-    'export default class MyComponent extends Component { @service routing; }',
-    "export default class MyComponent extends Component { @service('routing') routing; }",
+    `${SERVICE_IMPORT} export default class MyComponent extends Component { @service router; }`,
+    `${SERVICE_IMPORT} export default class MyComponent extends Component { @service('router') routing; }`,
+    `${SERVICE_IMPORT} export default class MyComponent extends Component { @service routing; }`,
+    `${SERVICE_IMPORT} export default class MyComponent extends Component { @service('routing') routing; }`,
     `
     export default class MyComponent extends Component {
       @computed('-routing', 'lastName')
@@ -48,8 +50,8 @@ ruleTester.run('no-private-routing-service', rule, {
       }
     }
     `,
-    'class MyComponent extends Component { @service() routing; }',
-    'class MyComponent extends Component { @service() notRouting; }',
+    `${SERVICE_IMPORT} class MyComponent extends Component { @service() routing; }`,
+    `${SERVICE_IMPORT} class MyComponent extends Component { @service() notRouting; }`,
     'class MyComponent extends Component { aProp="routing"; }',
     'class MyComponent extends Component { aProp="-routing"; }',
     'class MyComponent extends Component { aProp="another value"; }',
@@ -72,14 +74,14 @@ ruleTester.run('no-private-routing-service', rule, {
   invalid: [
     // Classic
     {
-      code: "export default Component.extend({ routing: service('-routing') });",
+      code: `${SERVICE_IMPORT} export default Component.extend({ routing: service('-routing') });`,
       output: null,
       errors: [{ message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, type: 'Property' }],
     },
 
     // Octane
     {
-      code: "export default class MyComponent extends Component { @service('-routing') routing; }",
+      code: `${SERVICE_IMPORT} export default class MyComponent extends Component { @service('-routing') routing; }`,
       output: null,
       errors: [{ message: PRIVATE_ROUTING_SERVICE_ERROR_MESSAGE, type: 'ClassProperty' }],
     },

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -32,10 +32,10 @@ ruleTester.run('no-private-routing-service', rule, {
     `${SERVICE_IMPORT} export default Component.extend({ someService: service('-router') });`,
     `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('routing') });`,
     `${SERVICE_IMPORT} export default Component.extend({ '-routing': service('-router') });`,
-    `Component.extend({ routing: someOtherFunction('-routing') });`,
+    "Component.extend({ routing: someOtherFunction('-routing') });",
     `${SERVICE_IMPORT} export default Component.extend({ someService: service() });`,
-    `export default Component.extend({ notAService: "a value" });`,
-    `export default Component.extend({ anInt: 25 });`,
+    'export default Component.extend({ notAService: "a value" });',
+    'export default Component.extend({ anInt: 25 });',
 
     // Octane
     `${SERVICE_IMPORT} export default class MyComponent extends Component { @service router; }`,

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -3,6 +3,7 @@ const rule = require('../../../lib/rules/no-restricted-service-injections');
 
 const { DEFAULT_ERROR_MESSAGE } = rule;
 
+const EMBER_IMPORT = "import Ember from 'ember';";
 const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 
 const ruleTester = new RuleTester({
@@ -22,8 +23,20 @@ ruleTester.run('no-restricted-service-injections', rule, {
       filename: 'app/components/path.js',
     },
     {
+      // Service name doesn't match (with property name):
+      code: `${EMBER_IMPORT} Component.extend({ myService: Ember.inject.service() })`,
+      options: [{ paths: ['app/components'], services: ['abc'] }],
+      filename: 'app/components/path.js',
+    },
+    {
       // Service name doesn't match (with string argument):
       code: `${SERVICE_IMPORT} Component.extend({ randomName: service('myService') })`,
+      options: [{ paths: ['app/components'], services: ['abc'] }],
+      filename: 'app/components/path.js',
+    },
+    {
+      // Service name doesn't match (with string argument):
+      code: `${EMBER_IMPORT} Component.extend({ randomName: Ember.inject.service('myService') })`,
       options: [{ paths: ['app/components'], services: ['abc'] }],
       filename: 'app/components/path.js',
     },

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -3,6 +3,8 @@ const rule = require('../../../lib/rules/no-restricted-service-injections');
 
 const { DEFAULT_ERROR_MESSAGE } = rule;
 
+const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
+
 const ruleTester = new RuleTester({
   parser: require.resolve('babel-eslint'),
   parserOptions: {
@@ -15,43 +17,43 @@ ruleTester.run('no-restricted-service-injections', rule, {
   valid: [
     {
       // Service name doesn't match (with property name):
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [{ paths: ['app/components'], services: ['abc'] }],
       filename: 'app/components/path.js',
     },
     {
       // Service name doesn't match (with string argument):
-      code: "Component.extend({ randomName: service('myService') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('myService') })`,
       options: [{ paths: ['app/components'], services: ['abc'] }],
       filename: 'app/components/path.js',
     },
     {
       // Service name doesn't match (with decorator)
-      code: "class MyComponent extends Component { @service('myService') randomName }",
+      code: `${SERVICE_IMPORT} class MyComponent extends Component { @service('myService') randomName }`,
       options: [{ paths: ['app/components'], services: ['abc'] }],
       filename: 'app/components/path.js',
     },
     {
       // Service scope doesn't match:
-      code: "Component.extend({ randomName: service('scope/myService') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('scope/myService') })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       filename: 'app/components/path.js',
     },
     {
       // File path doesn't match:
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [{ paths: ['other/path'], services: ['my-service'] }],
       filename: 'app/components/path.js',
     },
     {
       // Not the service decorator:
-      code: 'Component.extend({ myService: otherDecorator() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: otherDecorator() })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       filename: 'app/components/path.js',
     },
     {
       // Ignores injection due to dynamic variable usage:
-      code: 'Component.extend({ myService: service(SOME_VARIABLE) })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service(SOME_VARIABLE) })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       filename: 'app/components/path.js',
     },
@@ -59,7 +61,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
   invalid: [
     {
       // Without service name argument:
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -67,7 +69,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With camelized service name argument:
-      code: "Component.extend({ randomName: service('myService') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('myService') })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -75,7 +77,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With dasherized service name argument:
-      code: "Component.extend({ randomName: service('my-service') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('my-service') })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -83,7 +85,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With nested, camelized service name:
-      code: "Component.extend({ randomName: service('scope/myService') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('scope/myService') })`,
       options: [{ paths: ['app/components'], services: ['scope/my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -91,7 +93,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With nested, dasherized service name:
-      code: "Component.extend({ randomName: service('scope/my-service') })",
+      code: `${SERVICE_IMPORT} Component.extend({ randomName: service('scope/my-service') })`,
       options: [{ paths: ['app/components'], services: ['scope/my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -99,7 +101,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With decorator with camelized service name argument:
-      code: "class MyComponent extends Component { @service('myService') randomName }",
+      code: `${SERVICE_IMPORT} class MyComponent extends Component { @service('myService') randomName }`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -107,7 +109,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With decorator with dasherized service name argument:
-      code: "class MyComponent extends Component { @service('my-service') randomName }",
+      code: `${SERVICE_IMPORT} class MyComponent extends Component { @service('my-service') randomName }`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -115,7 +117,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With decorator without service name argument (without parentheses):
-      code: 'class MyComponent extends Component { @service myService }',
+      code: `${SERVICE_IMPORT} class MyComponent extends Component { @service myService }`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -123,7 +125,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With decorator without service name argument (with parentheses):
-      code: 'class MyComponent extends Component { @service() myService }',
+      code: `${SERVICE_IMPORT} class MyComponent extends Component { @service() myService }`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',
@@ -131,7 +133,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With custom error message:
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [
         {
           paths: ['app/components'],
@@ -145,7 +147,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // With multiple violations:
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [
         { paths: ['app/components'], services: ['my-service'], message: 'Error 1' },
         { paths: ['app/components'], services: ['my-service'], message: 'Error 2' },
@@ -159,7 +161,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
     },
     {
       // Without specifying any paths (should match any path):
-      code: 'Component.extend({ myService: service() })',
+      code: `${SERVICE_IMPORT} Component.extend({ myService: service() })`,
       options: [{ services: ['my-service'] }],
       output: null,
       filename: 'app/components/path.js',

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -7,6 +7,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 
+const EMBER_IMPORT = "import Ember from 'ember';";
 const SERVICE_IMPORT = "import {inject} from '@ember/service';";
 const RENAMED_SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 
@@ -25,6 +26,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-unnecessary-service-injection-argument', rule, {
   valid: [
     // No argument:
+    `${EMBER_IMPORT} export default Component.extend({ serviceName: Ember.inject.service() });`,
     `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service() });`,
     `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject() });`,
     `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service() });`,
@@ -49,9 +51,10 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
 
     // Property name matches service name but service name uses dashes
     // (allowed because it avoids needless runtime camelization <-> dasherization in the resolver):
+    `${EMBER_IMPORT} export default Component.extend({ specialName: Ember.inject.service('service-name') });`,
     `${RENAMED_SERVICE_IMPORT} export default Component.extend({ specialName: service('service-name') });`,
     `${SERVICE_IMPORT} export default Component.extend({ specialName: inject('service-name') });`,
-    "const controller = Controller.extend({ serviceName: service('service-name') });",
+    `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service('service-name') });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service("service-name") serviceName }`,
       parser: require.resolve('babel-eslint'),
@@ -63,7 +66,8 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     },
 
     // Property name does not match service name:
-    "const controller = Controller.extend({ specialName: service('service-name') });",
+    `${EMBER_IMPORT} const controller = Controller.extend({ specialName: Ember.inject.service('service-name') });`,
+    `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ specialName: service('service-name') });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service("specialName") serviceName }`,
       parser: require.resolve('babel-eslint'),
@@ -75,10 +79,12 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     },
 
     // When usage is ignored because of additional arguments:
+    `${EMBER_IMPORT} export default Component.extend({ serviceName: Ember.inject.service('serviceName', EXTRA_PROPERTY) });`,
     `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service('serviceName', EXTRA_PROPERTY) });`,
     `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject('serviceName', EXTRA_PROPERTY) });`,
 
     // When usage is ignored because of template literal:
+    `${EMBER_IMPORT} export default Component.extend({ serviceName: Ember.inject.service(\`serviceName\`) });`,
     `${SERVICE_IMPORT} export default Component.extend({ serviceName: service(\`serviceName\`) });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service(\`specialName\`) serviceName }`,

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -98,7 +98,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
 
     // Not Ember's `service()` function:
     "export default Component.extend({ serviceName: otherFunction('serviceName') });",
-    "export default Component.extend({ serviceName: service.otherFunction('serviceName') });",
+    `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service.otherFunction('serviceName') });`,
     "export default Component.extend({ serviceName: inject.otherFunction('serviceName') });",
     {
       code: 'class Test { @otherDecorator("name") name }',

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -7,6 +7,9 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 
+const SERVICE_IMPORT = "import {inject} from '@ember/service';";
+const RENAMED_SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -22,11 +25,11 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-unnecessary-service-injection-argument', rule, {
   valid: [
     // No argument:
-    'export default Component.extend({ serviceName: service() });',
-    'export default Component.extend({ serviceName: inject() });',
-    'const controller = Controller.extend({ serviceName: service() });',
+    `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service() });`,
+    `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject() });`,
+    `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service() });`,
     {
-      code: 'class Test { @service serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service serviceName }`,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,
@@ -35,7 +38,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
       },
     },
     {
-      code: 'class Test { @service() serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service() serviceName }`,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,
@@ -46,11 +49,11 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
 
     // Property name matches service name but service name uses dashes
     // (allowed because it avoids needless runtime camelization <-> dasherization in the resolver):
-    "export default Component.extend({ specialName: service('service-name') });",
-    "export default Component.extend({ specialName: inject('service-name') });",
+    `${RENAMED_SERVICE_IMPORT} export default Component.extend({ specialName: service('service-name') });`,
+    `${SERVICE_IMPORT} export default Component.extend({ specialName: inject('service-name') });`,
     "const controller = Controller.extend({ serviceName: service('service-name') });",
     {
-      code: 'class Test { @service("service-name") serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service("service-name") serviceName }`,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,
@@ -62,7 +65,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     // Property name does not match service name:
     "const controller = Controller.extend({ specialName: service('service-name') });",
     {
-      code: 'class Test { @service("specialName") serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service("specialName") serviceName }`,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,
@@ -72,13 +75,13 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     },
 
     // When usage is ignored because of additional arguments:
-    "export default Component.extend({ serviceName: service('serviceName', EXTRA_PROPERTY) });",
-    "export default Component.extend({ serviceName: inject('serviceName', EXTRA_PROPERTY) });",
+    `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service('serviceName', EXTRA_PROPERTY) });`,
+    `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject('serviceName', EXTRA_PROPERTY) });`,
 
     // When usage is ignored because of template literal:
-    'export default Component.extend({ serviceName: service(`serviceName`) });',
+    `${SERVICE_IMPORT} export default Component.extend({ serviceName: service(\`serviceName\`) });`,
     {
-      code: 'class Test { @service(`specialName`) serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service(\`specialName\`) serviceName }`,
       parser: require.resolve('babel-eslint'),
       parserOptions: {
         ecmaVersion: 6,
@@ -106,32 +109,32 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
   invalid: [
     // `Component` examples:
     {
-      code: "export default Component.extend({ serviceName: service('serviceName') });",
-      output: 'export default Component.extend({ serviceName: service() });',
+      code: `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service('serviceName') });`,
+      output: `${RENAMED_SERVICE_IMPORT} export default Component.extend({ serviceName: service() });`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
-      code: "export default Component.extend({ serviceName: inject('serviceName') });",
-      output: 'export default Component.extend({ serviceName: inject() });',
+      code: `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject('serviceName') });`,
+      output: `${SERVICE_IMPORT} export default Component.extend({ serviceName: inject() });`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
 
     // `Controller` examples:
     {
-      code: "const controller = Controller.extend({ serviceName: service('serviceName') });",
-      output: 'const controller = Controller.extend({ serviceName: service() });',
+      code: `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service('serviceName') });`,
+      output: `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service() });`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
     {
-      code: "const controller = Controller.extend({ serviceName: inject('serviceName') });",
-      output: 'const controller = Controller.extend({ serviceName: inject() });',
+      code: `${SERVICE_IMPORT} const controller = Controller.extend({ serviceName: inject('serviceName') });`,
+      output: `${SERVICE_IMPORT} const controller = Controller.extend({ serviceName: inject() });`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
     },
 
     // Decorator:
     {
-      code: 'class Test { @service("serviceName") serviceName }',
-      output: 'class Test { @service() serviceName }',
+      code: `${RENAMED_SERVICE_IMPORT} class Test { @service("serviceName") serviceName }`,
+      output: `${RENAMED_SERVICE_IMPORT} class Test { @service() serviceName }`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
       parser: require.resolve('babel-eslint'),
       parserOptions: {

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -213,7 +213,12 @@ ruleTester.run('no-unused-services', rule, {
       errors: [
         {
           messageId: 'main',
-          suggestions: [{ messageId: 'removeServiceInjection', output: `${SERVICE_IMPORT} Component.extend({  });` }],
+          suggestions: [
+            {
+              messageId: 'removeServiceInjection',
+              output: `${SERVICE_IMPORT} Component.extend({  });`,
+            },
+          ],
           type: 'Property',
         },
       ],
@@ -240,7 +245,12 @@ ruleTester.run('no-unused-services', rule, {
       errors: [
         {
           messageId: 'main',
-          suggestions: [{ messageId: 'removeServiceInjection', output: `${SERVICE_IMPORT} Component.extend({  });` }],
+          suggestions: [
+            {
+              messageId: 'removeServiceInjection',
+              output: `${SERVICE_IMPORT} Component.extend({  });`,
+            },
+          ],
           type: 'Property',
         },
       ],

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -18,6 +18,7 @@ const ruleTester = new RuleTester({
 });
 
 const SERVICE_NAME = 'fooName';
+const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 const EO_IMPORTS = "import {computed, get, getProperties} from '@ember/object';";
 const RENAMED_EO_IMPORTS =
   "import {computed as cp, get as g, getProperties as gp} from '@ember/object';";
@@ -75,10 +76,10 @@ function generateMacroUseCasesFor(propertyName, renamed = false) {
   const aliasName = renamed ? 'al' : 'alias';
   const aliasImport = renamed ? RENAMED_ALIAS_IMPORT : ALIAS_IMPORT;
   return [
-    `${aliasImport} class MyClass { @service('foo') ${propertyName}; @${aliasName}('${propertyName}.prop') someAlias; }`,
-    `${aliasImport} class MyClass { @service() ${propertyName}; @${aliasName}('${propertyName}.prop') someAlias; }`,
-    `${aliasImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someAlias: ${aliasName}('${propertyName}.prop') });`,
-    `${aliasImport} Component.extend({ ${SERVICE_NAME}: service(), someAlias: ${aliasName}('${propertyName}.prop') });`,
+    `${SERVICE_IMPORT}${aliasImport} class MyClass { @service('foo') ${propertyName}; @${aliasName}('${propertyName}.prop') someAlias; }`,
+    `${SERVICE_IMPORT}${aliasImport} class MyClass { @service() ${propertyName}; @${aliasName}('${propertyName}.prop') someAlias; }`,
+    `${SERVICE_IMPORT}${aliasImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someAlias: ${aliasName}('${propertyName}.prop') });`,
+    `${SERVICE_IMPORT}${aliasImport} Component.extend({ ${SERVICE_NAME}: service(), someAlias: ${aliasName}('${propertyName}.prop') });`,
   ];
 }
 
@@ -92,12 +93,12 @@ function generateComputedUseCasesFor(propertyName, renamed = false) {
   const computedName = renamed ? 'cp' : 'computed';
   const computedImport = renamed ? RENAMED_EO_IMPORTS : EO_IMPORTS;
   return [
-    `${computedImport} class MyClass { @service('foo') ${propertyName}; @${computedName}('${propertyName}.prop') get someComputed() {} }`,
-    `${computedImport} class MyClass { @service() ${propertyName}; @${computedName}('${propertyName}.prop') get someComputed() {} }`,
-    `${computedImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someComputed: ${computedName}('${propertyName}.prop', ()=>{}) });`,
-    `${computedImport} Component.extend({ ${SERVICE_NAME}: service(), someComputed: ${computedName}('${propertyName}.prop', ()=>{}) });`,
-    `${computedImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someComputed: ${computedName}.alias('${propertyName}.prop', ()=>{}) });`,
-    `${computedImport} Component.extend({ ${SERVICE_NAME}: service(), someComputed: ${computedName}.alias('${propertyName}.prop', ()=>{}) });`,
+    `${SERVICE_IMPORT}${computedImport} class MyClass { @service('foo') ${propertyName}; @${computedName}('${propertyName}.prop') get someComputed() {} }`,
+    `${SERVICE_IMPORT}${computedImport} class MyClass { @service() ${propertyName}; @${computedName}('${propertyName}.prop') get someComputed() {} }`,
+    `${SERVICE_IMPORT}${computedImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someComputed: ${computedName}('${propertyName}.prop', ()=>{}) });`,
+    `${SERVICE_IMPORT}${computedImport} Component.extend({ ${SERVICE_NAME}: service(), someComputed: ${computedName}('${propertyName}.prop', ()=>{}) });`,
+    `${SERVICE_IMPORT}${computedImport} Component.extend({ ${SERVICE_NAME}: service('foo'), someComputed: ${computedName}.alias('${propertyName}.prop', ()=>{}) });`,
+    `${SERVICE_IMPORT}${computedImport} Component.extend({ ${SERVICE_NAME}: service(), someComputed: ${computedName}.alias('${propertyName}.prop', ()=>{}) });`,
   ];
 }
 
@@ -111,10 +112,10 @@ function generateValid() {
   const useCases = generateUseCasesFor(SERVICE_NAME);
   for (const use of useCases) {
     valid.push(
-      `class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${use}} }`,
-      `class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${use}} }`,
-      `Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${use}} });`,
-      `Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${use}} });`
+      `${SERVICE_IMPORT} class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${use}} }`,
+      `${SERVICE_IMPORT} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${use}} }`,
+      `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${use}} });`,
+      `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${use}} });`
     );
   }
 
@@ -126,10 +127,10 @@ function generateValid() {
     const imports = idx === 0 ? EO_IMPORTS : RENAMED_EO_IMPORTS;
     for (const use of useCases) {
       valid.push(
-        `${imports} class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${use}} }`,
-        `${imports} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${use}} }`,
-        `${imports} Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${use}} });`,
-        `${imports} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${use}} });`
+        `${SERVICE_IMPORT}${imports} class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${use}} }`,
+        `${SERVICE_IMPORT}${imports} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${use}} }`,
+        `${SERVICE_IMPORT}${imports} Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${use}} });`,
+        `${SERVICE_IMPORT}${imports} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${use}} });`
       );
     }
   }
@@ -159,7 +160,7 @@ ruleTester.run('no-unused-services', rule, {
   valid: generateValid(),
   invalid: [
     {
-      code: `class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${nonUses}} }`,
+      code: `${SERVICE_IMPORT} class MyClass { @service('foo') ${SERVICE_NAME}; fooFunc() {${nonUses}} }`,
       output: null,
       errors: [
         {
@@ -167,7 +168,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass {  fooFunc() {${nonUses}} }`,
+              output: `${SERVICE_IMPORT} class MyClass {  fooFunc() {${nonUses}} }`,
             },
           ],
           type: 'ClassProperty',
@@ -175,7 +176,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${nonUses}} }`,
+      code: `${SERVICE_IMPORT} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${nonUses}} }`,
       output: null,
       errors: [
         {
@@ -183,7 +184,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass {  fooFunc() {${nonUses}} }`,
+              output: `${SERVICE_IMPORT} class MyClass {  fooFunc() {${nonUses}} }`,
             },
           ],
           type: 'ClassProperty',
@@ -191,7 +192,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${nonUses}} });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service('foo'), fooFunc() {${nonUses}} });`,
       output: null,
       errors: [
         {
@@ -199,7 +200,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `Component.extend({  fooFunc() {${nonUses}} });`,
+              output: `${SERVICE_IMPORT} Component.extend({  fooFunc() {${nonUses}} });`,
             },
           ],
           type: 'Property',
@@ -207,18 +208,18 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service('foo') });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service('foo') });`,
       output: null,
       errors: [
         {
           messageId: 'main',
-          suggestions: [{ messageId: 'removeServiceInjection', output: 'Component.extend({  });' }],
+          suggestions: [{ messageId: 'removeServiceInjection', output: `${SERVICE_IMPORT} Component.extend({  });` }],
           type: 'Property',
         },
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${nonUses}} });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${nonUses}} });`,
       output: null,
       errors: [
         {
@@ -226,7 +227,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `Component.extend({  fooFunc() {${nonUses}} });`,
+              output: `${SERVICE_IMPORT} Component.extend({  fooFunc() {${nonUses}} });`,
             },
           ],
           type: 'Property',
@@ -234,19 +235,19 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service() });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service() });`,
       output: null,
       errors: [
         {
           messageId: 'main',
-          suggestions: [{ messageId: 'removeServiceInjection', output: 'Component.extend({  });' }],
+          suggestions: [{ messageId: 'removeServiceInjection', output: `${SERVICE_IMPORT} Component.extend({  });` }],
           type: 'Property',
         },
       ],
     },
     /* Using get/getProperties without @ember/object import */
     {
-      code: `class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${emberObjectUses1}} }`,
+      code: `${SERVICE_IMPORT} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${emberObjectUses1}} }`,
       output: null,
       errors: [
         {
@@ -254,7 +255,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass {  fooFunc() {${emberObjectUses1}} }`,
+              output: `${SERVICE_IMPORT} class MyClass {  fooFunc() {${emberObjectUses1}} }`,
             },
           ],
           type: 'ClassProperty',
@@ -262,7 +263,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${emberObjectUses1}} });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${emberObjectUses1}} });`,
       output: null,
       errors: [
         {
@@ -270,7 +271,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `Component.extend({  fooFunc() {${emberObjectUses1}} });`,
+              output: `${SERVICE_IMPORT} Component.extend({  fooFunc() {${emberObjectUses1}} });`,
             },
           ],
           type: 'Property',
@@ -279,7 +280,7 @@ ruleTester.run('no-unused-services', rule, {
     },
     /* Using get/getProperties with @ember/object import for an unrelatedProp */
     {
-      code: `${EO_IMPORTS} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${emberObjectUses2}} }`,
+      code: `${SERVICE_IMPORT} ${EO_IMPORTS} class MyClass { @service() ${SERVICE_NAME}; fooFunc() {${emberObjectUses2}} }`,
       output: null,
       errors: [
         {
@@ -287,7 +288,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `${EO_IMPORTS} class MyClass {  fooFunc() {${emberObjectUses2}} }`,
+              output: `${SERVICE_IMPORT} ${EO_IMPORTS} class MyClass {  fooFunc() {${emberObjectUses2}} }`,
             },
           ],
           type: 'ClassProperty',
@@ -295,7 +296,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `${EO_IMPORTS} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${emberObjectUses2}} });`,
+      code: `${SERVICE_IMPORT} ${EO_IMPORTS} Component.extend({ ${SERVICE_NAME}: service(), fooFunc() {${emberObjectUses2}} });`,
       output: null,
       errors: [
         {
@@ -303,7 +304,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `${EO_IMPORTS} Component.extend({  fooFunc() {${emberObjectUses2}} });`,
+              output: `${SERVICE_IMPORT} ${EO_IMPORTS} Component.extend({  fooFunc() {${emberObjectUses2}} });`,
             },
           ],
           type: 'Property',
@@ -312,7 +313,7 @@ ruleTester.run('no-unused-services', rule, {
     },
     /* Using computed props and macros without the imports */
     {
-      code: `class MyClass { @service() ${SERVICE_NAME}; @alias('${SERVICE_NAME}') someAlias; @computed('${SERVICE_NAME}.prop') get someComputed() {} }`,
+      code: `${SERVICE_IMPORT} class MyClass { @service() ${SERVICE_NAME}; @alias('${SERVICE_NAME}') someAlias; @computed('${SERVICE_NAME}.prop') get someComputed() {} }`,
       output: null,
       errors: [
         {
@@ -320,7 +321,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass {  @alias('${SERVICE_NAME}') someAlias; @computed('${SERVICE_NAME}.prop') get someComputed() {} }`,
+              output: `${SERVICE_IMPORT} class MyClass {  @alias('${SERVICE_NAME}') someAlias; @computed('${SERVICE_NAME}.prop') get someComputed() {} }`,
             },
           ],
           type: 'ClassProperty',
@@ -328,7 +329,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `Component.extend({ ${SERVICE_NAME}: service(), someAlias1: alias('${SERVICE_NAME}'), someAlias2: computed.alias('${SERVICE_NAME}.prop'), someComputed: computed('${SERVICE_NAME}.prop', ()=>{}) });`,
+      code: `${SERVICE_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), someAlias1: alias('${SERVICE_NAME}'), someAlias2: computed.alias('${SERVICE_NAME}.prop'), someComputed: computed('${SERVICE_NAME}.prop', ()=>{}) });`,
       output: null,
       errors: [
         {
@@ -336,7 +337,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `Component.extend({  someAlias1: alias('${SERVICE_NAME}'), someAlias2: computed.alias('${SERVICE_NAME}.prop'), someComputed: computed('${SERVICE_NAME}.prop', ()=>{}) });`,
+              output: `${SERVICE_IMPORT} Component.extend({  someAlias1: alias('${SERVICE_NAME}'), someAlias2: computed.alias('${SERVICE_NAME}.prop'), someComputed: computed('${SERVICE_NAME}.prop', ()=>{}) });`,
             },
           ],
           type: 'Property',
@@ -345,7 +346,7 @@ ruleTester.run('no-unused-services', rule, {
     },
     /* Using computed props and macros with the imports for an unrelatedProp */
     {
-      code: `${EO_IMPORTS}${ALIAS_IMPORT} class MyClass { @service() ${SERVICE_NAME}; @alias('unrelatedProp', '${SERVICE_NAME}') someAlias; @computed('unrelatedProp.prop') get someComputed() {} }`,
+      code: `${SERVICE_IMPORT}${EO_IMPORTS}${ALIAS_IMPORT} class MyClass { @service() ${SERVICE_NAME}; @alias('unrelatedProp', '${SERVICE_NAME}') someAlias; @computed('unrelatedProp.prop') get someComputed() {} }`,
       output: null,
       errors: [
         {
@@ -353,7 +354,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `${EO_IMPORTS}${ALIAS_IMPORT} class MyClass {  @alias('unrelatedProp', '${SERVICE_NAME}') someAlias; @computed('unrelatedProp.prop') get someComputed() {} }`,
+              output: `${SERVICE_IMPORT}${EO_IMPORTS}${ALIAS_IMPORT} class MyClass {  @alias('unrelatedProp', '${SERVICE_NAME}') someAlias; @computed('unrelatedProp.prop') get someComputed() {} }`,
             },
           ],
           type: 'ClassProperty',
@@ -361,7 +362,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `${EO_IMPORTS}${ALIAS_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), someAlias1: alias('unrelatedProp', '${SERVICE_NAME}'), someAlias2: computed.alias('unrelatedProp.prop'), someComputed: computed('unrelatedProp.prop', ()=>{}) });`,
+      code: `${SERVICE_IMPORT}${EO_IMPORTS}${ALIAS_IMPORT} Component.extend({ ${SERVICE_NAME}: service(), someAlias1: alias('unrelatedProp', '${SERVICE_NAME}'), someAlias2: computed.alias('unrelatedProp.prop'), someComputed: computed('unrelatedProp.prop', ()=>{}) });`,
       output: null,
       errors: [
         {
@@ -369,7 +370,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `${EO_IMPORTS}${ALIAS_IMPORT} Component.extend({  someAlias1: alias('unrelatedProp', '${SERVICE_NAME}'), someAlias2: computed.alias('unrelatedProp.prop'), someComputed: computed('unrelatedProp.prop', ()=>{}) });`,
+              output: `${SERVICE_IMPORT}${EO_IMPORTS}${ALIAS_IMPORT} Component.extend({  someAlias1: alias('unrelatedProp', '${SERVICE_NAME}'), someAlias2: computed.alias('unrelatedProp.prop'), someComputed: computed('unrelatedProp.prop', ()=>{}) });`,
             },
           ],
           type: 'Property',
@@ -378,7 +379,7 @@ ruleTester.run('no-unused-services', rule, {
     },
     /* Multiple classes */
     {
-      code: `class MyClass1 { @service() ${SERVICE_NAME}; } class MyClass2 { fooFunc() {this.${SERVICE_NAME};} }`,
+      code: `${SERVICE_IMPORT} class MyClass1 { @service() ${SERVICE_NAME}; } class MyClass2 { fooFunc() {this.${SERVICE_NAME};} }`,
       output: null,
       errors: [
         {
@@ -386,7 +387,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass1 {  } class MyClass2 { fooFunc() {this.${SERVICE_NAME};} }`,
+              output: `${SERVICE_IMPORT} class MyClass1 {  } class MyClass2 { fooFunc() {this.${SERVICE_NAME};} }`,
             },
           ],
           type: 'ClassProperty',
@@ -394,7 +395,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `class MyClass1 { fooFunc() {this.${SERVICE_NAME};} } class MyClass2 { @service() ${SERVICE_NAME}; }`,
+      code: `${SERVICE_IMPORT} class MyClass1 { fooFunc() {this.${SERVICE_NAME};} } class MyClass2 { @service() ${SERVICE_NAME}; }`,
       output: null,
       errors: [
         {
@@ -402,7 +403,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass1 { fooFunc() {this.${SERVICE_NAME};} } class MyClass2 {  }`,
+              output: `${SERVICE_IMPORT} class MyClass1 { fooFunc() {this.${SERVICE_NAME};} } class MyClass2 {  }`,
             },
           ],
           type: 'ClassProperty',
@@ -411,7 +412,7 @@ ruleTester.run('no-unused-services', rule, {
     },
     /* Nested classes */
     {
-      code: `class MyClass1 { @service() ${SERVICE_NAME}; fooFunc1() { class MyClass2 { fooFunc2() {this.${SERVICE_NAME};} } } }`,
+      code: `${SERVICE_IMPORT} class MyClass1 { @service() ${SERVICE_NAME}; fooFunc1() { class MyClass2 { fooFunc2() {this.${SERVICE_NAME};} } } }`,
       output: null,
       errors: [
         {
@@ -419,7 +420,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass1 {  fooFunc1() { class MyClass2 { fooFunc2() {this.${SERVICE_NAME};} } } }`,
+              output: `${SERVICE_IMPORT} class MyClass1 {  fooFunc1() { class MyClass2 { fooFunc2() {this.${SERVICE_NAME};} } } }`,
             },
           ],
           type: 'ClassProperty',
@@ -427,7 +428,7 @@ ruleTester.run('no-unused-services', rule, {
       ],
     },
     {
-      code: `class MyClass1 { fooFunc1() {this.${SERVICE_NAME};} fooFunc2() { class MyClass2 { @service() ${SERVICE_NAME}; } } }`,
+      code: `${SERVICE_IMPORT} class MyClass1 { fooFunc1() {this.${SERVICE_NAME};} fooFunc2() { class MyClass2 { @service() ${SERVICE_NAME}; } } }`,
       output: null,
       errors: [
         {
@@ -435,7 +436,7 @@ ruleTester.run('no-unused-services', rule, {
           suggestions: [
             {
               messageId: 'removeServiceInjection',
-              output: `class MyClass1 { fooFunc1() {this.${SERVICE_NAME};} fooFunc2() { class MyClass2 {  } } }`,
+              output: `${SERVICE_IMPORT} class MyClass1 { fooFunc1() {this.${SERVICE_NAME};} fooFunc2() { class MyClass2 {  } } }`,
             },
           ],
           type: 'ClassProperty',

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -66,10 +66,12 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-    `export default Component.extend({
+    `
+      import Ember from 'ember';
+      import {inject as service} from '@ember/service';
+      export default Component.extend({
         abc: Ember.inject.service(),
-        def: inject.service(),
-        ghi: service(),
+        def: service(),
 
         role: "sloth",
 
@@ -80,8 +82,6 @@ eslintTester.run('order-in-components', rule, {
         import { inject } from '@ember/service';
         export default Component.extend({
           abc: inject(),
-          def: inject.service(),
-          ghi: service(),
 
           role: "sloth",
 
@@ -121,7 +121,9 @@ eslintTester.run('order-in-components', rule, {
           return true;
         }
       });`,
-    `export default Component.extend({
+    `
+      import {inject as service} from '@ember/service';
+      export default Component.extend({
         igh: service(),
 
         abc: [],
@@ -172,7 +174,9 @@ eslintTester.run('order-in-components', rule, {
 
         actions: {}
       });`,
-    `export default Component.extend({
+    `
+      import {inject as service} from '@ember/service';
+      export default Component.extend({
         test: service(),
 
         didReceiveAttrs() {
@@ -180,8 +184,11 @@ eslintTester.run('order-in-components', rule, {
 
         tSomeAction: task(function* (url) {
         })
-      });`,
-    `export default Component.extend({
+      });
+    `,
+    `
+      import {inject as service} from '@ember/service';
+      export default Component.extend({
         test: service(),
 
         test2: computed.equal("asd", "qwe"),
@@ -191,8 +198,11 @@ eslintTester.run('order-in-components', rule, {
 
         tSomeAction: task(function* (url) {
         }).restartable()
-      });`,
-    `export default Component.extend({
+      });
+    `,
+    `
+      import {inject as service} from '@ember/service';
+      export default Component.extend({
         test: service(),
 
         someEmptyMethod() {},
@@ -206,7 +216,8 @@ eslintTester.run('order-in-components', rule, {
         _anotherPrivateFnc() {
           return true;
         }
-      });`,
+      });
+    `,
     `export default Component.extend({
         classNameBindings: ["filterDateSelectClass"],
         content: [],
@@ -240,17 +251,20 @@ eslintTester.run('order-in-components', rule, {
         actions: {}
       });`,
     {
-      code: `export default Component.extend({
-        role: "sloth",
+      code: `
+        import Ember from 'ember';
+        export default Component.extend({
+          role: "sloth",
 
-        computed1: computed(function() {
-        }),
-        computed2: alias('computed1'),
+          computed1: computed(function() {
+          }),
+          computed2: alias('computed1'),
 
-        actions: {},
+          actions: {},
 
-        foobar: Ember.inject.service(),
-      });`,
+          foobar: Ember.inject.service(),
+        });
+      `,
       options: [
         {
           order: ['property', 'multi-line-function', 'single-line-function', 'actions'],
@@ -258,18 +272,21 @@ eslintTester.run('order-in-components', rule, {
       ],
     },
     {
-      code: `export default Component.extend({
-        role: "sloth",
+      code: `
+        import Ember from 'ember';
+        export default Component.extend({
+          role: "sloth",
 
-        computed1: alias('computed2'),
-        computed2: computed(function() {
-        }),
-        computed3: alias('computed1'),
+          computed1: alias('computed2'),
+          computed2: computed(function() {
+          }),
+          computed3: alias('computed1'),
 
-        actions: {},
+          actions: {},
 
-        foobar: Ember.inject.service(),
-      });`,
+          foobar: Ember.inject.service(),
+        });
+      `,
       options: [
         {
           order: ['property', ['single-line-function', 'multi-line-function'], 'actions'],
@@ -552,35 +569,39 @@ eslintTester.run('order-in-components', rule, {
       ],
     },
     {
-      code: `export default Component.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Component.extend({
         abc: true,
         i18n: service()
       });`,
-      output: `export default Component.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Component.extend({
         i18n: service(),
               abc: true,
 });`,
       errors: [
         {
-          message: 'The "i18n" service injection should be above the "abc" property on line 2',
-          line: 3,
+          message: 'The "i18n" service injection should be above the "abc" property on line 3',
+          line: 4,
         },
       ],
     },
     {
-      code: `export default Component.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Component.extend({
         vehicle: alias("car"),
         i18n: service()
       });`,
-      output: `export default Component.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Component.extend({
         i18n: service(),
               vehicle: alias("car"),
 });`,
       errors: [
         {
           message:
-            'The "i18n" service injection should be above the "vehicle" single-line function on line 2',
-          line: 3,
+            'The "i18n" service injection should be above the "vehicle" single-line function on line 3',
+          line: 4,
         },
       ],
     },

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -18,7 +18,9 @@ eslintTester.run('order-in-controllers', rule, {
   valid: [
     'export default Controller.extend();',
     'export default Controller.extend({ ...foo });',
-    `export default Controller.extend({
+    `
+      import {inject as service} from '@ember/service';
+      export default Controller.extend({
         application: controller(),
         currentUser: service(),
         queryParams: [],
@@ -28,7 +30,9 @@ eslintTester.run('order-in-controllers', rule, {
         _customAction2: function() { const foo = 'bar'; },
         tSomeTask: task(function* () {})
       });`,
-    `export default Controller.extend({
+    `
+      import {inject} from '@ember/service';
+      export default Controller.extend({
         currentUser: inject(),
         queryParams: [],
         customProp: "test",
@@ -68,10 +72,13 @@ eslintTester.run('order-in-controllers', rule, {
       ],
     },
     {
-      code: `export default Controller.extend({
-        queryParams: [],
-        currentUser: service(),
-      });`,
+      code: `
+        import {inject as service} from '@ember/service';
+        export default Controller.extend({
+          queryParams: [],
+          currentUser: service(),
+        });
+      `,
       options: [
         {
           order: ['query-params', 'service'],
@@ -90,33 +97,36 @@ eslintTester.run('order-in-controllers', rule, {
       ],
     },
     `
-        export default Controller.extend({
-          foo: service(),
-          someProp: null,
-          init() {
-            this._super(...arguments);
-          },
-          actions: {
-            onKeyPress: function (event) {}
-          }
-        });
-      `,
+      import {inject as service} from '@ember/service';
+      export default Controller.extend({
+        foo: service(),
+        someProp: null,
+        init() {
+          this._super(...arguments);
+        },
+        actions: {
+          onKeyPress: function (event) {}
+        }
+      });
+    `,
     `
-        export default Controller.extend({
-          foo: service(),
-          init() {
-            this._super(...arguments);
-          },
-          customFoo() {}
-        });
-      `,
-    `
-        export default Controller.extend({
-          foo: service(),
-          init() {
-            this._super(...arguments);
-          }
-        });
+      import {inject as service} from '@ember/service';
+      export default Controller.extend({
+        foo: service(),
+        init() {
+          this._super(...arguments);
+        },
+        customFoo() {}
+      });
+    `,
+    `      
+      import {inject as service} from '@ember/service';
+      export default Controller.extend({
+        foo: service(),
+        init() {
+          this._super(...arguments);
+        }
+      });
     `,
     {
       code: `export default Controller.extend({
@@ -136,54 +146,60 @@ eslintTester.run('order-in-controllers', rule, {
   ],
   invalid: [
     {
-      code: `export default Controller.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         queryParams: [],
         currentUser: service()
       });`,
-      output: `export default Controller.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         currentUser: service(),
               queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },
     {
-      code: `export default Controller.extend({
+      code: `import {inject} from '@ember/service';
+      export default Controller.extend({
         queryParams: [],
         currentUser: inject()
       });`,
-      output: `export default Controller.extend({
+      output: `import {inject} from '@ember/service';
+      export default Controller.extend({
         currentUser: inject(),
               queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },
     {
-      code: `export default Controller.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         currentUser: service(),
         customProp: "test",
         queryParams: []
       });`,
-      output: `export default Controller.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         currentUser: service(),
         queryParams: [],
               customProp: "test",
 });`,
       errors: [
         {
-          message: 'The "queryParams" property should be above the "customProp" property on line 3',
-          line: 4,
+          message: 'The "queryParams" property should be above the "customProp" property on line 4',
+          line: 5,
         },
       ],
     },
@@ -242,19 +258,21 @@ eslintTester.run('order-in-controllers', rule, {
       ],
     },
     {
-      code: `export default Controller.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         currentUser: service(),
         application: controller()
       });`,
-      output: `export default Controller.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         application: controller(),
               currentUser: service(),
 });`,
       errors: [
         {
           message:
-            'The "application" controller injection should be above the "currentUser" service injection on line 2',
-          line: 3,
+            'The "application" controller injection should be above the "currentUser" service injection on line 3',
+          line: 4,
         },
       ],
     },
@@ -280,60 +298,67 @@ eslintTester.run('order-in-controllers', rule, {
     },
     {
       filename: 'example-app/controllers/some-controller.js',
-      code: `export default CustomController.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default CustomController.extend({
         queryParams: [],
         currentUser: service()
       });`,
-      output: `export default CustomController.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default CustomController.extend({
         currentUser: service(),
               queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },
     {
       filename: 'example-app/some-feature/controller.js',
-      code: `export default CustomController.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default CustomController.extend({
         queryParams: [],
         currentUser: service()
       });`,
-      output: `export default CustomController.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default CustomController.extend({
         currentUser: service(),
               queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },
     {
       filename: 'example-app/twisted-path/some-controller.js',
-      code: `export default Controller.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         queryParams: [],
         currentUser: service()
       });`,
-      output: `export default Controller.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Controller.extend({
         currentUser: service(),
               queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           foo: service(),
           actions: {
@@ -345,6 +370,7 @@ eslintTester.run('order-in-controllers', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           foo: service(),
           init() {
@@ -357,13 +383,14 @@ eslintTester.run('order-in-controllers', rule, {
       `,
       errors: [
         {
-          message: 'The "init" lifecycle hook should be above the actions hash on line 4',
-          line: 7,
+          message: 'The "init" lifecycle hook should be above the actions hash on line 5',
+          line: 8,
         },
       ],
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           foo: service(),
           customFoo() {},
@@ -373,6 +400,7 @@ eslintTester.run('order-in-controllers', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           foo: service(),
           init() {
@@ -384,13 +412,14 @@ eslintTester.run('order-in-controllers', rule, {
       errors: [
         {
           message:
-            'The "init" lifecycle hook should be above the "customFoo" empty method on line 4',
-          line: 5,
+            'The "init" lifecycle hook should be above the "customFoo" empty method on line 5',
+          line: 6,
         },
       ],
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           init() {
             this._super(...arguments);
@@ -399,6 +428,7 @@ eslintTester.run('order-in-controllers', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           foo: service(),
                   init() {
@@ -410,8 +440,8 @@ eslintTester.run('order-in-controllers', rule, {
       errors: [
         {
           message:
-            'The "foo" service injection should be above the "init" lifecycle hook on line 3',
-          line: 6,
+            'The "foo" service injection should be above the "init" lifecycle hook on line 4',
+          line: 7,
         },
       ],
     },
@@ -442,19 +472,21 @@ eslintTester.run('order-in-controllers', rule, {
     {
       code:
         // whitespace is preserved inside `` and it's breaking the test
-        `export default Controller.extend({
+        `import {inject as service} from '@ember/service';
+        export default Controller.extend({
   queryParams: [],
   currentUser: service(),
 });`,
-      output: `export default Controller.extend({
+      output: `import {inject as service} from '@ember/service';
+        export default Controller.extend({
   currentUser: service(),
   queryParams: [],
 });`,
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the "queryParams" property on line 3',
+          line: 4,
         },
       ],
     },

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -18,7 +18,8 @@ eslintTester.run('order-in-routes', rule, {
   valid: [
     'export default Route.extend();',
     'export default Route.extend({ ...foo });',
-    `export default Route.extend({
+    `import {inject as service} from '@ember/service';
+      export default Route.extend({
         currentUser: service(),
         queryParams: {},
         customProp: "test",
@@ -40,7 +41,8 @@ eslintTester.run('order-in-routes', rule, {
         _customAction2: function() { const foo = 'bar'; },
         tSomeTask: task(function* () {})
       });`,
-    `export default Route.extend({
+    `import {inject} from '@ember/service';
+      export default Route.extend({
         currentUser: inject(),
         queryParams: {},
         customProp: "test",
@@ -84,7 +86,8 @@ eslintTester.run('order-in-routes', rule, {
         model() {}
       });`,
     {
-      code: `export default Route.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         model() {},
         beforeModel() {},
         currentUser: service(),
@@ -96,7 +99,8 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     {
-      code: `export default Route.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         deactivate() {},
         beforeModel() {},
         currentUser: service(),
@@ -109,7 +113,8 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     {
-      code: `export default Route.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         deactivate() {},
         setupController() {},
         beforeModel() {},
@@ -123,22 +128,24 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     `
-        export default Route.extend({
-          foo: service(),
-          init() {
-            this._super(...arguments);
-          },
-          actions: {}
-        });
-      `,
+      import {inject as service} from '@ember/service';
+      export default Route.extend({
+        foo: service(),
+        init() {
+          this._super(...arguments);
+        },
+        actions: {}
+      });
+    `,
     `
-        export default Route.extend({
-          foo: service(),
-          init() {
-            this._super(...arguments);
-          },
-          customFoo() {}
-        });
+      import {inject as service} from '@ember/service';
+      export default Route.extend({
+        foo: service(),
+        init() {
+          this._super(...arguments);
+        },
+        customFoo() {}
+      });
     `,
     {
       code: `export default Route.extend({
@@ -158,7 +165,8 @@ eslintTester.run('order-in-routes', rule, {
   ],
   invalid: [
     {
-      code: `export default Route.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         queryParams: {},
         currentUser: service(),
         customProp: "test",
@@ -168,7 +176,8 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      output: `export default Route.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         currentUser: service(),
         queryParams: {},
         customProp: "test",
@@ -181,18 +190,19 @@ eslintTester.run('order-in-routes', rule, {
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the inherited "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the inherited "queryParams" property on line 3',
+          line: 4,
         },
         {
           message:
-            'The "vehicle" single-line function should be above the "beforeModel" lifecycle hook on line 5',
-          line: 7,
+            'The "vehicle" single-line function should be above the "beforeModel" lifecycle hook on line 6',
+          line: 8,
         },
       ],
     },
     {
-      code: `export default Route.extend({
+      code: `import {inject} from '@ember/service';
+      export default Route.extend({
         queryParams: {},
         currentUser: inject(),
         customProp: "test",
@@ -202,7 +212,8 @@ eslintTester.run('order-in-routes', rule, {
         actions: {},
         _customAction() {}
       });`,
-      output: `export default Route.extend({
+      output: `import {inject} from '@ember/service';
+      export default Route.extend({
         currentUser: inject(),
         queryParams: {},
         customProp: "test",
@@ -215,13 +226,13 @@ eslintTester.run('order-in-routes', rule, {
       errors: [
         {
           message:
-            'The "currentUser" service injection should be above the inherited "queryParams" property on line 2',
-          line: 3,
+            'The "currentUser" service injection should be above the inherited "queryParams" property on line 3',
+          line: 4,
         },
         {
           message:
-            'The "vehicle" single-line function should be above the "beforeModel" lifecycle hook on line 5',
-          line: 7,
+            'The "vehicle" single-line function should be above the "beforeModel" lifecycle hook on line 6',
+          line: 8,
         },
       ],
     },
@@ -355,7 +366,8 @@ eslintTester.run('order-in-routes', rule, {
       ],
     },
     {
-      code: `export default Route.extend({
+      code: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         currentUser: service(),
         queryParams: {},
         customProp: "test",
@@ -377,7 +389,8 @@ eslintTester.run('order-in-routes', rule, {
         _customAction2: function() {},
         tSomeTask: task(function* () {})
       });`,
-      output: `export default Route.extend({
+      output: `import {inject as service} from '@ember/service';
+      export default Route.extend({
         currentUser: service(),
         queryParams: {},
         customProp: "test",
@@ -402,28 +415,28 @@ eslintTester.run('order-in-routes', rule, {
       errors: [
         {
           message:
-            'The "redirect" lifecycle hook should be above the "setupController" lifecycle hook on line 11',
-          line: 12,
-        },
-        {
-          message:
-            'The "serialize" lifecycle hook should be above the "setupController" lifecycle hook on line 11',
+            'The "redirect" lifecycle hook should be above the "setupController" lifecycle hook on line 12',
           line: 13,
         },
         {
           message:
-            'The "activate" lifecycle hook should be above the "setupController" lifecycle hook on line 11',
+            'The "serialize" lifecycle hook should be above the "setupController" lifecycle hook on line 12',
           line: 14,
         },
         {
           message:
-            'The "renderTemplate" lifecycle hook should be above the "deactivate" lifecycle hook on line 15',
-          line: 16,
+            'The "activate" lifecycle hook should be above the "setupController" lifecycle hook on line 12',
+          line: 15,
         },
         {
           message:
-            'The "resetController" lifecycle hook should be above the "deactivate" lifecycle hook on line 15',
+            'The "renderTemplate" lifecycle hook should be above the "deactivate" lifecycle hook on line 16',
           line: 17,
+        },
+        {
+          message:
+            'The "resetController" lifecycle hook should be above the "deactivate" lifecycle hook on line 16',
+          line: 18,
         },
       ],
     },
@@ -498,6 +511,7 @@ eslintTester.run('order-in-routes', rule, {
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           foo: service(),
           actions: {},
@@ -507,6 +521,7 @@ eslintTester.run('order-in-routes', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           foo: service(),
           init() {
@@ -517,13 +532,14 @@ eslintTester.run('order-in-routes', rule, {
       `,
       errors: [
         {
-          message: 'The "init" lifecycle hook should be above the actions hash on line 4',
-          line: 5,
+          message: 'The "init" lifecycle hook should be above the actions hash on line 5',
+          line: 6,
         },
       ],
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           foo: service(),
           customFoo() {},
@@ -533,6 +549,7 @@ eslintTester.run('order-in-routes', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           foo: service(),
           init() {
@@ -544,13 +561,14 @@ eslintTester.run('order-in-routes', rule, {
       errors: [
         {
           message:
-            'The "init" lifecycle hook should be above the "customFoo" empty method on line 4',
-          line: 5,
+            'The "init" lifecycle hook should be above the "customFoo" empty method on line 5',
+          line: 6,
         },
       ],
     },
     {
       code: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           init() {
             this._super(...arguments);
@@ -559,6 +577,7 @@ eslintTester.run('order-in-routes', rule, {
         });
       `,
       output: `
+        import {inject as service} from '@ember/service';
         export default Route.extend({
           foo: service(),
                   init() {
@@ -569,8 +588,8 @@ eslintTester.run('order-in-routes', rule, {
       errors: [
         {
           message:
-            'The "foo" service injection should be above the "init" lifecycle hook on line 3',
-          line: 6,
+            'The "foo" service injection should be above the "init" lifecycle hook on line 4',
+          line: 7,
         },
       ],
     },

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -776,32 +776,38 @@ describe('isInjectedServiceProp', () => {
   describe('classic classes', () => {
     it("should check if it's an injected service prop with renamed import", () => {
       const context = new FauxContext(`
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           currentUser: service()
         });
       `);
-      const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
     });
 
     it("should check if it's an injected service prop with full import", () => {
       const context = new FauxContext(`
+        import Ember from 'ember';
         export default Controller.extend({
           currentUser: Ember.inject.service()
         });
       `);
-      const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeTruthy();
     });
 
     it("should check if it's an injected service prop with destructured import", () => {
       const context = new FauxContext(`
+        import {inject} from '@ember/service';
         export default Controller.extend({
           currentUser: inject()
         });
       `);
-      const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
     });
 
     it("should check that it's not an injected service prop", () => {
@@ -816,34 +822,40 @@ describe('isInjectedServiceProp', () => {
 
     it("should check that it's not an injected service prop when 'service' is not a function", () => {
       const context = new FauxContext(`
+        import {inject as service} from '@ember/service';
         export default Controller.extend({
           currentUser: service.otherFunction()
         });
       `);
-      const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeFalsy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeFalsy();
     });
   });
 
   describe('native classes', () => {
     it("should check if it's an injected service prop when using renamed import", () => {
       const context = new FauxContext(`
+        import {inject as service} from '@ember/service';
         class MyController extends Controller {
           @service currentUser;
         }
       `);
-      const node = context.ast.body[0].body.body[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].body.body[0];
+      expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
     });
 
     it("should check if it's an injected service prop when using decorator", () => {
       const context = new FauxContext(`
+        import {inject} from '@ember/service';
         class MyController extends Controller {
           @inject currentUser;
         }
       `);
-      const node = context.ast.body[0].body.body[0];
-      expect(emberUtils.isInjectedServiceProp(node)).toBeTruthy();
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].body.body[0];
+      expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
     });
 
     it("should check that it's not an injected service prop when using another decorator", () => {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -853,7 +853,7 @@ describe('isInjectedServiceProp', () => {
       const node = context.ast.body[1].declaration.arguments[0].properties[0];
       expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
     });
-    
+
     it("should check that it's not an injected service prop with Ember.foo.service", () => {
       const context = new FauxContext(`
         import Ember from 'ember';

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -810,6 +810,72 @@ describe('isInjectedServiceProp', () => {
       expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
     });
 
+    it("should check that it's not an injected service prop without the renamed import", () => {
+      const context = new FauxContext(`
+        export default Controller.extend({
+          currentUser: service()
+        });
+      `);
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node)).toBeFalsy();
+    });
+
+    it("should check that it's not an injected service prop without the full import", () => {
+      const context = new FauxContext(`
+        export default Controller.extend({
+          currentUser: Ember.inject.service()
+        });
+      `);
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node)).toBeFalsy();
+    });
+
+    it("should check that it's not an injected service prop with Ember.inject", () => {
+      const context = new FauxContext(`
+        import Ember from 'ember';
+        export default Controller.extend({
+          currentUser: Ember.inject()
+        });
+      `);
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
+    });
+
+    it("should check that it's not an injected service prop with Ember.inject.foo", () => {
+      const context = new FauxContext(`
+        import Ember from 'ember';
+        export default Controller.extend({
+          currentUser: Ember.inject.foo()
+        });
+      `);
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
+    });
+
+    it("should check that it's not an injected service prop with Ember.service.foo", () => {
+      const context = new FauxContext(`
+        import Ember from 'ember';
+        export default Controller.extend({
+          currentUser: Ember.service.foo()
+        });
+      `);
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
+    });
+
+    it("should check that it's not an injected service prop with foo.service.inject", () => {
+      const context = new FauxContext(`
+        export default Controller.extend({
+          currentUser: Ember.service.foo()
+        });
+      `);
+      const node = context.ast.body[0].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node)).toBeFalsy();
+    });
+
     it("should check that it's not an injected service prop", () => {
       const context = new FauxContext(`
         export default Controller.extend({
@@ -856,6 +922,16 @@ describe('isInjectedServiceProp', () => {
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].body.body[0];
       expect(emberUtils.isInjectedServiceProp(node, undefined, importName)).toBeTruthy();
+    });
+
+    it("should check that it's not an injected service prop without an import", () => {
+      const context = new FauxContext(`
+        class MyController extends Controller {
+          @service currentUser;
+        }
+      `);
+      const node = context.ast.body[0].body.body[0];
+      expect(emberUtils.isInjectedServiceProp(node)).toBeFalsy();
     });
 
     it("should check that it's not an injected service prop when using another decorator", () => {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -853,6 +853,18 @@ describe('isInjectedServiceProp', () => {
       const node = context.ast.body[1].declaration.arguments[0].properties[0];
       expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
     });
+    
+    it("should check that it's not an injected service prop with Ember.foo.service", () => {
+      const context = new FauxContext(`
+        import Ember from 'ember';
+        export default Controller.extend({
+          currentUser: Ember.foo.service()
+        });
+      `);
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(emberUtils.isInjectedServiceProp(node, importName, undefined)).toBeFalsy();
+    });
 
     it("should check that it's not an injected service prop with Ember.service.foo", () => {
       const context = new FauxContext(`
@@ -869,7 +881,7 @@ describe('isInjectedServiceProp', () => {
     it("should check that it's not an injected service prop with foo.service.inject", () => {
       const context = new FauxContext(`
         export default Controller.extend({
-          currentUser: Ember.service.foo()
+          currentUser: foo.service.inject()
         });
       `);
       const node = context.ast.body[0].declaration.arguments[0].properties[0];

--- a/tests/lib/utils/property-order-test.js
+++ b/tests/lib/utils/property-order-test.js
@@ -57,7 +57,9 @@ describe('determinePropertyType', () => {
       );
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].declaration.arguments[0].properties[0];
-      expect(propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)).toStrictEqual('service');
+      expect(
+        propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)
+      ).toStrictEqual('service');
     });
 
     it('should determine controller-type props', () => {
@@ -270,7 +272,9 @@ describe('determinePropertyType', () => {
       );
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].body.body[0];
-      expect(propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)).toStrictEqual('service');
+      expect(
+        propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)
+      ).toStrictEqual('service');
     });
 
     it('should determine controller-type props', () => {
@@ -388,7 +392,14 @@ describe('reportUnorderedProperties', () => {
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
+      propertyOrder.reportUnorderedProperties(
+        node,
+        context,
+        'controller',
+        order,
+        undefined,
+        importName
+      );
       expect(context.report).not.toHaveBeenCalled();
     });
 
@@ -407,7 +418,14 @@ describe('reportUnorderedProperties', () => {
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
+      propertyOrder.reportUnorderedProperties(
+        node,
+        context,
+        'controller',
+        order,
+        undefined,
+        importName
+      );
       expect(context.report).toHaveBeenCalled(); // eslint-disable-line jest/prefer-called-with
     });
   });
@@ -428,7 +446,14 @@ describe('reportUnorderedProperties', () => {
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
+      propertyOrder.reportUnorderedProperties(
+        node,
+        context,
+        'controller',
+        order,
+        undefined,
+        importName
+      );
       expect(context.report).not.toHaveBeenCalled();
     });
 
@@ -447,7 +472,14 @@ describe('reportUnorderedProperties', () => {
       const importName = context.ast.body[0].specifiers[0].local.name;
       const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
+      propertyOrder.reportUnorderedProperties(
+        node,
+        context,
+        'controller',
+        order,
+        undefined,
+        importName
+      );
       expect(context.report).toHaveBeenCalled(); // eslint-disable-line jest/prefer-called-with
     });
   });

--- a/tests/lib/utils/property-order-test.js
+++ b/tests/lib/utils/property-order-test.js
@@ -50,12 +50,14 @@ describe('determinePropertyType', () => {
   describe('classic classes', () => {
     it('should determine service-type props', () => {
       const context = new FauxContext(
-        `export default Controller.extend({
+        `import {inject as service} from '@ember/service';
+        export default Controller.extend({
           currentUser: service(),
         });`
       );
-      const node = context.ast.body[0].declaration.arguments[0].properties[0];
-      expect(propertyOrder.determinePropertyType(node, 'controller')).toStrictEqual('service');
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration.arguments[0].properties[0];
+      expect(propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)).toStrictEqual('service');
     });
 
     it('should determine controller-type props', () => {
@@ -261,12 +263,14 @@ describe('determinePropertyType', () => {
   describe('native classes', () => {
     it('should determine service-type props', () => {
       const context = new FauxContext(
-        `class MyController extends Controller {
+        `import {inject as service} from '@ember/service';
+        class MyController extends Controller {
           @service currentUser;
         }`
       );
-      const node = context.ast.body[0].body.body[0];
-      expect(propertyOrder.determinePropertyType(node, 'controller')).toStrictEqual('service');
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].body.body[0];
+      expect(propertyOrder.determinePropertyType(node, 'controller', [], undefined, importName)).toStrictEqual('service');
     });
 
     it('should determine controller-type props', () => {
@@ -372,34 +376,38 @@ describe('reportUnorderedProperties', () => {
     it('should not report nodes if the order is correct', () => {
       const order = ['controller', 'service', 'query-params'];
       const context = new FauxContext(
-        `export default Controller.extend({
-        application: controller(),
-        currentUser: service(),
-        queryParams: [],
-      });`,
+        `import {inject as service} from '@ember/service';
+          export default Controller.extend({
+          application: controller(),
+          currentUser: service(),
+          queryParams: [],
+        });`,
         '',
         jest.fn()
       );
-      const node = context.ast.body[0].declaration;
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order);
+      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
       expect(context.report).not.toHaveBeenCalled();
     });
 
     it('should report nodes if the order is incorrect', () => {
       const order = ['controller', 'service', 'query-params'];
       const context = new FauxContext(
-        `export default Controller.extend({
-          currentUser: service(),
-          application: controller(),
-          queryParams: [],
-        });`,
+        `import {inject as service} from '@ember/service';
+          export default Controller.extend({
+            currentUser: service(),
+            application: controller(),
+            queryParams: [],
+          });`,
         '',
         jest.fn()
       );
-      const node = context.ast.body[0].declaration;
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order);
+      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
       expect(context.report).toHaveBeenCalled(); // eslint-disable-line jest/prefer-called-with
     });
   });
@@ -408,34 +416,38 @@ describe('reportUnorderedProperties', () => {
     it('should not report nodes if the order is correct', () => {
       const order = ['controller', 'service', 'query-params'];
       const context = new FauxContext(
-        `export default class MyController extends Controller {
-          @controller application;
-          @service currentUser;
-          queryParams = [];
-        }`,
+        `import {inject as service} from '@ember/service';
+          export default class MyController extends Controller {
+            @controller application;
+            @service currentUser;
+            queryParams = [];
+          }`,
         '',
         jest.fn()
       );
-      const node = context.ast.body[0].declaration;
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order);
+      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
       expect(context.report).not.toHaveBeenCalled();
     });
 
     it('should report nodes if the order is incorrect', () => {
       const order = ['controller', 'service', 'query-params'];
       const context = new FauxContext(
-        `export default class MyController extends Controller {
-          @service currentUser;
-          @controller application;
-          queryParams = [];
-        }`,
+        `import {inject as service} from '@ember/service';
+          export default class MyController extends Controller {
+            @service currentUser;
+            @controller application;
+            queryParams = [];
+          }`,
         '',
         jest.fn()
       );
-      const node = context.ast.body[0].declaration;
+      const importName = context.ast.body[0].specifiers[0].local.name;
+      const node = context.ast.body[1].declaration;
 
-      propertyOrder.reportUnorderedProperties(node, context, 'controller', order);
+      propertyOrder.reportUnorderedProperties(node, context, 'controller', order, undefined, importName);
       expect(context.report).toHaveBeenCalled(); // eslint-disable-line jest/prefer-called-with
     });
   });


### PR DESCRIPTION
Fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1155

This PR fixes `ember.isInjectedServiceProp` to look at the imported names of `Ember` and `injected` and updates the rules + tests that use this accordingly.