### PR TITLE
Super call missing arguments in some rule docs

### DIFF
--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -25,8 +25,8 @@ export default class MyService extends Service {
 ```js
 @classic
 export default class MyService extends Service {
-  constructor() {
-    super(...arguments);
+  constructor(...args) {
+    super(...args);
     // ...
   }
 }
@@ -49,8 +49,8 @@ export default class MyService extends Service {
 
 ```js
 export default class MyService extends Service {
-  constructor() {
-    super(...arguments);
+  constructor(...args) {
+    super(...args);
     // ...
   }
 

--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -26,7 +26,7 @@ export default class MyService extends Service {
 @classic
 export default class MyService extends Service {
   constructor() {
-    super();
+    super(...arguments);
     // ...
   }
 }
@@ -50,7 +50,7 @@ export default class MyService extends Service {
 ```js
 export default class MyService extends Service {
   constructor() {
-    super();
+    super(...arguments);
     // ...
   }
 

--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -63,7 +63,7 @@ import GlimmerComponent from '@glimmer/component';
 export default class MyComponent extends GlimmerComponent {
   // Glimmer component lifecycle hooks:
   constructor(...args) {
-    super(args);
+    super(...args);
   }
   willDestroy() {}
 }

--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -50,7 +50,9 @@ Examples of **correct** code for this rule:
 import Component from '@ember/component';
 
 export default class MyComponent extends Component {
-  init() {}
+  init(...args) {
+    this._super(args);
+  }
   willDestroy() {} // Both a classic and Glimmer component lifecycle hook
 }
 ```
@@ -60,8 +62,8 @@ import GlimmerComponent from '@glimmer/component';
 
 export default class MyComponent extends GlimmerComponent {
   // Glimmer component lifecycle hooks:
-  constructor() {
-    super();
+  constructor(...args) {
+    super(args);
   }
   willDestroy() {}
 }

--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -51,7 +51,7 @@ import Component from '@ember/component';
 
 export default class MyComponent extends Component {
   init(...args) {
-    this._super(args);
+    this._super(...args);
   }
   willDestroy() {} // Both a classic and Glimmer component lifecycle hook
 }


### PR DESCRIPTION
You should call `super` with `...arguments` otherwise bad things happen.