### PR TITLE
Strictly define Node API

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "url": "git+https://github.com/ember-cli/eslint-plugin-ember.git"
   },
   "license": "MIT",
-  "main": "lib/index.js",
+  "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "directories": {
     "test": "test",
     "rules": "rules"


### PR DESCRIPTION
This follows the lead of ESLint core and other ESLint plugins in strictly defining their Node API so that users cannot reach in and import/depend on arbitrary files inside the plugin.

* https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0#remove-lib
   > Beginning in v8.0.0, ESLint is strictly defining its public API. Previously, you could reach into individual files such as require("eslint/lib/rules/semi") and this is no longer allowed. There are a limited number of existing APIs that are now available through the /use-at-your-own-risk entrypoint for backwards compatibility, but these APIs are not formally supported and may break or disappear at any point in time.

https://nodejs.org/api/packages.html#main-entry-point-export

The following change helps prepare for this:
* #1512

Related change:
* https://github.com/ember-cli/eslint-plugin-ember/pull/1513

If anyone needs something that is no longer accessible, please file an issue to let us know and we can consider whether it's something that should be explicitly exported.

Part of v11 release (https://github.com/ember-cli/eslint-plugin-ember/issues/1169).