### PR TITLE
Remove `no-array-prototype-extensions` rule from `recommended` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 ## v11.0.0 (2022-07-20)
 
 #### :boom: Breaking Change
-* [#1517](https://github.com/ember-cli/eslint-plugin-ember/pull/1517) Add `no-array-prototype-extensions` as `recommended` rule ([@bmish](https://github.com/bmish))
+* [#1517](https://github.com/ember-cli/eslint-plugin-ember/pull/1517) Add `no-array-prototype-extensions` as `recommended` rule (NOTE: removed as `recommended` in v11.0.6) ([@bmish](https://github.com/bmish))
 * [#1515](https://github.com/ember-cli/eslint-plugin-ember/pull/1515) Drop support for ESLint v6 ([@bmish](https://github.com/bmish))
 * [#1318](https://github.com/ember-cli/eslint-plugin-ember/pull/1318) Drop support for Node 10, 12, 15, 17 ([@aggmoulik](https://github.com/aggmoulik))
 * [#1519](https://github.com/ember-cli/eslint-plugin-ember/pull/1519) Enable `useOptionalChaining` option by default for `no-get` rule ([@bmish](https://github.com/bmish))

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |:--------|:------------|:---------------|:-----------|:---------------|
 | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions | ✅ |  |  |
 | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 | ✅ |  |  |
-| [no-array-prototype-extensions](./docs/rules/no-array-prototype-extensions.md) | disallow usage of Ember's `Array` prototype extensions | ✅ |  |  |
+| [no-array-prototype-extensions](./docs/rules/no-array-prototype-extensions.md) | disallow usage of Ember's `Array` prototype extensions |  |  |  |
 | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions | ✅ |  |  |
 | [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins | ✅ |  |  |
 | [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins | ✅ |  |  |

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -1,7 +1,5 @@
 # no-array-prototype-extensions
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
-
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 
 The prototype extensions for the `Array` object will likely become deprecated in the future.

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -10,6 +10,8 @@ Some alternatives:
 * Use lodash helper functions instead of `.uniqBy()`, `.sortBy()` in Ember modules
 * Use immutable update style with `@tracked` properties or `TrackedArray` from `tracked-built-ins` instead of `.pushObject`, `removeObject` in Ember modules
 
+Note: this rule is not in the `recommended` configuration because of the risk of false positives.
+
 ## Rule Details
 
 This rule will disallow method calls that match any of the forbidden `Array` prototype extension method names.

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -13,7 +13,6 @@ module.exports = {
   "ember/jquery-ember-run": "error",
   "ember/new-module-imports": "error",
   "ember/no-actions-hash": "error",
-  "ember/no-array-prototype-extensions": "error",
   "ember/no-arrow-function-computed-properties": "error",
   "ember/no-assignment-of-untracked-properties-used-in-tracking-contexts": "error",
   "ember/no-attrs-in-components": "error",

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -156,7 +156,7 @@ module.exports = {
     docs: {
       description: "disallow usage of Ember's `Array` prototype extensions",
       category: 'Deprecations',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-array-prototype-extensions.md',
     },
     fixable: null,

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -10,7 +10,6 @@ Array [
   "jquery-ember-run",
   "new-module-imports",
   "no-actions-hash",
-  "no-array-prototype-extensions",
   "no-arrow-function-computed-properties",
   "no-assignment-of-untracked-properties-used-in-tracking-contexts",
   "no-attrs-in-components",


### PR DESCRIPTION
The `no-array-prototype-extensions` rule is trying to do an impossible thing. It's going to continue to produce a never-ending stream of false positives. You cannot statically tell which calls are actually relying on the array prototype extensions.

A correct implementation is probably possible, but only in typescript (where eslint rules can take advantage of type information), not in javascript.

I'm all in favor of pushing people away from using array prototype extensions, but that is going to require runtime implementation. It cannot be checked statically. A rule that is so often wrong will just encourage people not to trust it. I don't think it should be in the recommended set.

Examples:

https://github.com/ember-cli/eslint-plugin-ember/issues/1561
https://github.com/ember-cli/eslint-plugin-ember/pull/1552
https://github.com/ember-cli/eslint-plugin-ember/pull/1547
https://github.com/ember-cli/eslint-plugin-ember/pull/1546
https://github.com/ember-cli/eslint-plugin-ember/pull/1544
https://github.com/ember-cli/eslint-plugin-ember/pull/1543
https://github.com/ember-cli/eslint-plugin-ember/pull/1538
https://github.com/ember-cli/eslint-plugin-ember/pull/1539
https://github.com/ember-cli/eslint-plugin-ember/pull/1536