### PR TITLE
Add jsdoc `type` annotation to rules

### DIFF
--- a/lib/rules/alias-model-in-controller.js
+++ b/lib/rules/alias-model-in-controller.js
@@ -7,6 +7,9 @@ const ember = require('../utils/ember');
 // Controllers - Alias your model
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -48,6 +48,9 @@ function isAllowed(value) {
 // (Don't use arrays or objects as default props)
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/avoid-using-needs-in-controllers.js
+++ b/lib/rules/avoid-using-needs-in-controllers.js
@@ -6,6 +6,9 @@ const ember = require('../utils/ember');
 // Ember object rule - Avoid using needs in controllers
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/classic-decorator-hooks.js
+++ b/lib/rules/classic-decorator-hooks.js
@@ -5,6 +5,9 @@ const ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC =
 const ERROR_MESSAGE_CONSTRUCTOR_IN_CLASSIC =
   'You cannot use the constructor in a classic class. If the class can be converted, you can convert it to remove all classic APIs and remove the @classic decorator, then switch to the constructor.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_INIT_IN_NON_CLASSIC,
   ERROR_MESSAGE_DESTROY_IN_NON_CLASSIC,

--- a/lib/rules/classic-decorator-no-classic-methods.js
+++ b/lib/rules/classic-decorator-no-classic-methods.js
@@ -18,6 +18,9 @@ function disallowedMethodErrorMessage(name) {
   return `The this.${name}() method is a classic ember object method, and can't be used in octane classes. You can refactor this usage to use a utility version instead (e.g. get(this, 'foo')), or to use native/modern syntax instead. Alternatively, you can add the @classic decorator to this class to continue using classic APIs.`;
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   disallowedMethodErrorMessage,
 

--- a/lib/rules/closure-actions.js
+++ b/lib/rules/closure-actions.js
@@ -8,6 +8,9 @@ const types = require('../utils/types');
 
 const ERROR_MESSAGE = 'Use closure actions';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/computed-property-getters.js
+++ b/lib/rules/computed-property-getters.js
@@ -13,6 +13,9 @@ const PREVENT_GETTER_MESSAGE = 'Do not use a getter inside computed properties.'
 const ALWAYS_WITH_SETTER_MESSAGE =
   'Always define a getter inside computed properties when using a setter.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -29,6 +29,9 @@ const EMBER_RUNLOOP_FUNCTIONS = [
   'throttle',
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -6,6 +6,9 @@ const types = require('../utils/types');
 // General rule - Use named functions defined on objects to handle promises
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/new-module-imports.js
+++ b/lib/rules/new-module-imports.js
@@ -22,6 +22,9 @@ const GLOBALS = MAPPING.reduce((memo, exportDefinition) => {
 // General rule - Use "New Module Imports" from Ember RFC #176
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-actions-hash.js
+++ b/lib/rules/no-actions-hash.js
@@ -3,6 +3,9 @@ const utils = require('../utils/utils');
 
 const ERROR_MESSAGE = 'Use the @action decorator instead of declaring an actions hash';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
   meta: {

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -6,6 +6,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = 'Do not use arrow functions in computed properties';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
 

--- a/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -83,6 +83,9 @@ class Stack {
   }
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -9,6 +9,9 @@ const ERROR_MESSAGE = 'Do not use `this.attrs`';
 // General rule - Don't use this.attrs
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-attrs-snapshot.js
+++ b/lib/rules/no-attrs-snapshot.js
@@ -17,6 +17,9 @@ const hasAttrsSnapShot = function (node) {
   return (methodName === 'didReceiveAttrs' || methodName === 'didUpdateAttrs') && hasParams;
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-capital-letters-in-routes.js
+++ b/lib/rules/no-capital-letters-in-routes.js
@@ -7,6 +7,9 @@ const types = require('../utils/types');
 // Routing - No capital letters in routes
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -35,6 +35,9 @@ function isEmberImport(classImportedFrom) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_NO_CLASSIC_CLASSES,
 

--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -6,6 +6,9 @@ const assert = require('assert');
 const ERROR_MESSAGE =
   'Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-component-lifecycle-hooks.js
+++ b/lib/rules/no-component-lifecycle-hooks.js
@@ -16,6 +16,9 @@ const report = (context, node) => {
   context.report(node, ERROR_MESSAGE_NO_COMPONENT_LIFECYCLE_HOOKS);
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_NO_COMPONENT_LIFECYCLE_HOOKS,
   meta: {

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -26,6 +26,9 @@ function findComputedNodes(nodeBody) {
 // General rule - Do not use computed properties in native classes
 //----------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-controller-access-in-routes.js
+++ b/lib/rules/no-controller-access-in-routes.js
@@ -11,6 +11,9 @@ const ERROR_MESSAGE =
 // Routing - No controller access in routes
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-controllers.js
+++ b/lib/rules/no-controllers.js
@@ -5,6 +5,9 @@ const assert = require('assert');
 
 const ERROR_MESSAGE = 'Avoid using controllers except for specifying `queryParams`';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
   meta: {

--- a/lib/rules/no-current-route-name.js
+++ b/lib/rules/no-current-route-name.js
@@ -2,6 +2,9 @@
 
 const ERROR_MESSAGE = 'Use currentURL() instead of currentRouteName()';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -10,6 +10,9 @@ const { getImportIdentifier } = require('../utils/import');
 const ERROR_MESSAGE =
   'Dependent keys containing `@each` only work one level deep. You cannot use nested forms like: `todos.@each.owner.name`. Please create an intermediary computed property instead.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-duplicate-dependent-keys.js
+++ b/lib/rules/no-duplicate-dependent-keys.js
@@ -11,6 +11,9 @@ const ERROR_MESSAGE = 'Dependent keys should not be repeated';
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -1,5 +1,8 @@
 'use strict';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -9,6 +9,9 @@ const ERROR_MESSAGES = [
   'Can not use destructuring to reference Ember.testing',
 ];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-empty-attrs.js
+++ b/lib/rules/no-empty-attrs.js
@@ -6,6 +6,9 @@ const ember = require('../utils/ember');
 // Ember Data - Be explicit with Ember data attribute types
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-empty-glimmer-component-classes.js
+++ b/lib/rules/no-empty-glimmer-component-classes.js
@@ -8,6 +8,9 @@ const ERROR_MESSAGE = 'Do not create empty backing classes for Glimmer component
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-function-prototype-extensions.js
+++ b/lib/rules/no-function-prototype-extensions.js
@@ -6,6 +6,9 @@ const types = require('../utils/types');
 // General rule - Don't use Ember's function prototype extensions like .property() or .observe()
 //----------------------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -5,6 +5,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = 'Use `||` or the ternary operator instead of `getWithDefault()`';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
   meta: {

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -80,6 +80,9 @@ function fixGet({
   return fixer.replaceText(node, `${objectTextSafe}${objectPathSeparator}${replacementPath}`);
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_GET,
   ERROR_MESSAGE_GET_PROPERTIES,

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -9,6 +9,9 @@ const ERROR_MESSAGE = 'Do not use global `$` or `jQuery`';
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-html-safe.js
+++ b/lib/rules/no-html-safe.js
@@ -7,6 +7,9 @@ const { getImportIdentifier } = require('../utils/import');
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-implicit-service-injection-argument.js
+++ b/lib/rules/no-implicit-service-injection-argument.js
@@ -10,6 +10,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = "Don't omit the argument for the injected service name.";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -17,6 +17,9 @@ const functionRules = [
 
 const allDedupingRunMethodNames = new Set(functionRules.map((rule) => rule.importName));
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
 

--- a/lib/rules/no-incorrect-computed-macros.js
+++ b/lib/rules/no-incorrect-computed-macros.js
@@ -5,6 +5,9 @@ const types = require('../utils/types');
 
 const ERROR_MESSAGE_AND_OR = 'Computed property macro should be used with 2+ arguments';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-invalid-debug-function-arguments.js
+++ b/lib/rules/no-invalid-debug-function-arguments.js
@@ -12,6 +12,9 @@ const ERROR_MESSAGE =
 
 const DEBUG_FUNCTIONS = ['assert', 'deprecate', 'warn'];
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-invalid-dependent-keys.js
+++ b/lib/rules/no-invalid-dependent-keys.js
@@ -35,6 +35,9 @@ function hasMiddleBrackets(str) {
   return str.includes('[].');
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-invalid-test-waiters.js
+++ b/lib/rules/no-invalid-test-waiters.js
@@ -20,6 +20,9 @@ function isDirectVariableDeclaration(node) {
   return node.parent.type === 'VariableDeclarator';
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -10,6 +10,9 @@ const { globalMap, esmMap } = require('../utils/jquery');
 
 const ERROR_MESSAGE = 'Do not use jQuery';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-legacy-test-waiters.js
+++ b/lib/rules/no-legacy-test-waiters.js
@@ -5,6 +5,9 @@ const LEGACY_TEST_WAITER_FUNCTIONS = ['registerWaiter', 'unregisterWaiter'];
 const ERROR_MESSAGE =
   'The use of the legacy test waiters API is not allowed. Please use the new ember-test-waiters (https://github.com/emberjs/ember-test-waiters) APIs instead.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-mixins.js
+++ b/lib/rules/no-mixins.js
@@ -7,6 +7,9 @@
 const ERROR_MESSAGE = "Don't use a mixin";
 const mixinPathRegex = /\/mixins\//;
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-new-mixins.js
+++ b/lib/rules/no-new-mixins.js
@@ -8,6 +8,9 @@ const ember = require('../utils/ember');
 
 const ERROR_MESSAGE = "Don't create new mixins";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-noop-setup-on-error-in-before.js
+++ b/lib/rules/no-noop-setup-on-error-in-before.js
@@ -7,6 +7,9 @@ const types = require('../utils/types');
 // General rule - Disallows no-op `setupOnError` in `before` or `beforeEach`.
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-observers.js
+++ b/lib/rules/no-observers.js
@@ -10,6 +10,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = "Don't use observers";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-old-shims.js
+++ b/lib/rules/no-old-shims.js
@@ -248,6 +248,9 @@ const oldShimsData = {
 
 const { buildFix } = require('../utils/new-module');
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-on-calls-in-components.js
+++ b/lib/rules/no-on-calls-in-components.js
@@ -8,6 +8,9 @@ const types = require('../utils/types');
 // Don’t use .on() for component lifecycle events.
 //----------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-pause-test.js
+++ b/lib/rules/no-pause-test.js
@@ -10,6 +10,9 @@ const ERROR_MESSAGE = 'Do not use `pauseTest()`';
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -18,6 +18,9 @@ const ROUTER_MICROLIB_ERROR_MESSAGE =
 const ROUTER_MAIN_ERROR_MESSAGE =
   "Don't access `router:main` as it is a private API. Instead use the public 'router' service.";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-proxies.js
+++ b/lib/rules/no-proxies.js
@@ -6,6 +6,9 @@ const ERROR_MESSAGE = 'Do not use array or object proxies.';
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-replace-test-comments.js
+++ b/lib/rules/no-replace-test-comments.js
@@ -8,6 +8,9 @@ const ERROR_MESSAGE = "No 'Replace this with your real tests' comments. Add a su
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-restricted-property-modifications.js
+++ b/lib/rules/no-restricted-property-modifications.js
@@ -5,6 +5,9 @@ const { getImportIdentifier } = require('../utils/import');
 const { isThisSet: isThisSetNative } = require('../utils/property-setter');
 const { nodeToDependentKey } = require('../utils/property-getter');
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-restricted-resolver-tests.js
+++ b/lib/rules/no-restricted-resolver-tests.js
@@ -70,6 +70,9 @@ function getLastArgument(node) {
   return lastArgument;
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -7,6 +7,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const DEFAULT_ERROR_MESSAGE = 'Injecting this service is not allowed from this file.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-settled-after-test-helper.js
+++ b/lib/rules/no-settled-after-test-helper.js
@@ -19,6 +19,9 @@ const SETTLING_TEST_HELPERS = new Set([
   'visit',
 ]);
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-shadow-route-definition.js
+++ b/lib/rules/no-shadow-route-definition.js
@@ -34,6 +34,9 @@ function isNestedRouteWithSamePath(routeInfo) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -135,6 +135,9 @@ function findSideEffects(
 
 const ERROR_MESSAGE = "Don't introduce side-effects in computed properties";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-string-prototype-extensions.js
+++ b/lib/rules/no-string-prototype-extensions.js
@@ -16,6 +16,9 @@ const EXTENSION_METHODS = new Set([
   'w',
 ]);
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-test-and-then.js
+++ b/lib/rules/no-test-and-then.js
@@ -9,6 +9,9 @@ const ERROR_MESSAGE = 'Use `await` instead of `andThen` test wait helper.';
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -12,6 +12,9 @@ const NO_IMPORT_MESSAGE =
 
 const NO_EXPORT_MESSAGE = 'No exports from test file. Any exports should be done in a test helper.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-test-module-for.js
+++ b/lib/rules/no-test-module-for.js
@@ -11,6 +11,9 @@ const ERROR_MESSAGE = 'moduleFor* apis are are not allowed. Use `module` instead
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-test-support-import.js
+++ b/lib/rules/no-test-support-import.js
@@ -9,6 +9,9 @@ const path = require('path');
 const ERROR_MESSAGE_NO_IMPORT =
   'Do not import a file from test-support into production code, only into test files.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_NO_IMPORT,
 

--- a/lib/rules/no-test-this-render.js
+++ b/lib/rules/no-test-this-render.js
@@ -11,6 +11,9 @@ function makeErrorMessage(functionName) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-try-invoke.js
+++ b/lib/rules/no-try-invoke.js
@@ -5,6 +5,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = 'Use optional chaining operator `?.()` instead of `tryInvoke`';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
   meta: {

--- a/lib/rules/no-unnecessary-index-route.js
+++ b/lib/rules/no-unnecessary-index-route.js
@@ -9,6 +9,9 @@ const emberUtils = require('../utils/ember');
 const ERROR_MESSAGE =
   'The `index` route is automatically provided and does not need to be defined.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-unnecessary-route-path-option.js
+++ b/lib/rules/no-unnecessary-route-path-option.js
@@ -11,6 +11,9 @@ const { getNodeOrNodeFromVariable } = require('../utils/utils');
 
 const ERROR_MESSAGE = 'Do not provide unnecessary `path` option which matches the route name.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/lib/rules/no-unnecessary-service-injection-argument.js
@@ -11,6 +11,9 @@ const { getImportIdentifier } = require('../utils/import');
 const ERROR_MESSAGE =
   "Don't specify injected service name as an argument when it matches the property name.";
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -24,6 +24,9 @@ class Stack {
   }
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-volatile-computed-properties.js
+++ b/lib/rules/no-volatile-computed-properties.js
@@ -6,6 +6,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = 'Do not use volatile computed properties';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
 

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -35,6 +35,9 @@ const ORDER = [
 // Organizing - Organize your components and keep order in objects
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/order-in-controllers.js
+++ b/lib/rules/order-in-controllers.js
@@ -26,6 +26,9 @@ const ORDER = [
 // Organizing - Organize your routes and keep order in objects
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/order-in-models.js
+++ b/lib/rules/order-in-models.js
@@ -20,6 +20,9 @@ const ORDER = [
 // Attributes -> Relations -> Computed Properties
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/order-in-routes.js
+++ b/lib/rules/order-in-routes.js
@@ -33,6 +33,9 @@ const ORDER = [
 // Organizing - Organize your routes and keep order in objects
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -7,6 +7,9 @@ const { ReferenceTracker } = require('eslint-utils');
 // Rule Definition
 //-------------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -122,6 +122,9 @@ function makeFix(nodeToReplace, macro, macroArgs) {
   return `${prefix}computed.${macro}(${macroArgs})${suffix}`;
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -281,6 +281,9 @@ function removeServiceNames(keys, serviceNames) {
 
 const ERROR_MESSAGE_NON_STRING_VALUE = 'Non-string value used as computed property dependency';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/require-fetch-import.js
+++ b/lib/rules/require-fetch-import.js
@@ -4,6 +4,9 @@ const { ReferenceTracker } = require('eslint-utils');
 
 const ERROR_MESSAGE = 'Explicitly import `fetch` instead of using `window.fetch`';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -13,6 +13,9 @@ function isReachable(segment) {
 
 const ERROR_MESSAGE = 'Always return a value from computed properties';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -53,6 +53,9 @@ function isNativeSuper(node, hook) {
 
 const ERROR_MESSAGE = 'Call super in lifecycle hooks';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE,
 

--- a/lib/rules/require-tagless-components.js
+++ b/lib/rules/require-tagless-components.js
@@ -85,6 +85,9 @@ function getDecoratorCallExpressionWithName(node, name) {
   );
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS,
 

--- a/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -115,6 +115,9 @@ function _isTestHelperCall(node, hasTestHelperImport, localImportNames) {
   return hasTestHelperImport && localImportNames.includes(calleeName[0]);
 }
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/route-path-style.js
+++ b/lib/rules/route-path-style.js
@@ -11,6 +11,9 @@ const { getNodeOrNodeFromVariable } = require('../utils/utils');
 
 const ERROR_MESSAGE = 'Use kebab-case in route path.';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -13,6 +13,9 @@ const isNotSnakeCase = function (name) {
   return snakeCase(name) !== name;
 };
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/use-brace-expansion.js
+++ b/lib/rules/use-brace-expansion.js
@@ -10,6 +10,9 @@ const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE = 'Use brace expansion';
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -60,6 +60,9 @@ const ERROR_MESSAGE =
 // Rule Definition - Use "Ember Data Packages" from Ember RFC #395
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -12,6 +12,9 @@ const isThisExpression = types.isThisExpression;
 // General - use get and set
 //------------------------------------------------------------------------------
 
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
 module.exports = {
   meta: {
     type: 'suggestion',


### PR DESCRIPTION
Supported by VSCode/Webstorm/other code editors. Uses TypeScript declaration to give JavaScript hints so code editors can provide information/autocomplete about various rule fields.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113