### PR TITLE
Improve false positive detection, especially for variable names containing Set/Map, in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -59,35 +59,44 @@ const REPLACE_METHOD = 'replace';
  * */
 const EXTENSION_PROPERTIES = new Set(['lastObject', 'firstObject']);
 
+/**
+ * Ignore these function calls.
+ */
 const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
   // Promise.reject()
-  'window.Promise.reject',
-  'Promise.reject',
+  'window.Promise.reject()',
+  'Promise.reject()',
 
   // RSVP.reject
-  'RSVP.reject',
-  'RSVP.Promise.reject',
-  'Ember.RSVP.reject',
-  'Ember.RSVP.Promise.reject',
+  'RSVP.reject()',
+  'RSVP.Promise.reject()',
+  'Ember.RSVP.reject()',
+  'Ember.RSVP.Promise.reject()',
 
   // *storage.clear()
-  'window.localStorage.clear',
-  'window.sessionStorage.clear',
-  'localStorage.clear',
-  'sessionStorage.clear',
+  'window.localStorage.clear()',
+  'window.sessionStorage.clear()',
+  'localStorage.clear()',
+  'sessionStorage.clear()',
 ]);
 
+/**
+ * Ignore objects of these names.
+ */
 const KNOWN_NON_ARRAY_OBJECTS = new Set([
   // lodash
   '_',
   'lodash',
 
   // jquery
-  '$',
-  'jQuery',
-  'jquery',
+  '$()',
+  'jQuery()',
+  'jquery()',
 ]);
 
+/**
+ * Ignore variables initialized to instances of these classes.
+ */
 const KNOWN_NON_ARRAY_CLASSES = new Set([
   // These Set/Map data structure classes have an overlapping clear() method.
   'Set',
@@ -100,6 +109,40 @@ const KNOWN_NON_ARRAY_CLASSES = new Set([
   'TrackedWeakSet',
   'TrackedWeakMap',
 ]);
+
+/**
+ * Ignore variables containing these words as they are likely to be instances of non-array classes.
+ * Stored in lowercase.
+ */
+const KNOWN_NON_ARRAY_WORDS_WITH_CLEAR_FN = new Set([
+  // These Set/Map data structure classes have an overlapping clear() method.
+  'set',
+  'map',
+]);
+
+/**
+ * Return the (lowercase) list of words in a variable name of various casings (camelCase, PascalCase, snake_case, UPPER_CASE).
+ * @param {string} name - variable name
+ * @returns {string[]} list of (lowercase) words in the variable name
+ */
+function variableNameToWords(name) {
+  if (name.includes('_')) {
+    // snake_case, UPPER_CASE.
+    return name.toLowerCase().trim().split('_');
+  }
+
+  if (name === name.toUpperCase()) {
+    // Single word.
+    return [name.toLowerCase()];
+  }
+
+  // camelCase, PascalCase.
+  return name
+    .replace(/([A-Z])/g, ' $1')
+    .toLowerCase()
+    .trim()
+    .split(' ');
+}
 
 //----------------------------------------------------------------------------------------------
 // General rule - Don't use Ember's array prototype extensions like .any(), .pushObject() or .firstObject
@@ -135,6 +178,7 @@ module.exports = {
        * Example: something.filterBy();
        * @param {Object} node
        */
+      // eslint-disable-next-line complexity
       CallExpression(node) {
         // Skip case: filterBy();
         if (node.callee.type !== 'MemberExpression') {
@@ -150,12 +194,17 @@ module.exports = {
           return;
         }
 
-        const name = getName(node);
+        const name = getName(node, true);
+        const nameParts = name.split('.');
         if (
           KNOWN_NON_ARRAY_FUNCTION_CALLS.has(name) ||
-          KNOWN_NON_ARRAY_OBJECTS.has(name.split('.')[0])
+          KNOWN_NON_ARRAY_OBJECTS.has(nameParts[nameParts.length - 2]) ||
+          (variableNameToWords(nameParts[nameParts.length - 2]).some((word) =>
+            KNOWN_NON_ARRAY_WORDS_WITH_CLEAR_FN.has(word)
+          ) &&
+            nameParts[nameParts.length - 1] === 'clear()')
         ) {
-          // Ignore any known non-array objects/function calls to reduce false positives.
+          // Ignore any known non-array objects/function calls/variable names to reduce false positives.
           return;
         }
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -217,17 +217,23 @@ function getAncestor(node, predicate) {
  * x.y() -> x.y
  *
  * @param {node} node
+ * @param {boolean=false} includeFunctionCallParens - whether to include parenthesis () to distinguish function calls from objects/properties
  * @returns {string}
  */
-function getName(node) {
+function getName(node, includeFunctionCallParens = false) {
   if (isIdentifier(node)) {
     return node.name;
   } else if (isCallExpression(node) || isOptionalCallExpression(node)) {
-    return getName(node.callee);
+    return `${getName(node.callee, includeFunctionCallParens)}${
+      includeFunctionCallParens ? '()' : ''
+    }`;
   } else if (isMemberExpression(node) || isOptionalMemberExpression(node)) {
-    return `${getName(node.object)}.${getName(node.property)}`;
+    return `${getName(node.object, includeFunctionCallParens)}.${getName(
+      node.property,
+      includeFunctionCallParens
+    )}`;
   } else if (node.type === 'ChainExpression') {
-    return getName(node.expression);
+    return getName(node.expression, includeFunctionCallParens);
   }
   return undefined;
 }

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -95,6 +95,35 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'const foo = new TrackedWeakMap(); foo.clear();',
     'const foo = new TrackedWeakSet(); foo.clear();',
 
+    // Variable names with the Set/Map words and Set/Map function call.
+    'set.clear();',
+    'map.clear();',
+    'foo.set.clear();', // Longer chain.
+    // PascalCase
+    'Set.clear();',
+    'Map.clear();',
+    'SetFoo.clear();',
+    'SetMap.clear();',
+    'MySet.clear();',
+    'MyMap.clear();',
+    // camelCase
+    'aSetOfStuff.clear();',
+    'aMapOfStuff.clear();',
+    'setOfStuff.clear();',
+    'mapOfStuff.clear();',
+    // UPPER_CASE
+    'SET.clear();',
+    'MAP.clear();',
+    'SET_OF_STUFF.clear();',
+    'MAP_OF_STUFF.clear();',
+    'MY_SET.clear();',
+    'MY_MAP.clear();',
+    // snake_case
+    'a_set_of_stuff.clear();',
+    'a_map_of_stuff.clear();',
+    'set_foo.clear();',
+    'map_foo.clear();',
+
     // Class property definition with non-array class.
     `class MyClass {
       foo = new Set();
@@ -156,17 +185,65 @@ ruleTester.run('no-array-prototype-extensions', rule, {
   ],
   invalid: [
     {
-      code: '[1, 2, 3].filterBy()',
+      code: '[1, 2, 3].clear()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      code: 'something.filterBy()',
+      code: 'something.clear()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      code: 'something.else.filterBy()',
+      // map function call in chain
+      code: 'something.map().clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // set at beginning of chain but not directly before function call.
+      code: 'productSetMatcher.requiredItems.clear();',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // jquery at beginning of chain but not directly before function call.
+      code: 'jquery().foo.clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Set in variable name but not a Set function.
+      code: 'set.filterBy()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Set in variable name but not as its own word.
+      code: 'settle.clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Map in variable name (front) but not as its own word.
+      code: 'mApple.clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Map in variable name (middle) but not as its own word.
+      code: 'pumaParent.clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Map in variable name (inside word) but not as its own word.
+      code: 'mapleTree.clear()',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.else.clear()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
@@ -176,12 +253,12 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       errors: [{ messageId: 'main', type: 'MemberExpression' }],
     },
     {
-      code: 'something?.filterBy?.()',
+      code: 'something?.clear?.()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      code: 'getSomething().filterBy()',
+      code: 'getSomething().clear()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
@@ -323,11 +400,6 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     },
     {
       code: 'something.addObjects()',
-      output: null,
-      errors: [{ messageId: 'main', type: 'CallExpression' }],
-    },
-    {
-      code: 'something.clear()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },


### PR DESCRIPTION
Variables that have the word "set" or "map" in them are likely a set/map (non-array class that has overlapping `clear()` function) that we should ignore.

Note the risk of false negatives due to this :
* Some variable names have "set" in them but are not referring to the Set data structure. "targetProductSet.clear()", "expandedVariationSet.clear()"

Fixes #1537.