### PR TITLE
Remove non-existent option from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint:js": "eslint . --cache",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
-    "lint:package-json-sorting:fix": "sort-package-json --fix package.json",
+    "lint:package-json-sorting:fix": "sort-package-json package.json",
     "release": "release-it",
     "start": "yarn run test:watch",
     "test": "jest",


### PR DESCRIPTION
`sort-package-json` does not have a `--fix` option.