### PR TITLE
Set config `ecmaVersion` to `2020`

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -2,13 +2,13 @@ module.exports = {
   root: true,
 
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 
   env: {
     browser: true,
-    es6: true,
+    es2020: true,
   },
 
   plugins: ['ember'],


### PR DESCRIPTION
This is the highest version we can include while still supporting ESLint v7.