### PR TITLE
Catch destructured controller access in `no-controller-access-in-routes` rule

### DIFF
--- a/lib/rules/no-controller-access-in-routes.js
+++ b/lib/rules/no-controller-access-in-routes.js
@@ -154,6 +154,24 @@ module.exports = {
           currentRouteNode = null;
         }
       },
+
+      VariableDeclarator(node) {
+        if (!currentRouteNode) {
+          return;
+        }
+
+        if (node.init.type !== 'ThisExpression' || node.id.type !== 'ObjectPattern') {
+          return;
+        }
+
+        const controllerProperty = node.id.properties.find(
+          (prop) => prop.key.type === 'Identifier' && prop.key.name === 'controller'
+        );
+        if (controllerProperty) {
+          // Example: const { controller } = this;
+          context.report({ node: controllerProperty, message: ERROR_MESSAGE });
+        }
+      },
     };
   },
 };

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -57,6 +57,17 @@ ruleTester.run('no-controller-access-in-routes', rule, {
         }
       });
     `,
+    `
+      import Route from '@ember/routing/route';
+      export default Route.extend({
+        actions: {
+          myAction() {
+            const { foo } = this;
+            const { controller } = bar;
+          },
+        },
+      });
+    `,
 
     `
       import Component from '@ember/component';
@@ -276,6 +287,20 @@ ruleTester.run('no-controller-access-in-routes', rule, {
       `,
       output: null,
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
+    },
+    {
+      code: `
+        import Route from '@ember/routing/route';
+        import { action } from '@ember/object';
+        export default class MyRoute extends Route {
+          @action
+          myAction() {
+            const { controller } = this;
+          }
+        }
+      `,
+      output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'Property' }],
     },
   ],
 });


### PR DESCRIPTION
Fixes #1270.

CC: @mehulkar