### PR TITLE
Explain why `require-fetch-import` is not a `recommended` rule

### DIFF
--- a/docs/rules/require-fetch-import.md
+++ b/docs/rules/require-fetch-import.md
@@ -6,6 +6,8 @@ because this non-wrapped version does not have a built-in test waiter. Because
 of this it is generally better to use [ember-fetch] and explicitly
 `import fetch from 'fetch'`.
 
+Note: this rule is not in the `recommended` configuration because the global `fetch` is a web standard.
+
 ## Rule Details
 
 The rule looks for `fetch()` calls and reports them as issues if no


### PR DESCRIPTION
My goal is for all of our rules to explain their caveats including why we have chosen not to include them in the `recommended` configuration.

@Turbo87 @ef4 @rwjblue is this the right/sufficient wording for the explanation? Feel free to suggest the right wording to use.

Fixes #1224.