### PR TITLE
Stop exporting non-Ember utils

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,5 @@ module.exports = {
   configs: requireIndex(`${__dirname}/config`),
   utils: {
     ember: require('./utils/ember'),
-    utils: require('./utils/utils'),
   },
 };

--- a/tests/plugin-exports.js
+++ b/tests/plugin-exports.js
@@ -2,14 +2,13 @@
 
 const plugin = require('../lib');
 const ember = require('../lib/utils/ember');
-const utils = require('../lib/utils/utils');
 const base = require('../lib/config/base');
 const recommended = require('../lib/config/recommended');
 
 describe('plugin exports', () => {
   describe('utils', () => {
     it('has the right util functions', () => {
-      expect(plugin.utils).toStrictEqual({ ember, utils });
+      expect(plugin.utils).toStrictEqual({ ember });
     });
   });
 


### PR DESCRIPTION
Based on this [github search](https://github.com/search?p=1&q=require%28%27eslint-plugin-ember%27%29&type=Code), it doesn't look like anyone is importing anything of substance from our utils/utils.js utility file. These are all generic, non-Ember specific utils that are subject to change at any time and so it's best not to have anyone import/rely/depend on them.

If we hear that there's a need for any/some of these utils, we can consider individually-exporting them instead of exporting the entire file. Please file an issue if that is the case. For simple/trivial utils, it's probably best for anyone who uses them to just copy them into their own project.

Note that based on the above search, I did see a few more usages of our Ember utils, and those utils are specifically related to the purpose of eslint-plugin-ember, so we'll continue exporting those, but perhaps we should audit them at some point.

Related change:
* https://github.com/ember-cli/eslint-plugin-ember/pull/1514

Part of v11 release (https://github.com/ember-cli/eslint-plugin-ember/issues/1169).