### PR TITLE
Support `replace` in no-array-prototype-extensions

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -28,7 +28,7 @@ const EXTENSION_METHODS = new Set([
   'without',
   /**
    * https://api.emberjs.com/ember/release/classes/MutableArray
-   * MutableArray methods excluding `replace` since it's part of string native functions
+   * MutableArray methods excluding `replace`. `replace` is handled differently as it's also part of String.prototype.
    * */
   'addObject',
   'addObjects',
@@ -46,6 +46,8 @@ const EXTENSION_METHODS = new Set([
   'unshiftObject',
   'unshiftObjects',
 ]);
+
+const REPLACE_METHOD = 'replace';
 
 /**
  * https://api.emberjs.com/ember/release/classes/EmberArray
@@ -96,6 +98,13 @@ module.exports = {
         }
 
         if (EXTENSION_METHODS.has(node.callee.property.name)) {
+          context.report({ node, messageId: 'main' });
+        }
+
+        // Example: someArray.replace(1, 2, [1, 2, 3]);
+        // We can differentiate String.prototype.replace and Array.prototype.replace by arguments length
+        // String.prototype.replace can only have 2 arguments, Array.prototype.replace needs to have exact 3 arguments
+        if (node.callee.property.name === REPLACE_METHOD && node.arguments.length === 3) {
           context.report({ node, messageId: 'main' });
         }
       },

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -36,9 +36,8 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     /** Optional chaining */
     'arr?.notfirstObject?.foo',
     'arr?.filter?.()',
-    /** Replace is part of string native prototypes */
-    "'something'.replace()",
-    'something.replace()',
+    /** String prototype replace */
+    "'something'.replace(regexp, 'substring')",
   ],
   invalid: [
     {
@@ -269,6 +268,11 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     },
     {
       code: 'something.unshiftObjects()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.replace(1, 2, someArray)',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },


### PR DESCRIPTION
Catch `replace` as part of `no-array-prototype-extensions`. Previously we skipped as it's also part of String.prototype, we can still differentiate them by checking arguments length.

[String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)

[Array.prototype.replace()](https://api.emberjs.com/ember/4.3/classes/MutableArray/methods/replace?anchor=replace)