### PR TITLE
Use `meta.hasSuggestions` for suggestable rules to prepare for ESLint 8

### DIFF
--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -20,13 +20,13 @@ module.exports = {
       category: 'Routes',
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/route-path-style.md',
-      suggestion: true,
     },
     fixable: null,
     schema: [],
     messages: {
       convertToKebabCase: 'Convert route path to kebab case',
     },
+    hasSuggestions: true,
   },
 
   ERROR_MESSAGE,


### PR DESCRIPTION
The change to require suggestable rules to have `meta.hasSuggestions` has been accepted and mentioned in the blog post for the upcoming ESLint 8 breaking changes. So we should adopt this change now to ensure we are compatible with ESLint 8 as soon as possible. The old property `meta.docs.suggestion` was unused anyway.

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property