### PR TITLE
Fix Node 14.0.0 support by removing node protocol imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
     'unicorn/no-null': 'off',
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-module': 'off',
+    'unicorn/prefer-node-protocol': 'off', // Enable once we drop support for Node 14.0.0.
     'unicorn/prevent-abbreviations': 'off',
   },
   overrides: [

--- a/lib/rules/no-classic-components.js
+++ b/lib/rules/no-classic-components.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const types = require('../utils/types');
-const assert = require('node:assert');
+const assert = require('assert');
 
 const ERROR_MESSAGE =
   'Use Glimmer components(@glimmer/component) instead of classic components(@ember/component)';

--- a/lib/rules/no-controllers.js
+++ b/lib/rules/no-controllers.js
@@ -1,7 +1,7 @@
 const ember = require('../utils/ember');
 const types = require('../utils/types');
 const utils = require('../utils/utils');
-const assert = require('node:assert');
+const assert = require('assert');
 
 const ERROR_MESSAGE = 'Avoid using controllers except for specifying `queryParams`';
 

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -3,7 +3,7 @@
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 const utils = require('../utils/utils');
-const assert = require('node:assert');
+const assert = require('assert');
 const { getImportIdentifier } = require('../utils/import');
 
 const ERROR_MESSAGE_GET = "Use ES5 getters (`this.property`) instead of Ember's `get` function";

--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('node:assert');
+const assert = require('assert');
 const emberUtils = require('../utils/ember');
 const decoratorUtils = require('../utils/decorators');
 const { getImportIdentifier } = require('../utils/import');

--- a/lib/rules/no-test-import-export.js
+++ b/lib/rules/no-test-import-export.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const path = require('node:path');
+const path = require('path');
 const emberUtils = require('../utils/ember');
 
 const NO_IMPORT_MESSAGE =

--- a/lib/rules/no-test-module-for.js
+++ b/lib/rules/no-test-module-for.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('node:assert');
+const assert = require('assert');
 
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');

--- a/lib/rules/no-test-support-import.js
+++ b/lib/rules/no-test-support-import.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const path = require('node:path');
+const path = require('path');
 
 const ERROR_MESSAGE_NO_IMPORT =
   'Do not import a file from test-support into production code, only into test files.';

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -3,7 +3,7 @@
 const types = require('../utils/types');
 const emberUtils = require('../utils/ember');
 const propertyGetterUtils = require('../utils/property-getter');
-const assert = require('node:assert');
+const assert = require('assert');
 const scopeReferencesThis = require('../utils/scope-references-this');
 const { getImportIdentifier } = require('../utils/import');
 

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -7,7 +7,7 @@ const types = require('../utils/types');
 const utils = require('../utils/utils');
 const propertyGetterUtils = require('../utils/property-getter');
 const computedPropertyDependentKeyUtils = require('../utils/computed-property-dependent-keys');
-const assert = require('node:assert');
+const assert = require('assert');
 const { getImportIdentifier } = require('../utils/import');
 
 /**

--- a/lib/utils/computed-properties.js
+++ b/lib/utils/computed-properties.js
@@ -1,5 +1,5 @@
 const types = require('./types');
-const assert = require('node:assert');
+const assert = require('assert');
 
 module.exports = {
   isComputedPropertyBodyArg,

--- a/lib/utils/computed-property-dependent-keys.js
+++ b/lib/utils/computed-property-dependent-keys.js
@@ -4,7 +4,7 @@ const javascriptUtils = require('./javascript');
 const { getName } = require('../utils/utils');
 const types = require('../utils/types');
 const decoratorUtils = require('../utils/decorators');
-const assert = require('node:assert');
+const assert = require('assert');
 const { getMacrosFromImports } = require('../utils/computed-property-macros');
 
 module.exports = {

--- a/lib/utils/computed-property-macros.js
+++ b/lib/utils/computed-property-macros.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require('assert');
 
 /**
  * Example macros:

--- a/lib/utils/decorators.js
+++ b/lib/utils/decorators.js
@@ -1,6 +1,6 @@
 const { getName } = require('./utils');
 const types = require('./types');
-const assert = require('node:assert');
+const assert = require('assert');
 
 module.exports = {
   getDecoratorName,

--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const path = require('node:path');
+const path = require('path');
 const utils = require('./utils');
 const importUtils = require('./import');
 const types = require('./types');
-const assert = require('node:assert');
+const assert = require('assert');
 const decoratorUtils = require('../utils/decorators');
 const { getNodeOrNodeFromVariable } = require('../utils/utils');
 const kebabCase = require('lodash.kebabcase');

--- a/lib/utils/import.js
+++ b/lib/utils/import.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('node:assert');
+const assert = require('assert');
 const {
   isCallExpression,
   isIdentifier,

--- a/scripts/list-jquery-methods.js
+++ b/scripts/list-jquery-methods.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const fs = require('node:fs');
+const fs = require('fs');
 const { JSDOM } = require('jsdom');
 
 const { window } = new JSDOM('');

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -11,8 +11,8 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require('fs');
+const path = require('path');
 
 // ------------------------------------------------------------------------------
 // Main

--- a/tests/config-setup.js
+++ b/tests/config-setup.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { readdirSync, readFileSync } = require('node:fs');
-const path = require('node:path');
+const { readdirSync, readFileSync } = require('fs');
+const path = require('path');
 const configs = require('../lib').configs;
 
 const CONFIG_NAMES = Object.keys(configs);

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -1,4 +1,4 @@
-const path = require('node:path');
+const path = require('path');
 const rule = require('../../../lib/rules/no-get');
 const RuleTester = require('eslint').RuleTester;
 

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -1,4 +1,4 @@
-const path = require('node:path');
+const path = require('path');
 
 // ------------------------------------------------------------------------------
 // Requirements

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { readdirSync, readFileSync } = require('node:fs');
-const path = require('node:path');
+const { readdirSync, readFileSync } = require('fs');
+const path = require('path');
 const rules = require('../lib').rules;
 const recommendedRules = require('../lib/recommended-rules');
 


### PR DESCRIPTION
Had to disable [unicorn/prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md) and remove the `node:` prefix from imports since Node 14.0.0 doesn't support that.

https://2ality.com/2021/12/node-protocol-imports.html

> Supported in Node.js starting:
> v16.0.0, v14.18.0 (ESM import and CommonJS require())
> v14.13.1, v12.20.0 (only ESM import)

Note that this bug hasn't been released yet (caused by https://github.com/ember-cli/eslint-plugin-ember/pull/1352) so we don't need to publicize this fix.

I would add a CI test for Node 14.0.0 (and 16.0.0 and 18.0.0) but some of our dev dependencies already dropped support for these.