### PR TITLE
Update `avoid-leaking-state-in-ember-objects` rule to augment instead of replace default config

### DIFF
--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -62,22 +62,14 @@ export default class FooComponent extends Component {
 
 ## Configuration
 
-If you have properties where you know that the shared state won't be a problem (for example, read-only configuration values),
-you can configure this rule to ignore specific properties. Ember already does this internally for properties such as `actions`.
-
-The configuration of this rule takes a second argument that is a list of property names to ignore. This plugin makes the default
-list of ignored properties available for you to extend from, as follows:
+If you have custom properties where you know that the shared state won't be a problem (for example, read-only configuration values), you can configure this rule to ignore them by passing the property names to the rule as follows. Note that this rule will always automatically ignore known-safe Ember properties such as `actions`.
 
 ```js
-const {
-  DEFAULT_IGNORED_PROPERTIES
-} = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');
-
 module.exports = {
   rules: {
     'ember/avoid-leaking-state-in-ember-objects': [
       'error',
-      [...DEFAULT_IGNORED_PROPERTIES, 'array', 'of', 'ignored', 'properties']
+      ['array', 'of', 'ignored', 'properties']
     ]
   }
 };

--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -69,10 +69,10 @@ module.exports = {
     ],
   },
 
-  DEFAULT_IGNORED_PROPERTIES,
-
   create(context) {
-    const ignoredProperties = context.options[0] || DEFAULT_IGNORED_PROPERTIES;
+    const ignoredProperties = context.options[0]
+      ? [...DEFAULT_IGNORED_PROPERTIES, ...context.options[0]]
+      : DEFAULT_IGNORED_PROPERTIES;
 
     const report = function (node) {
       const message =

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -9,22 +9,6 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-describe('imports', () => {
-  it('should expose the default ignored properties', () => {
-    expect(rule.DEFAULT_IGNORED_PROPERTIES).toStrictEqual([
-      'classNames',
-      'classNameBindings',
-      'actions',
-      'concatenatedProperties',
-      'mergedProperties',
-      'positionalParams',
-      'attributeBindings',
-      'queryParams',
-      'attrs',
-    ]);
-  });
-});
-
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
@@ -71,11 +55,25 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
     'import Component from "@ember/component"; export default class MyNativeClassComponent extends Component { someArrayField = []; }',
     'import Component from "@ember/component"; export default class MyNativeClassComponent extends Component { someObjectField = {}; }',
     'import EmberObject from "@ember/object"; export default class MyNativeClassComponentWithAMixin extends EmberObject.extend(MyMixin) { someArrayField = []; }',
+    { code: 'export default Foo.extend({ someProp: [] });', options: [['someProp']] }, // With options.
+    { code: 'export default Foo.extend({ someProp: [], actions: {} });', options: [['someProp']] }, // With options and known Ember property.
   ],
   invalid: [
     {
       code: 'export default Foo.extend({someProp: []});',
       output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      // With options.
+      code: 'export default Foo.extend({someProp: [], someProp2: [], actions: {} });',
+      output: null,
+      options: [['someProp']],
       errors: [
         {
           message:


### PR DESCRIPTION
Right now, it's inconvenient and error-prone how users have to import the default config in order to augment it for the [avoid-leaking-state-in-ember-objects](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/avoid-leaking-state-in-ember-objects.md) rule. Augmenting the default config is the behavior that all or most users want (I'm unaware why anyone would ever NOT want to augment it), so we can simplify the rule by doing this automatically. Please file an issue if this doesn't meet your needs.



Before:

```js
const {
  DEFAULT_IGNORED_PROPERTIES
} = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects');

module.exports = {
  rules: {
    'ember/avoid-leaking-state-in-ember-objects': [
      'error',
      [...DEFAULT_IGNORED_PROPERTIES, 'array', 'of', 'ignored', 'properties']
    ]
  }
};
```

Another before example:

```js
const { DEFAULT_IGNORED_PROPERTIES } = require('eslint-plugin-ember/lib/rules/avoid-leaking-state-in-ember-objects')
// This comes directly from the documentation for Ember Data URL Templates:
// https://github.com/amiel/ember-data-url-templates/wiki/Custom-urlSegments
'ember/avoid-leaking-state-in-ember-objects': ['error', ['urlSegments'].concat(DEFAULT_IGNORED_PROPERTIES)],
```

After this change (no behavior change):

```js
module.exports = {
  rules: {
    'ember/avoid-leaking-state-in-ember-objects': [
      'error',
      ['array', 'of', 'ignored', 'properties']
    ]
  }
};
```

Eliminating the need to import from this rule will make it easier for us to strictly-define our Node API using package.json `exports` in the next major release (meaning we will prevent users from importing data from arbitrary files inside this plugin).

Part of v11 release (#1169).