### PR TITLE
Fix broken URLs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ If you have any suggestions, ideas, or problems, feel free to [create an issue](
   - `docs/rules/new-rule.md` (documentation, start from the template -- [raw](https://raw.githubusercontent.com/ember-cli/eslint-plugin-ember/master/docs/rules/_TEMPLATE_.md), [rendered](docs/rules/_TEMPLATE_.md))
   - `tests/lib/rules/new-rule.js` (tests, see [no-proxies](tests/lib/rules/no-proxies.js) for an example)
 - Run `yarn update` to automatically update the README and other files (and re-run this if you change the rule name or description)
-- Make sure your changes will pass [CI](.travis.yml) by running:
+- Make sure your changes will pass [CI](./.github/workflows/ci.yml) by running:
   - `yarn test`
   - `yarn lint` (`yarn lint:js --fix` can fix many errors)
 - Create a PR and link the created issue in the description

--- a/docs/rules/no-empty-attrs.md
+++ b/docs/rules/no-empty-attrs.md
@@ -32,7 +32,7 @@ export default Model.extend({
 });
 ```
 
-In case you need a custom behavior, it's good to write your own [transform](http://emberjs.com/api/data/classes/DS.Transform.html).
+In case you need a custom behavior, it's good to write your own [transform](https://api.emberjs.com/ember-data/release/classes/Transform).
 
 ## Help Wanted
 

--- a/docs/rules/no-get-with-default.md
+++ b/docs/rules/no-get-with-default.md
@@ -50,7 +50,7 @@ This rule takes an optional object containing:
 ## References
 
 - [RFC](https://github.com/emberjs/rfcs/pull/554/) to deprecate `getWithDefault`
-- [spec](http://api.emberjs.com/ember/3.13/functions/@ember%2Fobject/getWithDefault)
+- [spec](https://api.emberjs.com/ember/3.13/functions/@ember%2Fobject/getWithDefault)
 
 ## Related Rules
 

--- a/docs/rules/no-implicit-service-injection-argument.md
+++ b/docs/rules/no-implicit-service-injection-argument.md
@@ -39,4 +39,4 @@ export default class Page extends Component {
 ## References
 
 * Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
-* Ember [inject](https://emberjs.com/api/ember/release/functions/@ember%2Fservice/inject) function spec
+* Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec

--- a/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
+++ b/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
@@ -62,5 +62,5 @@ export default Component.extend({
 ## References
 
 - [Ember debounce API Docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/debounce)
-- [Ember once API Docs](http://api.emberjs.com/ember/release/functions/@ember%2Frunloop/once)
+- [Ember once API Docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/once)
 - [Ember scheduleOnce API Docs](https://api.emberjs.com/ember/release/functions/@ember%2Frunloop/scheduleOnce)

--- a/docs/rules/no-incorrect-computed-macros.md
+++ b/docs/rules/no-incorrect-computed-macros.md
@@ -43,4 +43,4 @@ export default Component.extend({
 ## References
 
 * [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
-* [Spec](http://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
+* [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros

--- a/docs/rules/no-invalid-debug-function-arguments.md
+++ b/docs/rules/no-invalid-debug-function-arguments.md
@@ -42,6 +42,6 @@ deprecate('Title is no longer supported.', title, { id: 'unwanted-title', until:
 
 ## Further Reading
 
-* See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Fdebug/assert) for the Ember `assert` function.
-* See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Fdebug/warn) for the Ember `warn` function.
-* See the [documentation](https://emberjs.com/api/api/ember/release/functions/@ember%2Fapplication%2Fdeprecations/deprecate) for the Ember `deprecate` function.
+* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/assert) for the Ember `assert` function.
+* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/warn) for the Ember `warn` function.
+* See the [documentation](https://api.emberjs.com/ember/3.4/functions/@ember%2Fapplication%2Fdeprecations/deprecate) for the Ember `deprecate` function.

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -62,7 +62,7 @@ export default Component.extend({
 ## References
 
 * [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
-* [Why Are Mixins Considered Harmful?](http://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
+* [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
 
 ## Related Rules
 

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -9,7 +9,7 @@ For practical strategies on removing mixins see [this discourse thread](https://
 For more details and examples of how mixins create problems down-the-line, see these excellent blog posts:
 
 * [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
-* [Why Are Mixins Considered Harmful?](http://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
+* [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
 
 ## Examples
 

--- a/docs/rules/no-string-prototype-extensions.md
+++ b/docs/rules/no-string-prototype-extensions.md
@@ -8,7 +8,7 @@ on these methods in addons, but that addon being used in an app that has the
 extensions disabled.
 
 Additionally, the prototype extensions for the `String` object have been
-deprecated in [RFC #236](http://emberjs.github.io/rfcs/0236-deprecation-ember-string.html).
+deprecated in [RFC #236](https://emberjs.github.io/rfcs/0236-deprecation-ember-string.html).
 
 ## Rule Details
 
@@ -64,4 +64,4 @@ dasherize('myString');
 ## References
 
 * [Prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
-* [String prototype extensions deprecation RFC](http://emberjs.github.io/rfcs/0236-deprecation-ember-string.html#string-prototype-extensions)
+* [String prototype extensions deprecation RFC](https://emberjs.github.io/rfcs/0236-deprecation-ember-string.html#string-prototype-extensions)

--- a/docs/rules/no-unnecessary-service-injection-argument.md
+++ b/docs/rules/no-unnecessary-service-injection-argument.md
@@ -48,4 +48,4 @@ export default Component.extend({
 ## References
 
 * Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
-* Ember [inject](https://emberjs.com/api/ember/release/functions/@ember%2Fservice/inject) function spec
+* Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec

--- a/docs/rules/no-unused-services.md
+++ b/docs/rules/no-unused-services.md
@@ -45,4 +45,4 @@ export default class MyComponent extends Component {
 ## References
 
 - Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
-- Ember [inject](https://emberjs.com/api/ember/release/functions/@ember%2Fservice/inject) function spec
+- Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -70,7 +70,7 @@ If you would like to specify ordering for a property type that is not listed, yo
 
 ### Additional Properties
 
-You can find the full list of properties [here](/lib/utils/property-order.js#L10).
+You can find the full list of properties [here](../../lib/utils/property-order.js#L10).
 
 ## Description
 

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -46,7 +46,7 @@ If you would like to specify ordering for a property type that is not listed, yo
 
 ### Additional Properties
 
-You can find the full list of properties [here](/lib/utils/property-order.js#L10).
+You can find the full list of properties [here](../../lib/utils/property-order.js#L10).
 
 ## Description
 

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -41,7 +41,7 @@ If you would like to specify ordering for a property type that is not listed, yo
 
 ### Additional Properties
 
-You can find the full list of properties [here](/lib/utils/property-order.js#L10).
+You can find the full list of properties [here](../../lib/utils/property-order.js#L10).
 
 ## Description
 

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -66,7 +66,7 @@ If you would like to specify ordering for a property type that is not listed, yo
 
 ### Additional Properties
 
-You can find the full list of properties [here](/lib/utils/property-order.js#L10).
+You can find the full list of properties [here](../../lib/utils/property-order.js#L10).
 
 ## Description
 

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -124,7 +124,7 @@ This rule takes an optional object containing:
 ## References
 
 * [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
-* [Spec](http://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
+* [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
 
 ## Related Rules
 


### PR DESCRIPTION
Detected with: https://github.com/tcort/markdown-link-check