### PR TITLE
Fix false positives with `RSVP.Promise.reject()` in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -66,6 +66,9 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
 
   // RSVP.reject
   'RSVP.reject',
+  'RSVP.Promise.reject',
+  'Ember.RSVP.reject',
+  'Ember.RSVP.Promise.reject',
 
   // *storage.clear()
   'window.localStorage.clear',

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -48,17 +48,23 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'Promise.reject();',
     'Promise.reject("some reason");',
     'reject();',
+    'this.reject();',
 
     // Global non-array class (RSVP.reject)
     'RSVP.reject();',
     'RSVP.reject("some reason");',
+    'RSVP.Promise.reject();',
+    'Ember.RSVP.reject();',
+    'Ember.RSVP.Promise.reject();',
 
     // Global non-array class (*storage.clear)
     'window.localStorage.clear();',
     'window.sessionStorage.clear();',
     'localStorage.clear();',
     'sessionStorage.clear();',
+    'sessionStorage?.clear();',
     'clear();',
+    'this.clear();',
 
     // Global non-array class (location.replace)
     'window.document.location.replace(url)',


### PR DESCRIPTION
Fixes #1537 (some related scenarios).