### PR TITLE
Fix markdownlint glob path

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "changelog": "lerna-changelog",
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint **/*.md",
+    "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint . --cache",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",


### PR DESCRIPTION
Quotes around the glob is necessary to ensure it picks up all files in this case.

Another example of this: https://github.com/ember-template-lint/ember-template-lint/pull/2124