### PR TITLE
Avoid unnecessary optional chaining in autofix for `no-get` rule when using `useOptionalChaining` option

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -59,8 +59,12 @@ function fixGet({
     return null;
   }
 
+  const getResultIsChained = node.parent.type === 'MemberExpression' && node.parent.object === node;
+
+  // If the result of get is chained, we can safely autofix nests paths without using optional chaining.
   // In the left side of an assignment, we can safely autofix nested paths without using optional chaining.
-  let replacementPath = isInLeftSideOfAssignmentExpression ? path : path.replace(/\./g, '?.');
+  let replacementPath =
+    getResultIsChained || isInLeftSideOfAssignmentExpression ? path : path.replace(/\./g, '?.');
 
   // Replace any array element access (foo.1 => foo[1] or foo?.[1]).
   replacementPath = replacementPath

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -210,6 +210,24 @@ ruleTester.run('no-get', rule, {
       errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
     },
     {
+      code: "foo1.foo2.get('bar').baz;",
+      output: 'foo1.foo2.bar.baz;',
+      options: [{ catchUnsafeObjects: true, useOptionalChaining: true }],
+      errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
+    },
+    {
+      code: "foo1.foo2.get('bar.bar').baz;",
+      output: null,
+      options: [{ catchUnsafeObjects: true }],
+      errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
+    },
+    {
+      code: "foo1.foo2.get('bar.bar').baz;",
+      output: 'foo1.foo2.bar.bar.baz;',
+      options: [{ catchUnsafeObjects: true, useOptionalChaining: true }],
+      errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
+    },
+    {
       code: `
       import { get } from '@ember/object';
       import { somethingElse } from '@ember/object';
@@ -364,6 +382,17 @@ ruleTester.run('no-get', rule, {
     {
       code: "this.get('foo.bar');",
       output: 'this.foo?.bar;',
+      options: [{ useOptionalChaining: true }],
+      errors: [
+        {
+          message: ERROR_MESSAGE_GET,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: "this.get('foo.bar').baz;",
+      output: 'this.foo.bar.baz;',
       options: [{ useOptionalChaining: true }],
       errors: [
         {


### PR DESCRIPTION
This maintains the behavior more closely when a nested chain contains a nullish value.

```
  // when foo or bar is nullish:
  this.get('foo.bar').baz // will error with "baz of undefined"
  this.foo?.bar?.baz      // (previous behavior) evaluates to `undefined`
  this.foo.bar.baz        // (updated behavior)  errors with either "bar of undefined" or "baz of undefined"
```

