### PR TITLE
Enable `useOptionalChaining` option by default for `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -92,8 +92,8 @@ export default EmberObject.extend({
 This rule takes an optional object containing:
 
 * `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
-* `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (default `false`)
-* `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `false`)
+* `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`) (default `false`)
+* `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `true`)
 * `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `get(foo, 'bar')` (default `true`)
 * `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)
 

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -107,7 +107,7 @@ module.exports = {
           },
           useOptionalChaining: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
           catchSafeObjects: {
             type: 'boolean',

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -19,10 +19,13 @@ ruleTester.run('no-get', rule, {
     // **************************
 
     // Nested property path.
-    { code: "this.get('foo.bar');", options: [{ ignoreNestedPaths: true }] },
+    {
+      code: "this.get('foo.bar');",
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
+    },
     {
       code: "import { get } from '@ember/object'; get(this, 'foo.bar');",
-      options: [{ ignoreNestedPaths: true }],
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
     },
 
     // Template literals.
@@ -74,15 +77,21 @@ ruleTester.run('no-get', rule, {
     // **************************
 
     // Nested property path.
-    { code: "this.getProperties('foo', 'bar.baz');", options: [{ ignoreNestedPaths: true }] },
-    { code: "this.getProperties(['foo', 'bar.baz']);", options: [{ ignoreNestedPaths: true }] }, // With parameters in array.
+    {
+      code: "this.getProperties('foo', 'bar.baz');",
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
+    },
+    {
+      code: "this.getProperties(['foo', 'bar.baz']);",
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
+    }, // With parameters in array.
     {
       code: "import { getProperties } from '@ember/object'; getProperties(this, 'foo', 'bar.baz');",
-      options: [{ ignoreNestedPaths: true }],
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
     },
     {
       code: "import { getProperties } from '@ember/object'; getProperties(this, ['foo', 'bar.baz']);",
-      options: [{ ignoreNestedPaths: true }],
+      options: [{ ignoreNestedPaths: true, useOptionalChaining: false }],
     }, // With parameters in array.
 
     // Template literals.
@@ -216,12 +225,21 @@ ruleTester.run('no-get', rule, {
       errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
     },
     {
+      // useOptionalChaining = false
       code: "foo1.foo2.get('bar.bar').baz;",
       output: null,
+      options: [{ catchUnsafeObjects: true, useOptionalChaining: false }],
+      errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
+    },
+    {
+      // useOptionalChaining = true (implicit)
+      code: "foo1.foo2.get('bar.bar').baz;",
+      output: 'foo1.foo2.bar.bar.baz;',
       options: [{ catchUnsafeObjects: true }],
       errors: [{ message: ERROR_MESSAGE_GET, type: 'CallExpression' }],
     },
     {
+      // useOptionalChaining = true (explicit)
       code: "foo1.foo2.get('bar.bar').baz;",
       output: 'foo1.foo2.bar.bar.baz;',
       options: [{ catchUnsafeObjects: true, useOptionalChaining: true }],


### PR DESCRIPTION
We can enable this option given that we are dropping support for Node versions below Node 14.

Optional chaining is available as of Node 14: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

Part of v11 release (https://github.com/ember-cli/eslint-plugin-ember/issues/1169).