### PR TITLE
Fix false positive with `RSVP.reject()` in `no-array-prototype-extensions`

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -62,6 +62,9 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
   'window.Promise.reject',
   'Promise.reject',
 
+  // RSVP.reject
+  'RSVP.reject',
+
   // *storage.clear()
   'window.localStorage.clear',
   'window.sessionStorage.clear',

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -49,6 +49,10 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'Promise.reject("some reason");',
     'reject();',
 
+    // Global non-array class (RSVP.reject)
+    'RSVP.reject();',
+    'RSVP.reject("some reason");',
+
     // Global non-array class (*storage.clear)
     'window.localStorage.clear();',
     'window.sessionStorage.clear();',


### PR DESCRIPTION
(partially) fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1537.