### PR TITLE
Improve columns in README rules table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,153 +60,153 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 
 ### Components
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components |
-| :white_check_mark: | [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks |
-| :white_check_mark: | [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components |
-| :white_check_mark: | [no-component-lifecycle-hooks](./docs/rules/no-component-lifecycle-hooks.md) | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. |
-| :white_check_mark: | [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components |
-| :white_check_mark: | [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components | :white_check_mark: |  |
+| [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks | :white_check_mark: |  |
+| [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components | :white_check_mark: |  |
+| [no-component-lifecycle-hooks](./docs/rules/no-component-lifecycle-hooks.md) | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. | :white_check_mark: |  |
+| [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components | :white_check_mark: |  |
+| [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component | :white_check_mark: |  |
 
 ### Computed Properties
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |
-| :white_check_mark: | [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties |
-| :white_check_mark::wrench: | [no-assignment-of-untracked-properties-used-in-tracking-contexts](./docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md) | disallow assignment of untracked properties that are used as computed property dependencies |
-| :white_check_mark: | [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes |
-| :white_check_mark: | [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` |
-| :white_check_mark::wrench: | [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys |
-| :white_check_mark::wrench: | [no-incorrect-computed-macros](./docs/rules/no-incorrect-computed-macros.md) | disallow incorrect usage of computed property macros |
-| :white_check_mark::wrench: | [no-invalid-dependent-keys](./docs/rules/no-invalid-dependent-keys.md) | disallow invalid dependent keys in computed properties |
-| :white_check_mark: | [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties |
-| :white_check_mark: | [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties |
-| :white_check_mark::wrench: | [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible |
-| :white_check_mark::wrench: | [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties |
-| :white_check_mark: | [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties |
-| :white_check_mark: | [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |  |  |
+| [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties | :white_check_mark: |  |
+| [no-assignment-of-untracked-properties-used-in-tracking-contexts](./docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md) | disallow assignment of untracked properties that are used as computed property dependencies | :white_check_mark: | :wrench: |
+| [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes | :white_check_mark: |  |
+| [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` | :white_check_mark: |  |
+| [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys | :white_check_mark: | :wrench: |
+| [no-incorrect-computed-macros](./docs/rules/no-incorrect-computed-macros.md) | disallow incorrect usage of computed property macros | :white_check_mark: | :wrench: |
+| [no-invalid-dependent-keys](./docs/rules/no-invalid-dependent-keys.md) | disallow invalid dependent keys in computed properties | :white_check_mark: | :wrench: |
+| [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties | :white_check_mark: |  |
+| [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties | :white_check_mark: |  |
+| [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible | :white_check_mark: | :wrench: |
+| [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties | :white_check_mark: | :wrench: |
+| [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties | :white_check_mark: |  |
+| [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys | :white_check_mark: |  |
 
 ### Controllers
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | enforce aliasing model in controllers |
-| :white_check_mark: | [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers |
-|  | [no-controllers](./docs/rules/no-controllers.md) | disallow non-essential controllers |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | enforce aliasing model in controllers |  |  |
+| [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers | :white_check_mark: |  |
+| [no-controllers](./docs/rules/no-controllers.md) | disallow non-essential controllers |  |  |
 
 ### Deprecations
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions |
-| :white_check_mark: | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 |
-| :white_check_mark: | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions |
-| :white_check_mark: | [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins |
-| :white_check_mark: | [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins |
-| :white_check_mark: | [no-observers](./docs/rules/no-observers.md) | disallow usage of observers |
-| :white_check_mark::wrench: | [no-old-shims](./docs/rules/no-old-shims.md) | disallow usage of old shims for modules |
-| :white_check_mark: | [no-string-prototype-extensions](./docs/rules/no-string-prototype-extensions.md) | disallow usage of `String` prototype extensions |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions | :white_check_mark: |  |
+| [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 | :white_check_mark: |  |
+| [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions | :white_check_mark: |  |
+| [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins | :white_check_mark: |  |
+| [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins | :white_check_mark: |  |
+| [no-observers](./docs/rules/no-observers.md) | disallow usage of observers | :white_check_mark: |  |
+| [no-old-shims](./docs/rules/no-old-shims.md) | disallow usage of old shims for modules | :white_check_mark: | :wrench: |
+| [no-string-prototype-extensions](./docs/rules/no-string-prototype-extensions.md) | disallow usage of `String` prototype extensions | :white_check_mark: |  |
 
 ### Ember Data
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |
-| :white_check_mark::wrench: | [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | enforce usage of `@ember-data/` package imports instead `ember-data` |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |  |  |
+| [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | enforce usage of `@ember-data/` package imports instead `ember-data` | :white_check_mark: | :wrench: |
 
 ### Ember Object
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | disallow state leakage |
-| :white_check_mark::wrench: | [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function |
-| :white_check_mark::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
-|  | [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |
-| :white_check_mark: | [no-try-invoke](./docs/rules/no-try-invoke.md) | disallow usage of the Ember's `tryInvoke` util |
-| :white_check_mark::wrench: | [require-super-in-lifecycle-hooks](./docs/rules/require-super-in-lifecycle-hooks.md) | require super to be called in lifecycle hooks |
-| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | disallow state leakage | :white_check_mark: |  |
+| [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function | :white_check_mark: | :wrench: |
+| [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions | :white_check_mark: | :wrench: |
+| [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |  |  |
+| [no-try-invoke](./docs/rules/no-try-invoke.md) | disallow usage of the Ember's `tryInvoke` util | :white_check_mark: |  |
+| [require-super-in-lifecycle-hooks](./docs/rules/require-super-in-lifecycle-hooks.md) | require super to be called in lifecycle hooks | :white_check_mark: | :wrench: |
+| [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |  | :wrench: |
 
 ### Ember Octane
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes |
-| :white_check_mark: | [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` |
-| :white_check_mark: | [no-actions-hash](./docs/rules/no-actions-hash.md) | disallow the actions hash in components, controllers, and routes |
-| :white_check_mark: | [no-classic-classes](./docs/rules/no-classic-classes.md) | disallow "classic" classes in favor of native JS classes |
-| :white_check_mark::wrench: | [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods |
-| :white_check_mark: | [no-empty-glimmer-component-classes](./docs/rules/no-empty-glimmer-component-classes.md) | disallow empty backing classes for Glimmer components |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes | :white_check_mark: |  |
+| [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` | :white_check_mark: |  |
+| [no-actions-hash](./docs/rules/no-actions-hash.md) | disallow the actions hash in components, controllers, and routes | :white_check_mark: |  |
+| [no-classic-classes](./docs/rules/no-classic-classes.md) | disallow "classic" classes in favor of native JS classes | :white_check_mark: |  |
+| [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods | :white_check_mark: | :wrench: |
+| [no-empty-glimmer-component-classes](./docs/rules/no-empty-glimmer-component-classes.md) | disallow empty backing classes for Glimmer components | :white_check_mark: |  |
 
 ### jQuery
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [jquery-ember-run](./docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop |
-| :white_check_mark: | [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object |
-| :white_check_mark: | [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [jquery-ember-run](./docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop | :white_check_mark: |  |
+| [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object | :white_check_mark: |  |
+| [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery | :white_check_mark: |  |
 
 ### Miscellaneous
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |
-|  | [no-html-safe](./docs/rules/no-html-safe.md) | disallow the use of `htmlSafe` |
-| :white_check_mark: | [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` |
-| :white_check_mark: | [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. |
-|  | [require-fetch-import](./docs/rules/require-fetch-import.md) | enforce explicit import for `fetch()` |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |  |  |
+| [no-html-safe](./docs/rules/no-html-safe.md) | disallow the use of `htmlSafe` |  |  |
+| [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` | :white_check_mark: |  |
+| [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. | :white_check_mark: |  |
+| [require-fetch-import](./docs/rules/require-fetch-import.md) | enforce explicit import for `fetch()` |  |  |
 
 ### Routes
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js |
-| :white_check_mark: | [no-controller-access-in-routes](./docs/rules/no-controller-access-in-routes.md) | disallow routes from accessing the controller outside of setupController/resetController |
-| :white_check_mark: | [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service |
-| :white_check_mark: | [no-shadow-route-definition](./docs/rules/no-shadow-route-definition.md) | enforce no route path definition shadowing |
-|  | [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |
-| :white_check_mark::wrench: | [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option |
-|  | [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |
-| :white_check_mark: | [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | enforce usage of snake_cased dynamic segments in routes |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js | :white_check_mark: |  |
+| [no-controller-access-in-routes](./docs/rules/no-controller-access-in-routes.md) | disallow routes from accessing the controller outside of setupController/resetController | :white_check_mark: |  |
+| [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service | :white_check_mark: |  |
+| [no-shadow-route-definition](./docs/rules/no-shadow-route-definition.md) | enforce no route path definition shadowing | :white_check_mark: |  |
+| [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |  |  |
+| [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option | :white_check_mark: | :wrench: |
+| [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |  |  |
+| [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | enforce usage of snake_cased dynamic segments in routes | :white_check_mark: |  |
 
 ### Services
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |
-| :wrench: | [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |
-|  | [no-unused-services](./docs/rules/no-unused-services.md) | disallow unused service injections (see rule doc for limitations) |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |  |  |
+| [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |  | :wrench: |
+| [no-unused-services](./docs/rules/no-unused-services.md) | disallow unused service injections (see rule doc for limitations) |  |  |
 
 ### Stylistic Issues
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :wrench: | [order-in-components](./docs/rules/order-in-components.md) | enforce proper order of properties in components |
-| :wrench: | [order-in-controllers](./docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |
-| :wrench: | [order-in-models](./docs/rules/order-in-models.md) | enforce proper order of properties in models |
-| :wrench: | [order-in-routes](./docs/rules/order-in-routes.md) | enforce proper order of properties in routes |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [order-in-components](./docs/rules/order-in-components.md) | enforce proper order of properties in components |  | :wrench: |
+| [order-in-controllers](./docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |  | :wrench: |
+| [order-in-models](./docs/rules/order-in-models.md) | enforce proper order of properties in models |  | :wrench: |
+| [order-in-routes](./docs/rules/order-in-routes.md) | enforce proper order of properties in routes |  | :wrench: |
 
 ### Testing
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-|  | [no-current-route-name](./docs/rules/no-current-route-name.md) | disallow usage of the `currentRouteName()` test helper |
-| :white_check_mark: | [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope |
-| :white_check_mark: | [no-invalid-test-waiters](./docs/rules/no-invalid-test-waiters.md) | disallow incorrect usage of test waiter APIs |
-| :white_check_mark: | [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs |
-| :white_check_mark::wrench: | [no-noop-setup-on-error-in-before](./docs/rules/no-noop-setup-on-error-in-before.md) | disallows using no-op setupOnerror in `before` or `beforeEach` |
-| :white_check_mark: | [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests |
-|  | [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments in test files |
-| :white_check_mark: | [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests |
-| :white_check_mark::wrench: | [no-settled-after-test-helper](./docs/rules/no-settled-after-test-helper.md) | disallow usage of `await settled()` right after test helper that calls it internally |
-| :white_check_mark: | [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper |
-| :white_check_mark: | [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file |
-| :white_check_mark: | [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc |
-| :white_check_mark: | [no-test-support-import](./docs/rules/no-test-support-import.md) | disallow importing of "test-support" files in production code. |
-| :white_check_mark: | [no-test-this-render](./docs/rules/no-test-this-render.md) | disallow usage of the `this.render` in tests, recommending to use @ember/test-helpers' `render` instead. |
-| :white_check_mark: | [prefer-ember-test-helpers](./docs/rules/prefer-ember-test-helpers.md) | enforce usage of `@ember/test-helpers` methods over native window methods |
-| :white_check_mark::wrench: | [require-valid-css-selector-in-test-helpers](./docs/rules/require-valid-css-selector-in-test-helpers.md) | disallow using invalid CSS selectors in test helpers |
+| Name    | Description | :white_check_mark: | :wrench: |
+|:--------|:------------|:---------------|:-----------|
+| [no-current-route-name](./docs/rules/no-current-route-name.md) | disallow usage of the `currentRouteName()` test helper |  |  |
+| [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope | :white_check_mark: |  |
+| [no-invalid-test-waiters](./docs/rules/no-invalid-test-waiters.md) | disallow incorrect usage of test waiter APIs | :white_check_mark: |  |
+| [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs | :white_check_mark: |  |
+| [no-noop-setup-on-error-in-before](./docs/rules/no-noop-setup-on-error-in-before.md) | disallows using no-op setupOnerror in `before` or `beforeEach` | :white_check_mark: | :wrench: |
+| [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests | :white_check_mark: |  |
+| [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments in test files |  |  |
+| [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests | :white_check_mark: |  |
+| [no-settled-after-test-helper](./docs/rules/no-settled-after-test-helper.md) | disallow usage of `await settled()` right after test helper that calls it internally | :white_check_mark: | :wrench: |
+| [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper | :white_check_mark: |  |
+| [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file | :white_check_mark: |  |
+| [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc | :white_check_mark: |  |
+| [no-test-support-import](./docs/rules/no-test-support-import.md) | disallow importing of "test-support" files in production code. | :white_check_mark: |  |
+| [no-test-this-render](./docs/rules/no-test-this-render.md) | disallow usage of the `this.render` in tests, recommending to use @ember/test-helpers' `render` instead. | :white_check_mark: |  |
+| [prefer-ember-test-helpers](./docs/rules/prefer-ember-test-helpers.md) | enforce usage of `@ember/test-helpers` methods over native window methods | :white_check_mark: |  |
+| [require-valid-css-selector-in-test-helpers](./docs/rules/require-valid-css-selector-in-test-helpers.md) | disallow using invalid CSS selectors in test helpers | :white_check_mark: | :wrench: |
 
 <!--RULES_TABLE_END-->
 

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -24,8 +24,8 @@ const recommendedRulesFile = path.resolve(__dirname, '../lib/recommended-rules.j
 const tablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/;
 const readmeContent = fs.readFileSync(readmeFile, 'utf8');
 
-const STAR = ':white_check_mark:';
-const PEN = ':wrench:';
+const RECOMMENDED = ':white_check_mark:';
+const FIXABLE = ':wrench:';
 
 const rules = fs
   .readdirSync(root)
@@ -49,17 +49,18 @@ let rulesTableContent = categories
   .map(
     (category) => `### ${category}
 
-|    | Rule ID | Description |
-|:---|:--------|:------------|
+| Name    | Description | ${RECOMMENDED} | ${FIXABLE} |
+|:--------|:------------|:---------------|:-----------|
 ${rules
   .filter(([, rule]) => rule.meta.docs.category === category && !rule.meta.deprecated)
   .map((entry) => {
     const name = entry[0];
     const meta = entry[1].meta;
-    const mark = `${meta.docs.recommended ? STAR : ''}${meta.fixable ? PEN : ''}`;
     const link = `[${name}](./docs/rules/${name}.md)`;
     const description = meta.docs.description || '(no description)';
-    return `| ${mark} | ${link} | ${description} |`;
+    return `| ${link} | ${description} | ${meta.docs.recommended ? RECOMMENDED : ''} | ${
+      meta.fixable ? FIXABLE : ''
+    } |`;
   })
   .join('\n')}
 `
@@ -73,7 +74,7 @@ if (deprecatedRules.length > 0) {
 
 > :warning: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
 
-| Rule ID | Replaced by |
+| Name    | Replaced by |
 |:--------|:------------|
 ${deprecatedRules
   .map((entry) => {


### PR DESCRIPTION
Give config/fixable emojis separate columns.

Matches the format in: https://github.com/sindresorhus/eslint-plugin-unicorn#rules