### PR TITLE
Fix IIFE crash in `require-return-from-computed` rule

### DIFF
--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -78,6 +78,10 @@ module.exports = {
       },
 
       'FunctionExpression:exit'(node) {
+        if (node.parent.parent.parent === null) {
+          return;
+        }
+
         if (
           ember.isComputedProp(node.parent, importedEmberName, importedComputedName) ||
           ember.isComputedProp(node.parent.parent.parent, importedEmberName, importedComputedName)

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -23,7 +23,7 @@ eslintTester.run('require-return-from-computed', rule, {
     'let foo = computed("test", function() { if (true) { return ""; } return ""; })',
     'let foo = computed("test", { get() { data.forEach(function() { }); return true; }, set() { return true; } })',
     'let foo = computed("test", function() { data.forEach(function() { }); return ""; })',
-
+    '(function() { computed(); } )',
     {
       // This rule intentionally does not apply to native classes / decorator usage.
       // ESLint already has its own recommended rules `getter-return` and `no-setter-return` for this.


### PR DESCRIPTION
Currently for code snippets like IIFE,`require-return-from-computed` will with a message saying 

```
    TypeError: Cannot read property 'type' of null
    Occurred while linting <input>:2

      214 |  */
      215 | function isIdentifier(node) {
    > 216 |   return node !== undefined && node.type === 'Identifier';
          |                                     ^
      217 | }
      218 |
      219 | /**

      at Object.isIdentifier (lib/utils/types.js:216:37)
      at Object.isComputedProp (lib/utils/ember.js:408:12)
      at FunctionExpression:exit (lib/rules/require-return-from-computed.js:87:17)
      at node_modules/eslint/lib/linter/safe-emitter.js:45:58
          at Array.forEach (<anonymous>)
      at Object.emit (node_modules/eslint/lib/linter/safe-emitter.js:45:38)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/linter/node-event-generator.js:293:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/linter/node-event-generator.js:322:22)
      at NodeEventGenerator.leaveNode (node_modules/eslint/lib/linter/node-event-generator.js:345:14)
      at CodePathAnalyzer.leaveNode (node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:732:23)
```

code snippet 

```js
( function() { 
    computed(); 
} )
```


it looks like a check should be added to look for the existences of `node.parent.parent.parent` before passing it to the `ember.isComputedProp`.


