### PR TITLE
Add `meta.hasSuggestions` to `no-unused-services` rule

### DIFF
--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -39,6 +39,7 @@ module.exports = {
       main: 'The service `{{name}}` is not referenced in this JS file and might be unused (note: it could still be used in a corresponding handlebars template file, mixin, or parent/child class).',
       removeServiceInjection: 'Remove the service injection.',
     },
+    hasSuggestions: true,
   },
 
   create(context) {


### PR DESCRIPTION
The change to require suggestable rules to have `meta.hasSuggestions` has been accepted and mentioned in the blog post for the upcoming ESLint 8 breaking changes. So we should adopt this change now to ensure we are compatible with ESLint 8 as soon as possible. The old property `meta.docs.suggestion` was unused anyway.

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property

Follow-up to #1230.