### PR TITLE
Improve robustness of classic class body detection in several rules using `getModuleProperties` util

### DIFF
--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -28,13 +28,16 @@ module.exports = {
       context.report(node, message);
     };
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       CallExpression(node) {
         if (!ember.isEmberController(context, node)) {
           return;
         }
 
-        const properties = ember.getModuleProperties(node);
+        const properties = ember.getModuleProperties(node, scopeManager);
         let aliasPresent = false;
 
         for (const property of properties) {

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -80,6 +80,9 @@ module.exports = {
       context.report(node, message);
     };
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       CallExpression(node) {
         if (
@@ -92,7 +95,7 @@ module.exports = {
           return;
         }
 
-        const properties = ember.getModuleProperties(node);
+        const properties = ember.getModuleProperties(node, scopeManager);
 
         for (const property of properties.filter(
           (property) => property.key && !ignoredProperties.includes(property.key.name)

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -27,6 +27,9 @@ module.exports = {
       context.report(node, message);
     };
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       CallExpression(node) {
         const isReopenNode = ember.isReopenObject(node) || ember.isReopenClassObject(node);
@@ -35,7 +38,7 @@ module.exports = {
           return;
         }
 
-        const properties = ember.getModuleProperties(node);
+        const properties = ember.getModuleProperties(node, scopeManager);
 
         for (const property of properties) {
           if (

--- a/lib/rules/no-actions-hash.js
+++ b/lib/rules/no-actions-hash.js
@@ -19,6 +19,9 @@ module.exports = {
   },
 
   create: (context) => {
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     function reportActionsProp(properties) {
       const actionsProp = properties.find((property) => ember.isActionsProp(property));
       if (actionsProp) {
@@ -34,7 +37,7 @@ module.exports = {
       },
       CallExpression(node) {
         if (inClassWhichCanContainActions(context, node)) {
-          reportActionsProp(ember.getModuleProperties(node));
+          reportActionsProp(ember.getModuleProperties(node, scopeManager));
         }
       },
     };

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -28,13 +28,16 @@ module.exports = {
       context.report(node, message);
     };
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       CallExpression(node) {
         if (!ember.isDSModel(node, filePath)) {
           return;
         }
 
-        const allProperties = ember.getModuleProperties(node);
+        const allProperties = ember.getModuleProperties(node, scopeManager);
         const isDSAttr = allProperties.filter((property) =>
           ember.isModule(property.value, 'attr', 'DS')
         );

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -140,6 +140,9 @@ module.exports = {
 
     const filename = context.getFilename();
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     // Skip mirage directory
     if (emberUtils.isMirageConfig(filename)) {
       return {};
@@ -177,7 +180,7 @@ module.exports = {
         if (emberUtils.isEmberProxy(context, node)) {
           currentProxyObject = node; // Keep track of being inside a proxy object.
         }
-        if (emberUtils.isEmberObjectImplementingUnknownProperty(node)) {
+        if (emberUtils.isEmberObjectImplementingUnknownProperty(node, scopeManager)) {
           currentClassWithUnknownPropertyMethod = node; // Keep track of being inside an object implementing `unknownProperty`.
         }
       },
@@ -191,7 +194,7 @@ module.exports = {
         if (emberUtils.isEmberProxy(context, node)) {
           currentProxyObject = node; // Keep track of being inside a proxy object.
         }
-        if (emberUtils.isEmberObjectImplementingUnknownProperty(node)) {
+        if (emberUtils.isEmberObjectImplementingUnknownProperty(node, scopeManager)) {
           currentClassWithUnknownPropertyMethod = node;
         }
         if (currentProxyObject || currentClassWithUnknownPropertyMethod) {

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -62,13 +62,18 @@ module.exports = {
       context.report(node, message);
     };
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       CallExpression(node) {
         if (!ember.isEmberComponent(context, node)) {
           return;
         }
 
-        const propertiesWithOnCalls = ember.getModuleProperties(node).filter(isOnCall);
+        const propertiesWithOnCalls = ember
+          .getModuleProperties(node, scopeManager)
+          .filter(isOnCall);
 
         if (propertiesWithOnCalls.length > 0) {
           for (const property of propertiesWithOnCalls) {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -89,6 +89,9 @@ module.exports = {
     let importedInjectName;
     let importedEmberName;
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       ImportDeclaration(node) {
         if (node.source.value === 'ember') {
@@ -110,7 +113,8 @@ module.exports = {
           'component',
           order,
           importedEmberName,
-          importedInjectName
+          importedInjectName,
+          scopeManager
         );
       },
     };

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -61,6 +61,9 @@ module.exports = {
     let importedInjectName;
     let importedEmberName;
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       ImportDeclaration(node) {
         if (node.source.value === 'ember') {
@@ -82,7 +85,8 @@ module.exports = {
           'controller',
           order,
           importedEmberName,
-          importedInjectName
+          importedInjectName,
+          scopeManager
         );
       },
     };

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -56,6 +56,9 @@ module.exports = {
     let importedInjectName;
     let importedEmberName;
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       ImportDeclaration(node) {
         if (node.source.value === 'ember') {
@@ -77,7 +80,8 @@ module.exports = {
           'model',
           order,
           importedEmberName,
-          importedInjectName
+          importedInjectName,
+          scopeManager
         );
       },
     };

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -84,6 +84,9 @@ module.exports = {
     let importedInjectName;
     let importedEmberName;
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       ImportDeclaration(node) {
         if (node.source.value === 'ember') {
@@ -104,7 +107,8 @@ module.exports = {
           'route',
           order,
           importedEmberName,
-          importedInjectName
+          importedInjectName,
+          scopeManager
         );
       },
     };

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -6,6 +6,8 @@ const importUtils = require('./import');
 const types = require('./types');
 const assert = require('assert');
 const decoratorUtils = require('../utils/decorators');
+const { getNodeOrNodeFromVariable } = require('../utils/utils');
+const { flatMap } = require('../utils/javascript');
 
 module.exports = {
   isDSModel,
@@ -548,9 +550,13 @@ function isControllerDefaultProp(property) {
   );
 }
 
-function getModuleProperties(module) {
-  const firstObjectExpressionNode = utils.findNodes(module.arguments, 'ObjectExpression')[0];
-  return firstObjectExpressionNode ? firstObjectExpressionNode.properties : [];
+function getModuleProperties(moduleNode, scopeManager) {
+  return flatMap(moduleNode.arguments, (arg) => {
+    const resultingNode = getNodeOrNodeFromVariable(arg, scopeManager);
+    return resultingNode && resultingNode.type === 'ObjectExpression'
+      ? resultingNode.properties
+      : [];
+  });
 }
 
 /**
@@ -675,13 +681,13 @@ function unwrapBraceExpressions(dependentKeys) {
   return unwrappedExpressions.reduce((acc, cur) => acc.concat(cur), []);
 }
 
-function isEmberObjectImplementingUnknownProperty(node) {
+function isEmberObjectImplementingUnknownProperty(node, scopeManager) {
   if (types.isCallExpression(node)) {
     if (!isExtendObject(node) && !isReopenObject(node)) {
       return false;
     }
     // Classic class.
-    const properties = getModuleProperties(node);
+    const properties = getModuleProperties(node, scopeManager);
     return properties.some(
       (property) => types.isIdentifier(property.key) && property.key.name === 'unknownProperty'
     );

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -194,7 +194,8 @@ function reportUnorderedProperties(
   parentType,
   ORDER,
   importedEmberName,
-  importedInjectName
+  importedInjectName,
+  scopeManager
 ) {
   let maxOrder = -1;
   const firstPropertyOfType = {};
@@ -202,7 +203,7 @@ function reportUnorderedProperties(
 
   const properties = types.isClassDeclaration(node)
     ? node.body.body
-    : ember.getModuleProperties(node);
+    : ember.getModuleProperties(node, scopeManager);
 
   for (const property of properties) {
     const type = determinePropertyType(

--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -27,6 +27,7 @@ eslintTester.run('alias-model-in-controller', rule, {
     'export default Ember.Controller.extend({nail: computed.reads("model")});',
     'export default Ember.Controller.extend({nail: Ember.computed.reads("model")});',
     'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model")});',
+    'const body = {nail: Ember.computed.alias("model")}; export default Ember.Controller.extend(TestMixin, body);', // With object variable.
     'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
     {
       filename: 'example-app/controllers/path/to/some-feature.js',

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -84,6 +84,17 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
       ],
     },
     {
+      // With object variable.
+      code: 'const body = {someProp: []}; export default Foo.extend(body);',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
       code: 'export default Foo.extend({someProp: new Ember.A()});',
       output: null,
       errors: [

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -39,6 +39,17 @@ eslintTester.run('avoid-using-needs-in-controllers', rule, {
       ],
     },
     {
+      // With object variable.
+      code: 'const body = { needs: [] }; export default Controller.extend(body);',
+      output: null,
+      errors: [
+        {
+          message:
+            '`needs` API has been deprecated, `Ember.inject.controller` should be used instead',
+        },
+      ],
+    },
+    {
       code: 'Controller.reopenClass({ needs: [] });',
       output: null,
       errors: [

--- a/tests/lib/rules/no-actions-hash.js
+++ b/tests/lib/rules/no-actions-hash.js
@@ -83,6 +83,12 @@ ruleTester.run('no-actions-hash', rule, {
       errors: [{ type: 'Property', message: ERROR_MESSAGE }],
     },
     {
+      // With object variable.
+      code: 'const body = { actions: { } }; export default Component.extend(body); ',
+      output: null,
+      errors: [{ type: 'Property', message: ERROR_MESSAGE }],
+    },
+    {
       code: `
         import Component from '@ember/component';
         export default class MyComponent extends Component {

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -43,6 +43,12 @@ eslintTester.run('no-empty-attrs', rule, {
       errors: [{ message, line: 2 }],
     },
     {
+      // With object variable.
+      code: 'const body = {name: attr()}; export default Model.extend(body);',
+      output: null,
+      errors: [{ message, line: 1 }],
+    },
+    {
       code: `export default Model.extend({
         name: attr("string"),
         points: attr("number"),

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -52,6 +52,13 @@ eslintTester.run('no-on-calls-in-components', rule, {
       errors: [{ message, line: 2 }],
     },
     {
+      // With object variable.
+      code:
+        'const body = { test: on("didInsertElement", function () {}) }; export default Component.extend(body);',
+      output: null,
+      errors: [{ message, line: 1 }],
+    },
+    {
       code: `export default Component.extend({
         test: on("init", observer("someProperty", function () {
           return true;


### PR DESCRIPTION
Several rules use the `getModuleProperties` to get the properties in a classic class body. There were a few problems with this:
* Did not handle when the object was passed in as a variable: `const body = {someProp: []}; export default Component.extend(body);`
* Did not handle when there were multiple objects passed in: `export default Component.extend({ ... }, { ... });`