### PR TITLE
Fix false positives with simple Set/Map-initialized objects in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getName } = require('../utils/utils');
+const { getName, getNodeOrNodeFromVariable } = require('../utils/utils');
 
 const ERROR_MESSAGE = "Don't use Ember's array prototype extensions";
 
@@ -80,6 +80,19 @@ const KNOWN_NON_ARRAY_OBJECTS = new Set([
   'jquery',
 ]);
 
+const KNOWN_NON_ARRAY_CLASSES = new Set([
+  // These Set/Map data structure classes have an overlapping clear() method.
+  'Set',
+  'Map',
+  'WeakSet',
+  'WeakMap',
+  // https://github.com/tracked-tools/tracked-built-ins
+  'TrackedSet',
+  'TrackedMap',
+  'TrackedWeakSet',
+  'TrackedWeakMap',
+]);
+
 //----------------------------------------------------------------------------------------------
 // General rule - Don't use Ember's array prototype extensions like .any(), .pushObject() or .firstObject
 //----------------------------------------------------------------------------------------------
@@ -102,6 +115,9 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     return {
       /**
        * Cover cases when `EXTENSION_METHODS` is getting called.
@@ -129,6 +145,17 @@ module.exports = {
           KNOWN_NON_ARRAY_OBJECTS.has(name.split('.')[0])
         ) {
           // Ignore any known non-array objects/function calls to reduce false positives.
+          return;
+        }
+
+        const nodeInitializedTo = getNodeOrNodeFromVariable(node.callee.object, scopeManager);
+        if (
+          nodeInitializedTo.type === 'NewExpression' &&
+          nodeInitializedTo.callee.type === 'Identifier' &&
+          KNOWN_NON_ARRAY_CLASSES.has(nodeInitializedTo.callee.name)
+        ) {
+          // Ignore when we can tell the variable was initialized to an instance of a non-array class.
+          // Example: const foo = new Set();
           return;
         }
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -74,6 +74,16 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     '$( "li" ).toArray();',
     'jQuery( "li" ).toArray();',
     'jquery( "li" ).toArray();',
+
+    // Non-array classes with clear() method
+    'const foo = new Set(); foo.clear();',
+    'const foo = new WeakSet(); foo.clear();',
+    'const foo = new Map(); foo.clear();',
+    'const foo = new WeakMap(); foo.clear();',
+    'const foo = new TrackedMap(); foo.clear();',
+    'const foo = new TrackedSet(); foo.clear();',
+    'const foo = new TrackedWeakMap(); foo.clear();',
+    'const foo = new TrackedWeakSet(); foo.clear();',
   ],
   invalid: [
     {


### PR DESCRIPTION
(partially) fixes #1537.