### PR TITLE
Fix false positive with Set/Map-initialized *private* class properties in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -171,9 +171,15 @@ module.exports = {
           node.callee.type === 'MemberExpression' &&
           node.callee.object.type === 'MemberExpression' &&
           node.callee.object.object.type === 'ThisExpression' &&
-          node.callee.object.property.type === 'Identifier' &&
+          ['Identifier', 'PrivateIdentifier', 'PrivateName'].includes(
+            node.callee.object.property.type
+          ) &&
           classStack.peek() &&
-          classStack.peek().classPropertiesToIgnore.has(node.callee.object.property.name)
+          classStack.peek().classPropertiesToIgnore.has(
+            node.callee.object.property.type === 'Identifier'
+              ? node.callee.object.property.name
+              : `#${node.callee.object.property.name}` // Add # for private properties to avoid confusing public/private properties.
+          )
         ) {
           // Ignore when we can tell the class property was initialized to an instance of a non-array class.
           // Example:
@@ -241,14 +247,15 @@ module.exports = {
           node.body.body
             .filter(
               (n) =>
-                isClassPropertyOrPropertyDefinition(n) &&
-                n.key.type === 'Identifier' &&
+                // ClassProperty / ClassPrivateProperty / PrivateName are for ESLint v7.
+                (isClassPropertyOrPropertyDefinition(n) || n.type === 'ClassPrivateProperty') &&
+                ['Identifier', 'PrivateIdentifier', 'PrivateName'].includes(n.key.type) &&
                 n.value &&
                 n.value.type === 'NewExpression' &&
                 n.value.callee.type === 'Identifier' &&
                 KNOWN_NON_ARRAY_CLASSES.has(n.value.callee.name)
             )
-            .map((n) => n.key.name)
+            .map((n) => (n.key.type === 'Identifier' ? n.key.name : `#${n.key.name}`)) // Add # for private properties to avoid confusing public/private properties.
         );
 
         classStack.push({ node, classPropertiesToIgnore });

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -97,6 +97,14 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       }
     }`,
 
+    // Class property definition (private) with non-array class.
+    `class MyClass {
+      #foo = new Set();
+      myFunc() {
+        this.#foo.clear();
+      }
+    }`,
+
     {
       // Class property definition with non-array class (TypeScript).
       code: `
@@ -104,6 +112,33 @@ ruleTester.run('no-array-prototype-extensions', rule, {
         foo: Set<UploadFile> = new Set();
         myFunc() {
           this.foo.clear();
+        }
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+
+    {
+      // Class property definition (private) with non-array class (TypeScript).
+      code: `
+      class MyClass {
+        #foo: Set<UploadFile> = new TrackedSet();
+        myFunc() {
+          this.#foo.clear();
+        }
+      }
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      // Class property definition (private) with non-array class (TypeScript) (does not confuse public/private properties).
+      code: `
+      class MyClass {
+        #foo: Set<UploadFile> = new TrackedSet();
+        foo: Array<UploadFile> = new Array();
+
+        myFunc() {
+          this.#foo.clear();
         }
       }
       `,
@@ -374,12 +409,54 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // Class property (private) with array value.
+      code: `
+      class MyClass {
+        #foo = new Array();
+        myFunc() {
+          this.#foo.clear();
+        }
+      }`,
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // Class property with array value (TypeScript).
       code: `
       class MyClass {
         foo: Array<UploadFile> = new Array();
         myFunc() {
           this.foo.clear();
+        }
+      }
+      `,
+      output: null,
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Class property (private) with array value (TypeScript).
+      code: `
+      class MyClass {
+        #foo: Array<UploadFile> = new Array();
+        myFunc() {
+          this.#foo.clear();
+        }
+      }
+      `,
+      output: null,
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Class property definition (private) with array class (TypeScript) (does not confuse public/private properties).
+      code: `
+      class MyClass {
+        #foo: Array<UploadFile> = new Array();
+        foo: Set<UploadFile> = new Set();
+
+        myFunc() {
+          this.#foo.clear();
         }
       }
       `,


### PR DESCRIPTION
Fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1537 (this is the last remaining fix for this issue).

CC: @gilest