### PR TITLE
Ignore `super` in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -186,8 +186,8 @@ module.exports = {
           return;
         }
 
-        // Skip case: this.filterBy();
-        if (node.callee.object.type === 'ThisExpression') {
+        // Skip case: this.filterBy(); super.filterBy();
+        if (['ThisExpression', 'Super'].includes(node.callee.object.type)) {
           return;
         }
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -142,6 +142,9 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'set_foo.clear();',
     'map_foo.clear();',
 
+    // super
+    'super.clear();',
+
     // Class property definition with non-array class.
     `class MyClass {
       foo = new Set();


### PR DESCRIPTION
Fixes #1553.