### PR TITLE
BREAKING CHANGE: drop node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows ]
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
In order to support: https://github.com/ember-cli/eslint-plugin-ember/pull/1395
We cannot support node 10