### PR TITLE
Handle both `babel-eslint` and `@babel/eslint-parser` spread syntax in `order-in-*` rules

### DIFF
--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -132,7 +132,8 @@ function determinePropertyType(node, parentType, ORDER, importedEmberName, impor
     return 'method';
   }
 
-  if (node.type === 'ExperimentalSpreadProperty') {
+  // Handle both babel-eslint and @babel/eslint-parser
+  if (node.type === 'ExperimentalSpreadProperty' || node.type === 'SpreadElement') {
     return 'spread';
   }
 


### PR DESCRIPTION
https://github.com/babel/babel-eslint#note-babel-eslint-is-now-babeleslint-parser-and-has-moved-into-the-babel-monorepo