### PR TITLE
Switch from `babel-eslint` to `@babel/eslint-parser`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }]
+  ]
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   root: true,
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'script',
+    babelOptions: {
+      configFile: require.resolve('./.babelrc'),
+    },
   },
   plugins: ['eslint-plugin', 'filenames', 'import', 'jest', 'node', 'prettier', 'unicorn'],
   extends: [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "snake-case": "^3.0.3"
   },
   "devDependencies": {
-    "babel-eslint": "^10.1.0",
+    "@babel/eslint-parser": "^7.13.14",
+    "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-proposal-decorators": "^7.13.15",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/tests/helpers/babel-eslint-parser.js
+++ b/tests/helpers/babel-eslint-parser.js
@@ -1,0 +1,22 @@
+const babelEslint = require('@babel/eslint-parser');
+
+function parse(code) {
+  return babelEslint.parse(code, {
+    babelOptions: {
+      configFile: require.resolve('../../.babelrc'),
+    },
+  });
+}
+
+function parseForESLint(code) {
+  return babelEslint.parseForESLint(code, {
+    babelOptions: {
+      configFile: require.resolve('../../.babelrc'),
+    },
+  });
+}
+
+module.exports = {
+  parse,
+  parseForESLint,
+};

--- a/tests/helpers/faux-context.js
+++ b/tests/helpers/faux-context.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parseForESLint } = require('../helpers/babel-eslint-parser');
 
 /**
  * Builds a fake ESLint context object that's enough to satisfy the contract
@@ -8,7 +8,7 @@ const babelEslint = require('babel-eslint');
  */
 class FauxContext {
   constructor(code, filename = '', report = () => {}) {
-    const { ast } = babelEslint.parseForESLint(code);
+    const { ast } = parseForESLint(code);
 
     this.ast = ast;
     this.filename = filename;

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -26,7 +26,7 @@ describe('imports', () => {
 });
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -10,7 +10,7 @@ const {
 } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { disallowedMethodErrorMessage } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 eslintTester.run('new-module-imports', rule, {
   valid: [

--- a/tests/lib/rules/no-actions-hash.js
+++ b/tests/lib/rules/no-actions-hash.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 ruleTester.run('no-actions-hash', rule, {

--- a/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -12,10 +12,13 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
+    babelOptions: {
+      configFile: require.resolve('../../../.babelrc'),
+    },
   },
 });
 

--- a/tests/lib/rules/no-attrs-in-components.js
+++ b/tests/lib/rules/no-attrs-in-components.js
@@ -15,7 +15,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('no-attrs-in-components', rule, {

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('no-attrs-snapshot', rule, {

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-controllers.js
+++ b/tests/lib/rules/no-controllers.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 ruleTester.run('no-controllers', rule, {

--- a/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-duplicate-dependent-keys.js
+++ b/tests/lib/rules/no-duplicate-dependent-keys.js
@@ -14,7 +14,7 @@ const { addComputedImport } = require('../../helpers/test-case');
 
 const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE_GET, ERROR_MESSAGE_GET_PROPERTIES } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/tests/lib/rules/no-incorrect-computed-macros.js
+++ b/tests/lib/rules/no-incorrect-computed-macros.js
@@ -13,7 +13,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE_AND_OR } = rule;
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -16,7 +16,7 @@ const {
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -19,7 +19,7 @@ const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGES } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 ruleTester.run('no-restricted-resolver-tests', rule, {

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -7,7 +7,7 @@ const EMBER_IMPORT = "import Ember from 'ember';";
 const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/tests/lib/rules/no-settled-after-test-helper.js
+++ b/tests/lib/rules/no-settled-after-test-helper.js
@@ -4,7 +4,7 @@ const rule = require('../../../lib/rules/no-settled-after-test-helper');
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -12,7 +12,7 @@ const { buildErrorMessage } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 
@@ -47,7 +47,7 @@ eslintTester.run('no-side-effects', rule, {
           get fullName() { return this.first + ' ' + this.last; }
         }
       `,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -61,7 +61,7 @@ eslintTester.run('no-side-effects', rule, {
           get fullName() { return 'foo'; }
         }
       `,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -219,7 +219,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -236,7 +236,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -253,7 +253,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',

--- a/tests/lib/rules/no-string-prototype-extensions.js
+++ b/tests/lib/rules/no-string-prototype-extensions.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
 });
 

--- a/tests/lib/rules/no-unnecessary-route-path-option.js
+++ b/tests/lib/rules/no-unnecessary-route-path-option.js
@@ -11,7 +11,7 @@ const { ERROR_MESSAGE } = rule;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parser: require.resolve('babel-eslint') });
+const ruleTester = new RuleTester({ parser: require.resolve('@babel/eslint-parser') });
 ruleTester.run('no-unnecessary-route-path-option', rule, {
   valid: [
     'this.route("blog");',

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2015,
     sourceType: 'module',
   },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 ruleTester.run('no-unnecessary-service-injection-argument', rule, {
@@ -32,7 +32,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service() });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service serviceName }`,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -41,7 +41,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     },
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service() serviceName }`,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -57,7 +57,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ serviceName: service('service-name') });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service("service-name") serviceName }`,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -70,7 +70,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     `${RENAMED_SERVICE_IMPORT} const controller = Controller.extend({ specialName: service('service-name') });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service("specialName") serviceName }`,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -88,7 +88,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     `${SERVICE_IMPORT} export default Component.extend({ serviceName: service(\`serviceName\`) });`,
     {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service(\`specialName\`) serviceName }`,
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -102,7 +102,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
     "export default Component.extend({ serviceName: inject.otherFunction('serviceName') });",
     {
       code: 'class Test { @otherDecorator("name") name }',
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -142,7 +142,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service("serviceName") serviceName }`,
       output: `${RENAMED_SERVICE_IMPORT} class Test { @service() serviceName }`,
       errors: [{ message: ERROR_MESSAGE, type: 'Literal' }],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -14,7 +14,7 @@ const ruleTester = new RuleTester({
     ecmaVersion: 6,
     sourceType: 'module',
   },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 const SERVICE_NAME = 'fooName';

--- a/tests/lib/rules/no-volatile-computed-properties.js
+++ b/tests/lib/rules/no-volatile-computed-properties.js
@@ -25,7 +25,7 @@ ruleTester.run('no-volatile-computed-properties', rule, {
     {
       // Decorator:
       code: "class Test { @computed('prop') get someProp() {} }",
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
@@ -52,17 +52,20 @@ ruleTester.run('no-volatile-computed-properties', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
     },
 
+    /*
+    // This is invalid syntax according to @babel/eslint-parser.
     {
       // Decorator:
       code: "class Test { @computed('prop').volatile() get someProp() {} }",
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
     },
+    */
   ].map(addComputedImport),
 });

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('order-in-components', rule, {

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('order-in-controllers', rule, {
@@ -119,7 +119,7 @@ eslintTester.run('order-in-controllers', rule, {
         customFoo() {}
       });
     `,
-    `      
+    `
       import {inject as service} from '@ember/service';
       export default Controller.extend({
         foo: service(),

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('order-in-models', rule, {

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('order-in-routes', rule, {

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -25,7 +25,7 @@ const {
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE_NON_STRING_VALUE } = rule;
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -28,7 +28,7 @@ eslintTester.run('require-return-from-computed', rule, {
       // This rule intentionally does not apply to native classes / decorator usage.
       // ESLint already has its own recommended rules `getter-return` and `no-setter-return` for this.
       code: 'class Test { @computed() get someProp() {} set someProp(val) {} }',
-      parser: require.resolve('babel-eslint'),
+      parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE: message } = rule;
 
 const eslintTester = new RuleTester({
   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 
 eslintTester.run('require-super-in-lifecycle-hooks', rule, {

--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS: ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -16,7 +16,7 @@ const ruleTester = new RuleTester({
     ecmaVersion: 6,
     sourceType: 'module',
   },
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
 });
 ruleTester.run('route-path-style', rule, {
   valid: [

--- a/tests/lib/rules/routes-segments-snake-case.js
+++ b/tests/lib/rules/routes-segments-snake-case.js
@@ -9,7 +9,7 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const eslintTester = new RuleTester({ parser: require.resolve('babel-eslint') });
+const eslintTester = new RuleTester({ parser: require.resolve('@babel/eslint-parser') });
 eslintTester.run('routes-segments-snake-case', rule, {
   valid: [
     'this.route("tree", { path: ":tree_id"});',

--- a/tests/lib/rules/use-brace-expansion.js
+++ b/tests/lib/rules/use-brace-expansion.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parser: require.resolve('babel-eslint'),
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -15,7 +15,10 @@ const { ERROR_MESSAGE: message } = rule;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions, parser: require.resolve('babel-eslint') });
+const ruleTester = new RuleTester({
+  parserOptions,
+  parser: require.resolve('@babel/eslint-parser'),
+});
 ruleTester.run('use-ember-data-rfc-395-imports', rule, {
   valid: [
     "import Model from '@ember-data/model';",

--- a/tests/lib/utils/computed-properties-test.js
+++ b/tests/lib/utils/computed-properties-test.js
@@ -1,8 +1,8 @@
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const computedPropertyUtils = require('../../../lib/utils/computed-properties');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0].expression;
+  return babelESLintParse(code).body[0].expression;
 }
 
 describe('getComputedPropertyFunctionBody', () => {

--- a/tests/lib/utils/computed-property-dependent-keys-test.js
+++ b/tests/lib/utils/computed-property-dependent-keys-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const cpdkUtils = require('../../../lib/utils/computed-property-dependent-keys');
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 
 describe('collapseKeys', () => {
   it('returns the right result', () => {
@@ -143,7 +143,7 @@ describe('findComputedPropertyDependentKeys', () => {
       ],
     ]);
 
-    const classNode = babelEslint.parse(`
+    const classNode = babelESLintParse(`
       import { computed as c } from '@ember/object';
       import { rejectBy, t } from 'custom-macros/macros';
       import { somethingElse } from 'custom-macros';
@@ -247,7 +247,7 @@ describe('findComputedPropertyDependentKeys', () => {
       ],
     ]);
 
-    const classNode = babelEslint.parse(`
+    const classNode = babelESLintParse(`
       import { computed as c } from '@ember/object';
       import { rejectBy, t } from 'custom-macros/macros';
       import { somethingElse } from 'custom-macros';

--- a/tests/lib/utils/decorators-test.js
+++ b/tests/lib/utils/decorators-test.js
@@ -1,19 +1,19 @@
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const decoratorUtils = require('../../../lib/utils/decorators');
 
 describe('getDecoratorName', () => {
   it('should return decorator name with Identifier', () => {
-    const node = babelEslint.parse('class Test { @computed get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed get prop() {} }').body[0].body.body[0];
     expect(decoratorUtils.getDecoratorName(node.decorators[0])).toStrictEqual('computed');
   });
 
   it('should return decorator name with CallExpression', () => {
-    const node = babelEslint.parse('class Test { @computed() get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed() get prop() {} }').body[0].body.body[0];
     expect(decoratorUtils.getDecoratorName(node.decorators[0])).toStrictEqual('computed');
   });
 
   it('should return decorator name with MemberExpression', () => {
-    const node = babelEslint.parse('class Test { @computed.readOnly() get prop() {} }').body[0].body
+    const node = babelESLintParse('class Test { @computed.readOnly() get prop() {} }').body[0].body
       .body[0];
     expect(decoratorUtils.getDecoratorName(node.decorators[0])).toStrictEqual('computed.readOnly');
   });
@@ -21,27 +21,27 @@ describe('getDecoratorName', () => {
 
 describe('findDecorator', () => {
   it('should not find anything with non-decorator', () => {
-    const node = babelEslint.parse('const x = 123').body[0];
+    const node = babelESLintParse('const x = 123').body[0];
     expect(decoratorUtils.findDecorator(node, 'random')).toBeUndefined();
   });
 
   it('should not find anything with wrong decorator name', () => {
-    const node = babelEslint.parse('class Test { @computed get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed get prop() {} }').body[0].body.body[0];
     expect(decoratorUtils.findDecorator(node, 'random')).toBeUndefined();
   });
 
   it('should find something with Identifier decorator', () => {
-    const node = babelEslint.parse('class Test { @computed get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed get prop() {} }').body[0].body.body[0];
     expect(decoratorUtils.findDecorator(node, 'computed')).toBeTruthy();
   });
 
   it('should find something with CallExpression decorator', () => {
-    const node = babelEslint.parse('class Test { @computed() get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed() get prop() {} }').body[0].body.body[0];
     expect(decoratorUtils.findDecorator(node, 'computed')).toBeTruthy();
   });
 
   it('should find something with MemberExpression decorator', () => {
-    const node = babelEslint.parse('class Test { @computed.readOnly() get prop() {} }').body[0].body
+    const node = babelESLintParse('class Test { @computed.readOnly() get prop() {} }').body[0].body
       .body[0];
     expect(decoratorUtils.findDecorator(node, 'computed.readOnly')).toBeTruthy();
   });
@@ -49,21 +49,21 @@ describe('findDecorator', () => {
 
 describe('findDecoratorByNameCallback', () => {
   it('should not find anything with callback checking for wrong name', () => {
-    const node = babelEslint.parse('class Test { @computed get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed get prop() {} }').body[0].body.body[0];
     expect(
       decoratorUtils.findDecoratorByNameCallback(node, (name) => name === 'random')
     ).toBeUndefined();
   });
 
   it('should find decorator with callback checking for correct name', () => {
-    const node = babelEslint.parse('class Test { @computed get prop() {} }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @computed get prop() {} }').body[0].body.body[0];
     expect(
       decoratorUtils.findDecoratorByNameCallback(node, (name) => name === 'computed')
     ).toStrictEqual(node.decorators[0]);
   });
 });
 
-const expressionlessParse = (code) => babelEslint.parse(code).body[0];
+const expressionlessParse = (code) => babelESLintParse(code).body[0];
 describe('hasDecorator', () => {
   const withDecorator = '@classic class Rectangle {}';
   const withoutDecorator = 'class Rectangle {}';
@@ -104,22 +104,22 @@ describe('hasDecorator', () => {
 
 describe('isClassPropertyWithDecorator', () => {
   it('should not find anything with non-decorator', () => {
-    const node = babelEslint.parse('const x = 123').body[0];
+    const node = babelESLintParse('const x = 123').body[0];
     expect(decoratorUtils.isClassPropertyWithDecorator(node, 'random')).toStrictEqual(false);
   });
 
   it('should not find anything with wrong decorator name', () => {
-    const node = babelEslint.parse('class Test { @tracked x }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @tracked x }').body[0].body.body[0];
     expect(decoratorUtils.isClassPropertyWithDecorator(node, 'random')).toStrictEqual(false);
   });
 
   it('should find something with Identifier decorator', () => {
-    const node = babelEslint.parse('class Test { @tracked x }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @tracked x }').body[0].body.body[0];
     expect(decoratorUtils.isClassPropertyWithDecorator(node, 'tracked')).toStrictEqual(true);
   });
 
   it('should find something with CallExpression decorator', () => {
-    const node = babelEslint.parse('class Test { @tracked x }').body[0].body.body[0];
+    const node = babelESLintParse('class Test { @tracked x }').body[0].body.body[0];
     expect(decoratorUtils.isClassPropertyWithDecorator(node, 'tracked')).toStrictEqual(true);
   });
 });

--- a/tests/lib/utils/import-test.js
+++ b/tests/lib/utils/import-test.js
@@ -1,8 +1,8 @@
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const importUtils = require('../../../lib/utils/import');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0].expression;
+  return babelESLintParse(code).body[0].expression;
 }
 
 describe('getSourceModuleName', () => {
@@ -24,47 +24,47 @@ describe('getSourceModuleName', () => {
 
 describe('getImportIdentifier', () => {
   it('gets null when no import is found', () => {
-    const node = babelEslint.parse("import { later } from '@ember/runloop';").body[0];
+    const node = babelESLintParse("import { later } from '@ember/runloop';").body[0];
     expect(importUtils.getImportIdentifier(node, '@ember/object', 'action')).toBeNull();
   });
 
   it('gets an identifier when found', () => {
-    const node = babelEslint.parse("import { later } from '@ember/runloop';").body[0];
+    const node = babelESLintParse("import { later } from '@ember/runloop';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/runloop', 'later');
 
     expect(identifier).toStrictEqual('later');
   });
 
   it('gets an aliased identifier when found', () => {
-    const node = babelEslint.parse("import { later as laterz } from '@ember/runloop';").body[0];
+    const node = babelESLintParse("import { later as laterz } from '@ember/runloop';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/runloop', 'later');
 
     expect(identifier).toStrictEqual('laterz');
   });
 
   it('returns undefined when no default import is found', () => {
-    const node = babelEslint.parse("import { later } from '@ember/runloop';").body[0];
+    const node = babelESLintParse("import { later } from '@ember/runloop';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/runloop');
 
     expect(identifier).toBeUndefined();
   });
 
   it('gets an identifier when found for default imports', () => {
-    const node = babelEslint.parse("import Component from '@ember/component';").body[0];
+    const node = babelESLintParse("import Component from '@ember/component';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/component');
 
     expect(identifier).toStrictEqual('Component');
   });
 
   it('gets an named identifier when found with mixed imports', () => {
-    const node = babelEslint.parse("import { later } from '@ember/runloop';").body[0];
+    const node = babelESLintParse("import { later } from '@ember/runloop';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/runloop', 'later');
 
     expect(identifier).toStrictEqual('later');
   });
 
   it('gets a default identifier when found with mixed imports', () => {
-    const node = babelEslint.parse("import Component from '@ember/component';").body[0];
+    const node = babelESLintParse("import Component from '@ember/component';").body[0];
     const identifier = importUtils.getImportIdentifier(node, '@ember/component');
 
     expect(identifier).toStrictEqual('Component');

--- a/tests/lib/utils/new-module-test.js
+++ b/tests/lib/utils/new-module-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const { buildFix, isDestructuring } = require('../../../lib/utils/new-module');
 
 const modulesData = {
@@ -11,24 +11,24 @@ const modulesData = {
 
 describe('isDestructuring', () => {
   it('should check a destructuring import', () => {
-    const node = babelEslint.parse('const { destructured } = someVar;').body[0].declarations[0];
+    const node = babelESLintParse('const { destructured } = someVar;').body[0].declarations[0];
     expect(isDestructuring(node)).toBeTruthy();
   });
 
   it('should check a non-destructuring import', () => {
-    const node = babelEslint.parse('const destructured = someVar;').body[0].declarations[0];
+    const node = babelESLintParse('const destructured = someVar;').body[0].declarations[0];
     expect(isDestructuring(node)).toBeFalsy();
   });
 
   it('should check a ForInStatement', () => {
-    const node = babelEslint.parse('for (const item in list) {};').body[0].left.declarations[0];
+    const node = babelESLintParse('for (const item in list) {};').body[0].left.declarations[0];
     expect(isDestructuring(node)).toBeFalsy();
   });
 });
 
 describe('buildFix', () => {
   it('returns a function', () => {
-    const node = babelEslint.parse('import Model from "ember-data/model"').body[0];
+    const node = babelESLintParse('import Model from "ember-data/model"').body[0];
     const fix = buildFix(node, modulesData);
     expect(typeof fix === 'function').toBeTruthy();
   });

--- a/tests/lib/utils/property-getter-test.js
+++ b/tests/lib/utils/property-getter-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const propertyGetterUtils = require('../../../lib/utils/property-getter');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0].expression;
+  return babelESLintParse(code).body[0].expression;
 }
 
 describe('isSimpleThisExpression', () => {

--- a/tests/lib/utils/property-setter-test.js
+++ b/tests/lib/utils/property-setter-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const propertySetterUtils = require('../../../lib/utils/property-setter');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0];
+  return babelESLintParse(code).body[0];
 }
 
 describe('isThisSet', () => {

--- a/tests/lib/utils/scope-references-this-test.js
+++ b/tests/lib/utils/scope-references-this-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const scopeReferencesThis = require('../../../lib/utils/scope-references-this');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0];
+  return babelESLintParse(code).body[0];
 }
 
 describe('scopeReferencesThis', function () {

--- a/tests/lib/utils/types-test.js
+++ b/tests/lib/utils/types-test.js
@@ -1,8 +1,8 @@
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const types = require('../../../lib/utils/types');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0].expression;
+  return babelESLintParse(code).body[0].expression;
 }
 
 describe('function sort order', function () {
@@ -115,7 +115,7 @@ describe('isObjectExpression', () => {
 });
 
 describe('isReturnStatement', () => {
-  const node = babelEslint.parse('return').body[0];
+  const node = babelESLintParse('return').body[0];
 
   it('should check if node is a return statement', () => {
     expect(types.isReturnStatement(node)).toBeTruthy();

--- a/tests/lib/utils/utils-test.js
+++ b/tests/lib/utils/utils-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const utils = require('../../../lib/utils/utils');
 
 function parse(code) {
-  return babelEslint.parse(code).body[0].expression;
+  return babelESLintParse(code).body[0].expression;
 }
 
 function parseVariableDeclarator(code) {
-  return babelEslint.parse(code).body[0].declarations[0];
+  return babelESLintParse(code).body[0].declarations[0];
 }
 
 describe('collectObjectPatternBindings', () => {
@@ -111,7 +111,7 @@ describe('getPropertyValue', () => {
     },
   };
 
-  const node = babelEslint.parse(`
+  const node = babelESLintParse(`
     export default Ember.Component({
       init() {
         this._super(...arguments);

--- a/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
+++ b/tests/lib/utils/utils/get-source-module-name-for-identifier-test.js
@@ -1,6 +1,6 @@
 const { getSourceModuleNameForIdentifier } = require('../../../../lib/utils/import');
 const { FauxContext } = require('../../../helpers/faux-context');
-const babelEslint = require('babel-eslint');
+const { parse: babelESLintParse } = require('../../../helpers/babel-eslint-parser');
 
 describe('getSourceModuleNameForIdentifier', () => {
   describe('when the identifier is not imported', () => {
@@ -59,7 +59,7 @@ describe('getSourceModuleNameForIdentifier', () => {
         Model.extend();
       `);
 
-      const node = babelEslint.parse('Model.extend({})').body[0].expression.callee;
+      const node = babelESLintParse('Model.extend({})').body[0].expression.callee;
 
       expect(getSourceModuleNameForIdentifier(context, node)).toStrictEqual('@ember-data/model');
     });
@@ -71,7 +71,7 @@ describe('getSourceModuleNameForIdentifier', () => {
         DS.Model.extend();
       `);
 
-      const node = babelEslint.parse('DS.Model.extend({})').body[0].expression.callee;
+      const node = babelESLintParse('DS.Model.extend({})').body[0].expression.callee;
 
       expect(getSourceModuleNameForIdentifier(context, node)).toStrictEqual('ember-data');
     });
@@ -83,7 +83,7 @@ describe('getSourceModuleNameForIdentifier', () => {
         Some.Long.Chained.Path.extend();
       `);
 
-      const node = babelEslint.parse('Some.Long.Chained.Path.extend({})').body[0].expression.callee;
+      const node = babelESLintParse('Some.Long.Chained.Path.extend({})').body[0].expression.callee;
 
       expect(getSourceModuleNameForIdentifier(context, node)).toStrictEqual('some-path');
     });
@@ -96,7 +96,7 @@ describe('getSourceModuleNameForIdentifier', () => {
         export default class SomeClass extends Model.extend(Mixin) {}
       `);
 
-      const node = babelEslint.parse('Model.extend(Mixin)').body[0].expression;
+      const node = babelESLintParse('Model.extend(Mixin)').body[0].expression;
 
       expect(getSourceModuleNameForIdentifier(context, node)).toStrictEqual('@ember-data/model');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,15 @@
     eslint-visitor-keys "^1.3.0"
     semver "^6.3.0"
 
+"@babel/eslint-parser@^7.13.14":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz#f80fd23bdd839537221914cb5d17720a5ea6ba3a"
+  integrity sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==
+  dependencies:
+    eslint-scope "^5.1.0"
+    eslint-visitor-keys "^1.3.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.13.0", "@babel/generator@^7.13.9":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
@@ -93,6 +102,13 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/helper-annotate-as-pure@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
+  integrity sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-compilation-targets@^7.13.10":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz#1310a1678cb8427c07a753750da4f8ce442bdd0c"
@@ -102,6 +118,18 @@
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
     semver "^6.3.0"
+
+"@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.13.11":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.1.tgz#1fe11b376f3c41650ad9fedc665b0068722ea76c"
+  integrity sha512-r8rsUahG4ywm0QpGcCrLaUSOuNAISR3IZCg4Fx05Ozq31aCUrQsTLH6KPxy0N5ULoQ4Sn9qjNdGNtbPWAC6hYg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.13.12"
+    "@babel/helper-split-export-declaration" "^7.12.13"
 
 "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
@@ -141,6 +169,13 @@
   integrity sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==
   dependencies:
     "@babel/types" "^7.13.0"
+
+"@babel/helper-member-expression-to-functions@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
+  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
+  dependencies:
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-member-expression-to-functions@^7.8.3":
   version "7.8.3"
@@ -215,6 +250,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
+"@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
+  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
 "@babel/helper-replace-supers@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz#6034b7b51943094cb41627848cb219cb02be1d24"
@@ -224,6 +264,16 @@
     "@babel/helper-optimise-call-expression" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
+
+"@babel/helper-replace-supers@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
+  integrity sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
+    "@babel/helper-optimise-call-expression" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-replace-supers@^7.8.6":
   version "7.8.6"
@@ -268,6 +318,11 @@
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
 "@babel/helper-validator-identifier@^7.9.0":
   version "7.9.0"
@@ -320,7 +375,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
   integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
@@ -329,6 +384,23 @@
   version "7.13.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
   integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
+
+"@babel/plugin-proposal-class-properties@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"
+  integrity sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+
+"@babel/plugin-proposal-decorators@^7.13.15":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.15.tgz#e91ccfef2dc24dd5bd5dcc9fc9e2557c684ecfb8"
+  integrity sha512-ibAMAqUm97yzi+LPgdr5Nqb9CMkeieGHvwPg1ywSGjZrZHQEGqE01HmOio8kxRpA/+VtOHouIVy2FMpBbtltjA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.13.11"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-decorators" "^7.12.13"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -350,6 +422,13 @@
   integrity sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-syntax-decorators@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz#fac829bf3c7ef4a1bc916257b403e58c6bdaf648"
+  integrity sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-syntax-import-meta@^7.8.3":
   version "7.10.4"
@@ -432,7 +511,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
   integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
@@ -462,7 +541,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
@@ -478,6 +557,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.13.12":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.1.tgz#095bd12f1c08ab63eff6e8f7745fa7c9cc15a9db"
+  integrity sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.3.3":
@@ -1379,18 +1466,6 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
-
-babel-eslint@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
 
 babel-jest@^26.6.3:
   version "26.6.3"
@@ -2508,7 +2583,7 @@ eslint-scope@5.1.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.0.0, eslint-scope@^5.1.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -2534,7 +2609,7 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -5902,7 +5977,7 @@ resolve@^1.1.6:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
https://github.com/babel/babel-eslint#note-babel-eslint-is-now-babeleslint-parser-and-has-moved-into-the-babel-monorepo