### PR TITLE
Use `ecmaVersion` of `2020` internally for tests/linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2020,
     sourceType: 'script',
     babelOptions: {
       configFile: require.resolve('./.babelrc'),

--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('alias-model-in-controller', rule, {

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -27,7 +27,7 @@ describe('imports', () => {
 
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
   valid: [

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -11,7 +11,7 @@ const {
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('classic-decorator-hooks', rule, {

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -7,7 +7,7 @@ const { disallowedMethodErrorMessage } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('classic-decorator-no-classic-methods', rule, {

--- a/tests/lib/rules/closure-actions.js
+++ b/tests/lib/rules/closure-actions.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('closure-actions', rule, {

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -14,7 +14,7 @@ const { addComputedImport } = require('../../helpers/test-case');
 
 const { PREVENT_GETTER_MESSAGE, ALWAYS_GETTER_MESSAGE, ALWAYS_WITH_SETTER_MESSAGE } = rule;
 const ruleTester = new RuleTester();
-const parserOptions = { ecmaVersion: 2018, sourceType: 'module' };
+const parserOptions = { ecmaVersion: 2020, sourceType: 'module' };
 const output = null;
 
 const alwaysWithSetterOptionErrors = [

--- a/tests/lib/rules/jquery-ember-run.js
+++ b/tests/lib/rules/jquery-ember-run.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('jquery-ember-run', rule, {

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6 },
+  parserOptions: { ecmaVersion: 2020 },
 });
 
 eslintTester.run('named-functions-in-promises', rule, {

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -19,7 +19,7 @@ eslintTester.run('new-module-imports', rule, {
 
         const { Handlebars: { Utils: { escapeExpression } } } = Ember
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     'Ember.Handlebars.Utils.escapeExpression("foo");',
     'Ember.onerror = function() {};',
@@ -31,7 +31,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Component.extend({});
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: `
@@ -43,22 +43,22 @@ eslintTester.run('new-module-imports', rule, {
           ...foo
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: `import LOL from 'who-knows-but-definitely-not-ember';
 
         const { Controller } = LOL;
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'export const Ember = 1;',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'for (let i = 0; i < 10; i++) { }',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     'SomethingRandom.Ember.Service;',
   ],
@@ -70,7 +70,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Component.extend({});
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -85,7 +85,7 @@ eslintTester.run('new-module-imports', rule, {
 
         const { Controller } = LOL;
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -102,7 +102,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Controller.extend({});
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -124,7 +124,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Component.extend({});
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -148,7 +148,7 @@ eslintTester.run('new-module-imports', rule, {
           myService: service('my-service')
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -177,7 +177,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Component.extend({});
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       output: null,
       errors: [
         {
@@ -193,7 +193,7 @@ eslintTester.run('new-module-imports', rule, {
       ],
     },
     {
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       code: 'export default Ember.Service;',
       output: null,
       errors: [
@@ -204,7 +204,7 @@ eslintTester.run('new-module-imports', rule, {
       ],
     },
     {
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       code: 'export default Ember.Service.extend({});',
       output: null,
       errors: [

--- a/tests/lib/rules/no-actions-hash.js
+++ b/tests/lib/rules/no-actions-hash.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 ruleTester.run('no-actions-hash', rule, {
   valid: [

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     babelOptions: {
       configFile: require.resolve('../../../.babelrc'),

--- a/tests/lib/rules/no-attrs-in-components.js
+++ b/tests/lib/rules/no-attrs-in-components.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 

--- a/tests/lib/rules/no-capital-letters-in-routes.js
+++ b/tests/lib/rules/no-capital-letters-in-routes.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 //------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 eslintTester.run('no-capital-letters-in-routes', rule, {
   valid: [

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE_NO_CLASSIC_CLASSES: ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('no-classic-classes', rule, {

--- a/tests/lib/rules/no-classic-components.js
+++ b/tests/lib/rules/no-classic-components.js
@@ -13,7 +13,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const parserOptions = {
-  ecmaVersion: 6,
+  ecmaVersion: 2020,
   sourceType: 'module',
 };
 const ruleTester = new RuleTester({ parserOptions });

--- a/tests/lib/rules/no-component-lifecycle-hooks.js
+++ b/tests/lib/rules/no-component-lifecycle-hooks.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE_NO_COMPONENT_LIFECYCLE_HOOKS: ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('no-component-lifecycle-hooks', rule, {

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -8,7 +8,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-controllers.js
+++ b/tests/lib/rules/no-controllers.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 ruleTester.run('no-controllers', rule, {
   valid: [

--- a/tests/lib/rules/no-current-route-name.js
+++ b/tests/lib/rules/no-current-route-name.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('no-current-route-name', rule, {

--- a/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-duplicate-dependent-keys.js
+++ b/tests/lib/rules/no-duplicate-dependent-keys.js
@@ -16,7 +16,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-ember-super-in-es-classes.js
+++ b/tests/lib/rules/no-ember-super-in-es-classes.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6 },
+  parserOptions: { ecmaVersion: 2020 },
 });
 
 eslintTester.run('no-ember-super-in-es-classes', rule, {

--- a/tests/lib/rules/no-ember-testing-in-module-scope.js
+++ b/tests/lib/rules/no-ember-testing-in-module-scope.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGES } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 const message = 'Supply proper attribute type';
@@ -24,7 +24,7 @@ eslintTester.run('no-empty-attrs', rule, {
       code: `someArrayOfStrings.filter(function(attr) {
         return attr.underscore();
       });`,
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
     },
     `export default Model.extend({
         someArray: someArrayOfStrings.filter(function(attr) {

--- a/tests/lib/rules/no-empty-glimmer-component-classes.js
+++ b/tests/lib/rules/no-empty-glimmer-component-classes.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-function-prototype-extensions.js
+++ b/tests/lib/rules/no-function-prototype-extensions.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('no-function-prototype-extensions', rule, {

--- a/tests/lib/rules/no-get-with-default.js
+++ b/tests/lib/rules/no-get-with-default.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -7,7 +7,7 @@ const { ERROR_MESSAGE_GET, ERROR_MESSAGE_GET_PROPERTIES } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });
@@ -28,11 +28,11 @@ ruleTester.run('no-get', rule, {
     // Template literals.
     {
       code: 'this.get(`foo`);',
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
     },
     {
       code: "import { get } from '@ember/object'; get(this, `foo`);",
-      parserOptions: { ecmaVersion: 6 },
+      parserOptions: { ecmaVersion: 2020 },
     },
 
     // Not `this`.

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -13,7 +13,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester();
 const parserOptions = {
-  ecmaVersion: 6,
+  ecmaVersion: 2020,
   sourceType: 'module',
 };
 const globals = { $: true, jQuery: true };

--- a/tests/lib/rules/no-html-safe.js
+++ b/tests/lib/rules/no-html-safe.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-implicit-service-injection-argument.js
+++ b/tests/lib/rules/no-implicit-service-injection-argument.js
@@ -17,7 +17,7 @@ const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-incorrect-computed-macros.js
+++ b/tests/lib/rules/no-incorrect-computed-macros.js
@@ -15,7 +15,7 @@ const { ERROR_MESSAGE_AND_OR } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-invalid-debug-function-arguments.js
+++ b/tests/lib/rules/no-invalid-debug-function-arguments.js
@@ -120,7 +120,7 @@ const INVALID_USAGES = javascriptUtils.flat(
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -18,7 +18,7 @@ const {
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-invalid-test-waiters.js
+++ b/tests/lib/rules/no-invalid-test-waiters.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('no-jquery', rule, {

--- a/tests/lib/rules/no-legacy-test-waiters.js
+++ b/tests/lib/rules/no-legacy-test-waiters.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-mixins.js
+++ b/tests/lib/rules/no-mixins.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 eslintTester.run('no-mixins', rule, {
   valid: [

--- a/tests/lib/rules/no-new-mixins.js
+++ b/tests/lib/rules/no-new-mixins.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 eslintTester.run('no-new-mixins', rule, {
   valid: [

--- a/tests/lib/rules/no-noop-setup-on-error-in-before.js
+++ b/tests/lib/rules/no-noop-setup-on-error-in-before.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,

--- a/tests/lib/rules/no-old-shims.js
+++ b/tests/lib/rules/no-old-shims.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('no-old-shims', rule, {

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 const message = "Don't use .on() for component lifecycle events.";
@@ -40,7 +40,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
         ...foo,
       });
       `,
-      parserOptions: { ecmaVersion: 9, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
   ],
   invalid: [

--- a/tests/lib/rules/no-pause-test.js
+++ b/tests/lib/rules/no-pause-test.js
@@ -17,7 +17,7 @@ const TEST_FILE_NAME = 'some-test.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -21,7 +21,7 @@ const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-proxies.js
+++ b/tests/lib/rules/no-proxies.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-restricted-property-modifications.js
+++ b/tests/lib/rules/no-restricted-property-modifications.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGES } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 ruleTester.run('no-restricted-resolver-tests', rule, {
   valid: [

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -9,7 +9,7 @@ const SERVICE_IMPORT = "import {inject as service} from '@ember/service';";
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-settled-after-test-helper.js
+++ b/tests/lib/rules/no-settled-after-test-helper.js
@@ -6,7 +6,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -14,7 +14,7 @@ const { buildErrorMessage } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('no-side-effects', rule, {
@@ -49,7 +49,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -63,7 +63,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -209,7 +209,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -226,7 +226,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -243,7 +243,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/no-string-prototype-extensions.js
+++ b/tests/lib/rules/no-string-prototype-extensions.js
@@ -7,7 +7,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 ruleTester.run('no-string-prototype-extensions', rule, {

--- a/tests/lib/rules/no-test-and-then.js
+++ b/tests/lib/rules/no-test-and-then.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-import-export.js
+++ b/tests/lib/rules/no-test-import-export.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-module-for.js
+++ b/tests/lib/rules/no-test-module-for.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-support-import.js
+++ b/tests/lib/rules/no-test-support-import.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-this-render.js
+++ b/tests/lib/rules/no-test-this-render.js
@@ -17,7 +17,7 @@ const TEST_FILE_NAME = 'some-test.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-try-invoke.js
+++ b/tests/lib/rules/no-try-invoke.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -17,7 +17,7 @@ const RENAMED_SERVICE_IMPORT = "import {inject as service} from '@ember/service'
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),
@@ -34,7 +34,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service serviceName }`,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),

--- a/tests/lib/rules/no-volatile-computed-properties.js
+++ b/tests/lib/rules/no-volatile-computed-properties.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: 'module' } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020, sourceType: 'module' } });
 ruleTester.run('no-volatile-computed-properties', rule, {
   valid: [
     'computed()',
@@ -27,7 +27,7 @@ ruleTester.run('no-volatile-computed-properties', rule, {
       code: "class Test { @computed('prop') get someProp() {} }",
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -61,7 +61,7 @@ ruleTester.run('no-volatile-computed-properties', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -336,7 +336,7 @@ eslintTester.run('order-in-components', rule, {
         }).volatile(),
         bar() { const foo = 'bar'}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: [
@@ -357,7 +357,7 @@ eslintTester.run('order-in-components', rule, {
         },
         customProp: { a: 1 }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['property', 'actions', 'custom:customProp', 'method'],
@@ -971,7 +971,7 @@ eslintTester.run('order-in-components', rule, {
         bar() { const foo = 'bar'},
         onBar: () => {}
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       errors: [
         {
           message:
@@ -1021,7 +1021,7 @@ eslintTester.run('order-in-components', rule, {
         customProp: { a: 1 },
               actions: {},
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['property', 'custom:customProp', 'actions', 'method'],
@@ -1047,7 +1047,7 @@ eslintTester.run('order-in-components', rule, {
         },
               customProp: { a: 1 },
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['method', 'custom:customProp'],

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -139,7 +139,7 @@ eslintTester.run('order-in-controllers', rule, {
         },
         customProp: { a: 1 }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['property', 'actions', 'custom:customProp'],
@@ -443,7 +443,7 @@ eslintTester.run('order-in-controllers', rule, {
           },
 });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       errors: [
         {
           message:
@@ -510,7 +510,7 @@ eslintTester.run('order-in-controllers', rule, {
         },
               customProp: { a: 1 },
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['method', 'custom:customProp'],

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -83,7 +83,7 @@ eslintTester.run('order-in-models', rule, {
         },
         customProp: { a: 1 }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['attribute', 'method', 'custom:customProp'],
@@ -99,7 +99,7 @@ eslintTester.run('order-in-models', rule, {
           },
           customProp: { a: 1 }
         });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [{ order: ['service', 'attribute', 'method'] }],
     },
   ],
@@ -292,7 +292,7 @@ eslintTester.run('order-in-models', rule, {
         },
               customProp: { a: 1 },
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['method', 'custom:customProp'],

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -155,7 +155,7 @@ eslintTester.run('order-in-routes', rule, {
         },
         customProp: { a: 1 }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['property', 'actions', 'custom:customProp'],
@@ -771,7 +771,7 @@ eslintTester.run('order-in-routes', rule, {
         },
               customProp: { a: 1 },
 });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [
         {
           order: ['method', 'custom:customProp'],

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -9,7 +9,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -27,7 +27,7 @@ const {
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -8,7 +8,7 @@ const { ERROR_MESSAGE_NON_STRING_VALUE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/require-fetch-import.js
+++ b/tests/lib/rules/require-fetch-import.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   env: { browser: true },
 });
 

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
 });
 
 eslintTester.run('require-return-from-computed', rule, {
@@ -30,7 +30,7 @@ eslintTester.run('require-return-from-computed', rule, {
       code: 'class Test { @computed() get someProp() {} set someProp(val) {} }',
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2020,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE: message } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -88,7 +88,7 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
     'export default Service.extend();',
     {
       code: 'export default Service.extend({ ...spread })',
-      parserOptions: { ecmaVersion: 9, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     `export default Component({
         init() {

--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS: ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,

--- a/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),

--- a/tests/lib/rules/use-brace-expansion.js
+++ b/tests/lib/rules/use-brace-expansion.js
@@ -15,7 +15,7 @@ const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -7,7 +7,7 @@
 const rule = require('../../../lib/rules/use-ember-data-rfc-395-imports');
 const RuleTester = require('eslint').RuleTester;
 
-const parserOptions = { ecmaVersion: 6, sourceType: 'module' };
+const parserOptions = { ecmaVersion: 2020, sourceType: 'module' };
 
 const { ERROR_MESSAGE: message } = rule;
 

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -38,31 +38,31 @@ eslintTester.run('use-ember-get-and-set', rule, {
     },
     {
       code: 'import Ember from "ember"; Ember.get(this, "test")',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; Ember.set(this, "test", someValue)',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import EmberAlias from "ember"; EmberAlias.get(this, "test")',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
 
     // ignoreNonThisExpressions
     {
       code: "let a = new Map(); a.set('name', 'Tomster');",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [{ ignoreNonThisExpressions: true }],
     },
     {
       code: "let a = new Map(); a.get('myKey')",
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [{ ignoreNonThisExpressions: true }],
     },
     {
       code: 'this.test("ok")',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
       options: [{ ignoreNonThisExpressions: true }],
     },
 
@@ -172,99 +172,99 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import Ember from "ember"; const { get } = Ember; this.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(this, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; controller.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(controller, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; model.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(model, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; this.foo.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(this.foo, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; this.getWithDefault("test", "default")',
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(this, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; controller.getWithDefault("test", "default")',
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(controller, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; this.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(this, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; controller.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(controller, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; model.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(model, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; this.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(this, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; controller.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(controller, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; model.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(model, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; this.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(this, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; controller.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(controller, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; model.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(model, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; controller.getProperties("test", "test2")',
@@ -272,7 +272,7 @@ eslintTester.run('use-ember-get-and-set', rule, {
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(controller, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; controller.setProperties({test: "value"})',
@@ -280,7 +280,7 @@ eslintTester.run('use-ember-get-and-set', rule, {
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(controller, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; controller.getWithDefault("test", "default")',
@@ -288,119 +288,119 @@ eslintTester.run('use-ember-get-and-set', rule, {
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(controller, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     // Fixable errors using method on Ember
     {
       code: 'import Ember from "ember"; this.get("test")',
       output: 'import Ember from "ember"; Ember.get(this, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.get("test")',
       output: 'import Ember from "ember"; Ember.get(controller, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; model.get("test")',
       output: 'import Ember from "ember"; Ember.get(model, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; this.foo.get("test")',
       output: 'import Ember from "ember"; Ember.get(this.foo, "test")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; this.getWithDefault("test", "default")',
       output: 'import Ember from "ember"; Ember.getWithDefault(this, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.getWithDefault("test", "default")',
       output: 'import Ember from "ember"; Ember.getWithDefault(controller, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; this.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(this, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(controller, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; model.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(model, "test", "value")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; this.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(this, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(controller, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; model.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(model, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; this.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(this, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(controller, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; model.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(model, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.getProperties("test", "test2")',
       filename: 'app/tests/unit/controllers/controller-test.js',
       output: 'import Ember from "ember"; Ember.getProperties(controller, "test", "test2")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.setProperties({test: "value"})',
       filename: 'app/tests/unit/controllers/controller-test.js',
       output: 'import Ember from "ember"; Ember.setProperties(controller, {test: "value"})',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; controller.getWithDefault("test", "default")',
       filename: 'app/tests/unit/controllers/controller-test.js',
       output: 'import Ember from "ember"; Ember.getWithDefault(controller, "test", "default")',
       errors: [{ message: 'Use get/set' }],
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
     },
 
     // ignoreNonThisExpressions


### PR DESCRIPTION
Note: this does not touch the `ecmaVersion` in the `base` configuration, which we can update in a future major version.

`2020` is the highest supported version we can use while still supporting ESLint 6.