### PR TITLE
Allow empty-but-decorated classes in `no-empty-glimmer-component-classes` rule

### DIFF
--- a/docs/rules/no-empty-glimmer-component-classes.md
+++ b/docs/rules/no-empty-glimmer-component-classes.md
@@ -44,6 +44,14 @@ const MyComponent = templateOnly();
 export default MyComponent;
 ```
 
+```js
+import Component from '@glimmer/component';
+import MyDecorator from 'my-decorator';
+
+@MyDecorator
+class MyComponent extends Component {}
+```
+
 ## References
 
 - [Glimmer Components - Octane Upgrade Guide](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/)

--- a/lib/rules/no-empty-glimmer-component-classes.js
+++ b/lib/rules/no-empty-glimmer-component-classes.js
@@ -27,7 +27,7 @@ module.exports = {
   create(context) {
     return {
       ClassDeclaration(node) {
-        if (isGlimmerComponent(context, node) && node.body.body.length === 0) {
+        if (isGlimmerComponent(context, node) && !node.decorators && node.body.body.length === 0) {
           context.report({ node, message: ERROR_MESSAGE });
         }
       },

--- a/tests/lib/rules/no-empty-glimmer-component-classes.js
+++ b/tests/lib/rules/no-empty-glimmer-component-classes.js
@@ -12,6 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
+  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
@@ -28,6 +29,11 @@ ruleTester.run('no-empty-glimmer-component-classes', rule, {
       }
     }`,
     'class MyComponent extends NotAGlimmerComponent {}',
+    `import Component from '@glimmer/component';
+    import MyDecorator from 'my-decorator';
+
+    @MyDecorator
+    class MyComponent extends Component {}`,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #1373