### PR TITLE
Avoid some false positives with lodash usage when recognizing extended Ember objects

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -183,9 +183,11 @@ function isMirageConfig(fileName) {
   return path.normalize(fileName).endsWith(path.join('mirage', 'config.js'));
 }
 
-// jQuery has an `extend` function and we want to avoid mistaking it for an extended object.
-// TODO: ideally, this would check the actual name that jQuery is imported under, but there's a lot of plumbing needed for that.
-const COMMON_JQUERY_NAMES = new Set(['$', 'jQuery']);
+// Some third-party libraries have an `extend` function and we want to avoid mistaking this for an extended Ember object.
+// TODO: ideally, this would check the actual name that these libraries are imported under, but there's a lot of plumbing needed for that.
+const COMMON_JQUERY_NAMES = ['$', 'jQuery']; // https://api.jquery.com/jquery.extend/
+const COMMON_LODASH_NAMES = ['_', 'lodash']; // https://lodash.com/docs/4.17.15#assignIn
+const THIRD_PARTY_LIBRARIES_WITH_EXTEND = new Set([...COMMON_JQUERY_NAMES, ...COMMON_LODASH_NAMES]);
 
 function isExtendObject(node) {
   // Check for:
@@ -196,7 +198,10 @@ function isExtendObject(node) {
     node.callee.type === 'MemberExpression' &&
     ((node.callee.property.type === 'Identifier' && node.callee.property.name === 'extend') ||
       (node.callee.property.type === 'Literal' && node.callee.property.value === 'extend')) &&
-    !(node.callee.object.type === 'Identifier' && COMMON_JQUERY_NAMES.has(node.callee.object.name))
+    !(
+      node.callee.object.type === 'Identifier' &&
+      THIRD_PARTY_LIBRARIES_WITH_EXTEND.has(node.callee.object.name)
+    )
   );
 }
 

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -582,6 +582,11 @@ describe('isExtendObject', () => {
     expect(emberUtils.isExtendObject(node)).toBeFalsy();
   });
 
+  it('should not detect a potential lodash usage', () => {
+    expect(emberUtils.isExtendObject(parse('_.extend()'))).toBeFalsy();
+    expect(emberUtils.isExtendObject(parse('lodash.extend()'))).toBeFalsy();
+  });
+
   it('should not detect with non-extend name', () => {
     const node = parse('foo.notExtend()');
     expect(emberUtils.isExtendObject(node)).toBeFalsy();


### PR DESCRIPTION
Follow-up to #1168.

Fixes this report: https://github.com/ember-cli/eslint-plugin-ember/issues/601#issuecomment-846266584

CC: @ballPointPenguin