### PR TITLE
Switch to dash for markdown lists

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,6 @@
 {
-  "line-length": false
+  "line-length": false,
+  "ul-style": {
+    "style": "dash"
+  }
 }

--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -36,24 +36,24 @@ Examples of **correct** code for this rule:
 
 TODO: suggest any fast/automated techniques for fixing violations in a large codebase
 
-* TODO: suggestion on how to fix violations using find-and-replace / regexp
-* TODO: suggestion on how to fix violations using a codemod
+- TODO: suggestion on how to fix violations using find-and-replace / regexp
+- TODO: suggestion on how to fix violations using a codemod
 
 ## Configuration
 
 TODO: exclude this section if the rule has no extra configuration
 
-* object -- containing the following properties:
-  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+- object -- containing the following properties:
+  - string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
+  - boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
 
 ## Related Rules
 
-* [TODO-related-rule-name1](related-rule-name1.md)
-* [TODO-related-rule-name2](related-rule-name2.md)
+- [TODO-related-rule-name1](related-rule-name1.md)
+- [TODO-related-rule-name2](related-rule-name2.md)
 
 ## References
 
-* TODO: link to relevant documentation goes here)
-* TODO: link to relevant function spec goes here
-* TODO: link to relevant guide goes here
+- TODO: link to relevant documentation goes here)
+- TODO: link to relevant function spec goes here
+- TODO: link to relevant guide goes here

--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -52,4 +52,4 @@ export default Component.extend({
 
 ## References
 
-* [RFC](https://github.com/emberjs/rfcs/blob/master/text/0335-deprecate-send-action.md) to deprecate `sendAction`
+- [RFC](https://github.com/emberjs/rfcs/blob/master/text/0335-deprecate-send-action.md) to deprecate `sendAction`

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -11,9 +11,9 @@ This rule takes a single string option.
 
 String option:
 
-* `"always-with-setter"` (default) getters are *required* when computed property has a setter
-* `"always"` getters are *required* in computed properties
-* `"never"`  getters are *never allowed* in computed properties
+- `"always-with-setter"` (default) getters are *required* when computed property has a setter
+- `"always"` getters are *required* in computed properties
+- `"never"`  getters are *never allowed* in computed properties
 
 ## Examples
 

--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -67,4 +67,4 @@ test('it reloads user in promise handler', function (assert) {
 
 This rule takes an optional object containing:
 
-* `boolean` -- `allowSimpleArrowFunction` -- (default false) setting to `true` allows arrow function expressions that do not have block bodies. These simple arrow functions must also only contain a single function call. For example: `.then(user => this._reloadUser(user))`.
+- `boolean` -- `allowSimpleArrowFunction` -- (default false) setting to `true` allows arrow function expressions that do not have block bodies. These simple arrow functions must also only contain a single function call. For example: `.then(user => this._reloadUser(user))`.

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -6,9 +6,9 @@ The prototype extensions for the `Array` object were deprecated in [RFC #848](ht
 
 Some alternatives:
 
-* Use native array functions instead of `.filterBy()`, `.toArray()` in Ember modules
-* Use lodash helper functions instead of `.uniqBy()`, `.sortBy()` in Ember modules
-* Use immutable update style with `@tracked` properties or `TrackedArray` from `tracked-built-ins` instead of `.pushObject`, `removeObject` in Ember modules
+- Use native array functions instead of `.filterBy()`, `.toArray()` in Ember modules
+- Use lodash helper functions instead of `.uniqBy()`, `.sortBy()` in Ember modules
+- Use immutable update style with `@tracked` properties or `TrackedArray` from `tracked-built-ins` instead of `.pushObject`, `removeObject` in Ember modules
 
 Note: this rule is not in the `recommended` configuration because of the risk of false positives.
 
@@ -18,10 +18,10 @@ This rule will disallow method calls that match any of the forbidden `Array` pro
 
 Note that to reduce false positives, the rule ignores some common known-non-array classes/objects whose functions overlap with the array extension function names:
 
-* `Set.clear()`
-* `Map.clear()`
-* `Promise.reject()`
-* etc
+- `Set.clear()`
+- `Map.clear()`
+- `Promise.reject()`
+- etc
 
 If you run into additional false positives, please file a bug or submit a PR to add it to the rule's hardcoded ignore list.
 
@@ -113,14 +113,14 @@ export default class SampleComponent extends Component {
 
 ## References
 
-* [EmberArray](https://api.emberjs.com/ember/release/classes/EmberArray)
-* Ember [MutableArray](https://api.emberjs.com/ember/release/classes/MutableArray)
-* [Ember Prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
-* [Ember Array prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions)
-* [Native JavaScript array functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+- [EmberArray](https://api.emberjs.com/ember/release/classes/EmberArray)
+- Ember [MutableArray](https://api.emberjs.com/ember/release/classes/MutableArray)
+- [Ember Prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
+- [Ember Array prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions)
+- [Native JavaScript array functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
 
 ## Related Rules
 
-* [no-array-prototype-extensions](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) from ember-template-lint
-* [no-function-prototype-extensions](no-function-prototype-extensions.md)
-* [no-string-prototype-extensions](no-string-prototype-extensions.md)
+- [no-array-prototype-extensions](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-array-prototype-extensions.md) from ember-template-lint
+- [no-function-prototype-extensions](no-function-prototype-extensions.md)
+- [no-string-prototype-extensions](no-string-prototype-extensions.md)

--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -38,9 +38,9 @@ const Person = EmberObject.extend({
 
 This rule takes an optional object containing:
 
-* `boolean` -- `onlyThisContexts` -- whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference (default: `false`)
+- `boolean` -- `onlyThisContexts` -- whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference (default: `false`)
 
 ## References
 
-* [Arrow function spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
-* [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)
+- [Arrow function spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
+- [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)

--- a/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
+++ b/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
@@ -73,19 +73,19 @@ The autofixer for this rule will update assignments to use `set`. Alternatively,
 
 ## Configuration
 
-* object -- containing the following properties:
-  * array -- `extraMacros` -- Array of configurations for custom computed property macros which have dependent keys as arguments, each with hte following properties:
-    * string -- `name` -- The name the macro is exported with
-    * string -- `path` -- The file path used for importing the macro
-    * string -- `indexName` -- If this macro can also be imported through an index (like `computed` for `computed.and`), include it here
-    * string -- `indexPath` -- The path for importing the index. For example, with `import { computed } from '@ember/object'` and `computed.and(...)`, `@ember/object` is the `indexPath` and `computed` is the `indexName`.
-    * array -- `argumentFormat` -- array of configurations for how to parse the arguments of the macro to extract the computed dependencies, with at least one of the following properties:
-      * object -- `strings` -- Configuration for extracting raw strings from the argument list, with the following options:
-        * number -- `count` -- How many arguments to consider as dependencies. Use `Number.MAX_VALUE` for all of them.
-        * number -- `startIndex` -- Defaults to zero. If it's something else, that many arguments will be skipped before checking for `count` dependencies.
-      * object -- `objects` -- Configuration for extracting the values of an object as dependency keys, with the following properties:
-        * number -- `index` -- The index of the argument to be checked.
-        * array -- `keys` -- Array of strings for which keys values should be checked for. If not provided, all values will be checked.
+- object -- containing the following properties:
+  - array -- `extraMacros` -- Array of configurations for custom computed property macros which have dependent keys as arguments, each with hte following properties:
+    - string -- `name` -- The name the macro is exported with
+    - string -- `path` -- The file path used for importing the macro
+    - string -- `indexName` -- If this macro can also be imported through an index (like `computed` for `computed.and`), include it here
+    - string -- `indexPath` -- The path for importing the index. For example, with `import { computed } from '@ember/object'` and `computed.and(...)`, `@ember/object` is the `indexPath` and `computed` is the `indexName`.
+    - array -- `argumentFormat` -- array of configurations for how to parse the arguments of the macro to extract the computed dependencies, with at least one of the following properties:
+      - object -- `strings` -- Configuration for extracting raw strings from the argument list, with the following options:
+        - number -- `count` -- How many arguments to consider as dependencies. Use `Number.MAX_VALUE` for all of them.
+        - number -- `startIndex` -- Defaults to zero. If it's something else, that many arguments will be skipped before checking for `count` dependencies.
+      - object -- `objects` -- Configuration for extracting the values of an object as dependency keys, with the following properties:
+        - number -- `index` -- The index of the argument to be checked.
+        - array -- `keys` -- Array of strings for which keys values should be checked for. If not provided, all values will be checked.
 
 Example configuration:
 
@@ -147,6 +147,6 @@ export default function rejectBy(dependentKey, propertyKey, value) {
 
 ## References
 
-* [Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/set) for `set()`
-* [Spec](https://api.emberjs.com/ember/3.16/functions/@glimmer%2Ftracking/tracked) for `@tracked`
-* [Guide](https://guides.emberjs.com/release/upgrading/current-edition/tracked-properties/) for tracked properties
+- [Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/set) for `set()`
+- [Spec](https://api.emberjs.com/ember/3.16/functions/@glimmer%2Ftracking/tracked) for `@tracked`
+- [Guide](https://guides.emberjs.com/release/upgrading/current-edition/tracked-properties/) for tracked properties

--- a/docs/rules/no-attrs-in-components.md
+++ b/docs/rules/no-attrs-in-components.md
@@ -25,4 +25,4 @@ const name = this._name;
 
 ## Further Reading
 
-* <https://locks.svbtle.com/to-attrs-or-not-to-attrs>
+- <https://locks.svbtle.com/to-attrs-or-not-to-attrs>

--- a/docs/rules/no-capital-letters-in-routes.md
+++ b/docs/rules/no-capital-letters-in-routes.md
@@ -24,10 +24,10 @@ this.route('sign-up');
 
 ## References
 
-* [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
+- [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
 
 ## Related Rules
 
-* [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
-* [route-path-style](route-path-style.md)
-* [routes-segments-snake-case](routes-segments-snake-case.md)
+- [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
+- [route-path-style](route-path-style.md)
+- [routes-segments-snake-case](routes-segments-snake-case.md)

--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -68,12 +68,12 @@ export default class MyComponent extends Component {}
 
 This rule takes an optional object containing:
 
-* `boolean` -- `ignoreClassic` -- whether the rule should ignore usage inside of native classes labeled with `@classic` (default `true`)
+- `boolean` -- `ignoreClassic` -- whether the rule should ignore usage inside of native classes labeled with `@classic` (default `true`)
 
 ## References
 
-* [Ember 3.13 Release Notes](https://blog.emberjs.com/2019/09/25/ember-3-13-released.html) (minimum Ember version needed to use tracked properties)
-* [Ember Guides: Tracked Properties](https://octane-guides-preview.emberjs.com/release/state-management/tracked-properties/)
-* [Tracked Properties Deep Dive](https://www.pzuraq.com/coming-soon-in-ember-octane-part-3-tracked-properties/)
-* [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
-* [ember-classic-decorator](https://github.com/emberjs/ember-classic-decorator)
+- [Ember 3.13 Release Notes](https://blog.emberjs.com/2019/09/25/ember-3-13-released.html) (minimum Ember version needed to use tracked properties)
+- [Ember Guides: Tracked Properties](https://octane-guides-preview.emberjs.com/release/state-management/tracked-properties/)
+- [Tracked Properties Deep Dive](https://www.pzuraq.com/coming-soon-in-ember-octane-part-3-tracked-properties/)
+- [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+- [ember-classic-decorator](https://github.com/emberjs/ember-classic-decorator)

--- a/docs/rules/no-controller-access-in-routes.md
+++ b/docs/rules/no-controller-access-in-routes.md
@@ -64,5 +64,5 @@ export default class MyRoute extends Route {
 
 ## Configuration
 
-* object -- containing the following properties:
-  * boolean -- `allowControllerFor` -- whether the rule should allow or disallow routes from accessing the controller outside of `setupController`/`resetController` via `controllerFor` (default: `false`)
+- object -- containing the following properties:
+  - boolean -- `allowControllerFor` -- whether the rule should allow or disallow routes from accessing the controller outside of `setupController`/`resetController` via `controllerFor` (default: `false`)

--- a/docs/rules/no-current-route-name.md
+++ b/docs/rules/no-current-route-name.md
@@ -25,10 +25,10 @@ assert.equal(currentURL(), '/foo');
 
 ## Migration
 
-* Replace `currentRouteName()` with `currentURL()` and adjust
+- Replace `currentRouteName()` with `currentURL()` and adjust
   the assertion expectations
 
 ## References
 
-* [currentRouteName()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename) documentation
-* [currentURL()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl) documentation
+- [currentRouteName()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currentroutename) documentation
+- [currentURL()](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#currenturl) documentation

--- a/docs/rules/no-deeply-nested-dependent-keys-with-each.md
+++ b/docs/rules/no-deeply-nested-dependent-keys-with-each.md
@@ -36,4 +36,4 @@ export default Component.extend({
 
 ## Further Reading
 
-* See the [documentation](https://guides.emberjs.com/release/object-model/computed-properties-and-aggregate-data/) for Ember computed properties with `@each`
+- See the [documentation](https://guides.emberjs.com/release/object-model/computed-properties-and-aggregate-data/) for Ember computed properties with `@each`

--- a/docs/rules/no-function-prototype-extensions.md
+++ b/docs/rules/no-function-prototype-extensions.md
@@ -48,10 +48,10 @@ export default Component.extend({
 
 ## References
 
-* [Ember prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
-* [Ember function prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0272-deprecation-native-function-prototype-extensions)
+- [Ember prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
+- [Ember function prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0272-deprecation-native-function-prototype-extensions)
 
 ## Related Rules
 
-* [no-array-prototype-extensions](no-array-prototype-extensions.md)
-* [no-string-prototype-extensions](no-string-prototype-extensions.md)
+- [no-array-prototype-extensions](no-array-prototype-extensions.md)
+- [no-string-prototype-extensions](no-string-prototype-extensions.md)

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -10,13 +10,13 @@ Starting in Ember 3.1, native ES5 getters are available, which eliminates much o
 
 This rule disallows:
 
-* `this.get('someProperty')` when `this.someProperty` can be used
-* `this.getProperties('prop1', 'prop2')` when `{ prop1: this.prop1, prop2: this.prop2 }` can be used
+- `this.get('someProperty')` when `this.someProperty` can be used
+- `this.getProperties('prop1', 'prop2')` when `{ prop1: this.prop1, prop2: this.prop2 }` can be used
 
 **WARNING**: there are a number of circumstances where `get` / `getProperties` still need to be used, and you may need to manually disable the rule for these (although the rule will attempt to ignore them):
 
-* Ember proxy objects (`ObjectProxy`, `ArrayProxy`)
-* Objects implementing the `unknownProperty` method
+- Ember proxy objects (`ObjectProxy`, `ArrayProxy`)
+- Objects implementing the `unknownProperty` method
 
 In addition, `mirage/config.js` will be excluded from this rule.
 
@@ -91,21 +91,21 @@ export default EmberObject.extend({
 
 This rule takes an optional object containing:
 
-* `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
-* `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`) (default `false`)
-* `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `true`)
-* `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `get(foo, 'bar')` (default `true`)
-* `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)
+- `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
+- `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`) (default `false`)
+- `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `true`)
+- `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `get(foo, 'bar')` (default `true`)
+- `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)
 
 ## Related Rules
 
-* [no-proxies](no-proxies.md)
+- [no-proxies](no-proxies.md)
 
 ## References
 
-* [Ember 3.1 Release Notes](https://blog.emberjs.com/2018/04/13/ember-3-1-released.html) describing "ES5 Getters for Computed Properties"
-* [Ember get Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/get)
-* [Ember getProperties Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/getProperties)
-* [Ember ES5 Getter RFC](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md)
-* [es5-getter-ember-codemod](https://github.com/rondale-sc/es5-getter-ember-codemod)
-* [More context](https://github.com/emberjs/ember.js/issues/16148) about the proxy object exception to this rule
+- [Ember 3.1 Release Notes](https://blog.emberjs.com/2018/04/13/ember-3-1-released.html) describing "ES5 Getters for Computed Properties"
+- [Ember get Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/get)
+- [Ember getProperties Spec](https://api.emberjs.com/ember/release/functions/@ember%2Fobject/getProperties)
+- [Ember ES5 Getter RFC](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md)
+- [es5-getter-ember-codemod](https://github.com/rondale-sc/es5-getter-ember-codemod)
+- [More context](https://github.com/emberjs/ember.js/issues/16148) about the proxy object exception to this rule

--- a/docs/rules/no-html-safe.md
+++ b/docs/rules/no-html-safe.md
@@ -107,9 +107,9 @@ export default helper(substring);
 
 ## Related Rules
 
-* ember-template-lint has a [no-triple-curlies](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-triple-curlies.md) rule for the template equivalent of this rule.
+- ember-template-lint has a [no-triple-curlies](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-triple-curlies.md) rule for the template equivalent of this rule.
 
 ## References
 
-* [Ember's `htmlSafe` API documentation](https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe)
-* [MDN's Cross-site Scripting (XSS) documentation](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting)
+- [Ember's `htmlSafe` API documentation](https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe)
+- [MDN's Cross-site Scripting (XSS) documentation](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting)

--- a/docs/rules/no-implicit-service-injection-argument.md
+++ b/docs/rules/no-implicit-service-injection-argument.md
@@ -34,9 +34,9 @@ export default class Page extends Component {
 
 ## Related Rules
 
-* [no-unnecessary-service-injection-argument](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-unnecessary-service-injection-argument.md) is the opposite of this rule
+- [no-unnecessary-service-injection-argument](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-unnecessary-service-injection-argument.md) is the opposite of this rule
 
 ## References
 
-* Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
-* Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec
+- Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
+- Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec

--- a/docs/rules/no-incorrect-computed-macros.md
+++ b/docs/rules/no-incorrect-computed-macros.md
@@ -38,9 +38,9 @@ export default Component.extend({
 
 ## Related Rules
 
-* [require-computed-macros](require-computed-macros.md)
+- [require-computed-macros](require-computed-macros.md)
 
 ## References
 
-* [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
-* [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
+- [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
+- [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros

--- a/docs/rules/no-invalid-debug-function-arguments.md
+++ b/docs/rules/no-invalid-debug-function-arguments.md
@@ -6,9 +6,9 @@ Catch usages of Ember&#39;s `assert()` / `warn()` / `deprecate()` functions that
 
 This rule aims to catch a common mistake when using Ember's debug functions:
 
-* `assert(String description, Boolean condition)`
-* `warn(String description, Boolean condition, Object options)`
-* `deprecate(String description, Boolean condition, Object options)`
+- `assert(String description, Boolean condition)`
+- `warn(String description, Boolean condition, Object options)`
+- `deprecate(String description, Boolean condition, Object options)`
 
 When calling one of these functions, the author may mistakenly pass the `description` and `condition` arguments in the reverse order, and not notice because the function will be silent with a truthy string as the `condition`.
 
@@ -42,6 +42,6 @@ deprecate('Title is no longer supported.', title, { id: 'unwanted-title', until:
 
 ## Further Reading
 
-* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/assert) for the Ember `assert` function.
-* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/warn) for the Ember `warn` function.
-* See the [documentation](https://api.emberjs.com/ember/3.4/functions/@ember%2Fapplication%2Fdeprecations/deprecate) for the Ember `deprecate` function.
+- See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/assert) for the Ember `assert` function.
+- See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Fdebug/warn) for the Ember `warn` function.
+- See the [documentation](https://api.emberjs.com/ember/3.4/functions/@ember%2Fapplication%2Fdeprecations/deprecate) for the Ember `deprecate` function.

--- a/docs/rules/no-invalid-test-waiters.md
+++ b/docs/rules/no-invalid-test-waiters.md
@@ -8,8 +8,8 @@ Prevents invalid usage of test waiters.
 
 The new test waiters APIs, found in the [ember-test-waiters](https://github.com/emberjs/ember-test-waiters) addon, have recommended best practices that ensure you are successful with their usage. This rule ensures that all usages are adhering to recommended best practices:
 
-* Used in module scope
-* Assigned to a variable
+- Used in module scope
+- Assigned to a variable
 
 ## Examples
 

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -61,9 +61,9 @@ export default Component.extend({
 
 ## References
 
-* [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
-* [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
+- [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
+- [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
 
 ## Related Rules
 
-* [no-new-mixins](no-new-mixins.md)
+- [no-new-mixins](no-new-mixins.md)

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -8,8 +8,8 @@ For practical strategies on removing mixins see [this discourse thread](https://
 
 For more details and examples of how mixins create problems down-the-line, see these excellent blog posts:
 
-* [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
-* [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
+- [Mixins Considered Harmful](https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html)
+- [Why Are Mixins Considered Harmful?](https://raganwald.com/2016/07/16/why-are-mixins-considered-harmful.html)
 
 ## Examples
 
@@ -65,4 +65,4 @@ export default Component.extend({
 
 ## Related Rules
 
-* [no-mixins](no-mixins.md)
+- [no-mixins](no-mixins.md)

--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -4,9 +4,9 @@
 
 You should avoid observers for the following reasons:
 
-* Observers deal with data changes contrary to Ember's Data Down, Actions Up (DDAU) convention.
-* They also are synchronous by default which [has problems](https://emberjs.github.io/rfcs/0494-async-observers.html#motivation).
-* You can usually solve state management problems using other robust tools in Ember's toolbox such as actions, computed properties, or component life cycle hooks.
+- Observers deal with data changes contrary to Ember's Data Down, Actions Up (DDAU) convention.
+- They also are synchronous by default which [has problems](https://emberjs.github.io/rfcs/0494-async-observers.html#motivation).
+- You can usually solve state management problems using other robust tools in Ember's toolbox such as actions, computed properties, or component life cycle hooks.
 
 See [@ef4's](https://github.com/ef4/) [canonical answer](https://discuss.emberjs.com/t/why-should-i-not-use-observers-in-my-ember-application/16868/3) for why you should not use them.
 Observers do have some limited uses. They let you reflect state from your application to foreign interfaces that don't follow Ember's data flow conventions.

--- a/docs/rules/no-pause-test.md
+++ b/docs/rules/no-pause-test.md
@@ -56,4 +56,4 @@ module('Acceptance | foo test', function (hooks) {
 
 ## Further Reading
 
-* [ember-test-helpers pauseTest documentation](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest)
+- [ember-test-helpers pauseTest documentation](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#pausetest)

--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -4,9 +4,9 @@
 
 Disallow the use of:
 
-* The private `-routing` service
-* The private `_routerMicrolib` property
-* The private `router:main` property
+- The private `-routing` service
+- The private `_routerMicrolib` property
+- The private `router:main` property
 
 There has been a public `router` service since Ember 2.16 and using the private routing service should be unnecessary.
 
@@ -83,8 +83,8 @@ export default class MyComponent extends Component {
 
 This rule takes an optional object containing:
 
-* `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `true`)
-* `boolean` -- `catchRouterMain` -- whether the rule should catch usages of the private property `router:main` (default `true`)
+- `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `true`)
+- `boolean` -- `catchRouterMain` -- whether the rule should catch usages of the private property `router:main` (default `true`)
 
 ## References
 

--- a/docs/rules/no-proxies.md
+++ b/docs/rules/no-proxies.md
@@ -27,9 +27,9 @@ import ArrayProxy from '@ember/array/proxy';
 
 ## Related Rules
 
-* [no-get](no-get.md) which may need to be disabled for `this.get()` usages in proxy objects
+- [no-get](no-get.md) which may need to be disabled for `this.get()` usages in proxy objects
 
 ## References
 
-* [ObjectProxy](https://api.emberjs.com/ember/release/classes/ObjectProxy) spec
-* [ArrayProxy](https://api.emberjs.com/ember/release/classes/ArrayProxy) spec
+- [ObjectProxy](https://api.emberjs.com/ember/release/classes/ObjectProxy) spec
+- [ArrayProxy](https://api.emberjs.com/ember/release/classes/ArrayProxy) spec

--- a/docs/rules/no-restricted-property-modifications.md
+++ b/docs/rules/no-restricted-property-modifications.md
@@ -54,7 +54,7 @@ export default class MyComponent extends Component {
 
 ## Configuration
 
-* object -- containing the following properties:
-  * `String[]` -- `properties` -- array of names of properties that should not be modified (modifying child/nested/sub-properties of these is also not allowed)
+- object -- containing the following properties:
+  - `String[]` -- `properties` -- array of names of properties that should not be modified (modifying child/nested/sub-properties of these is also not allowed)
 
 Not yet implemented: There is currently no way to configure whether sub-properties are restricted from modification. To make this configurable, the `properties` array option could be updated to also accept objects of the form `{ name: 'myPropertyName', includeSubProperties: false }` where `includeSubProperties` defaults to `true`.

--- a/docs/rules/no-restricted-service-injections.md
+++ b/docs/rules/no-restricted-service-injections.md
@@ -2,8 +2,8 @@
 
 In some parts of your application, you may prefer to disallow certain services from being injected. This can be useful for:
 
-* Deprecating services one folder at a time
-* Creating isolation between different parts of your application
+- Deprecating services one folder at a time
+- Creating isolation between different parts of your application
 
 ## Rule Details
 
@@ -43,12 +43,12 @@ class MyComponent extends Component {
 
 ## Configuration
 
-* object[] -- containing the following properties:
-  * string[] -- `services` -- list of (kebab-case) service names that should be disallowed from being injected under the specified paths
-  * string[] -- `paths` -- optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path)
-  * string -- `message` -- optional custom error message to display for violations
+- object[] -- containing the following properties:
+  - string[] -- `services` -- list of (kebab-case) service names that should be disallowed from being injected under the specified paths
+  - string[] -- `paths` -- optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path)
+  - string -- `message` -- optional custom error message to display for violations
 
 ## Related Rules
 
-* The [no-restricted-imports](https://eslint.org/docs/rules/no-restricted-imports) or [import/no-restricted-paths](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md) rules are the JavaScript import statement equivalent of this rule.
-* ember-template-lint has a [no-restricted-invocations](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-restricted-invocations.md) rule for disallowing component usages.
+- The [no-restricted-imports](https://eslint.org/docs/rules/no-restricted-imports) or [import/no-restricted-paths](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md) rules are the JavaScript import statement equivalent of this rule.
+- ember-template-lint has a [no-restricted-invocations](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-restricted-invocations.md) rule for disallowing component usages.

--- a/docs/rules/no-settled-after-test-helper.md
+++ b/docs/rules/no-settled-after-test-helper.md
@@ -59,8 +59,8 @@ test('...', async function (assert) {
 
 ## Migration
 
-* Have a look at the [ember-test-waiters](https://github.com/emberjs/ember-test-waiters) project
+- Have a look at the [ember-test-waiters](https://github.com/emberjs/ember-test-waiters) project
 
 ## References
 
-* [`settled()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#settled)
+- [`settled()`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#settled)

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -6,9 +6,9 @@ When using computed properties, do not introduce side effects. Side effects make
 
 This rule currently disallows the following side-effect-causing statements inside computed properties:
 
-* `this.set('x', 123);`
-* `this.setProperties({ x: 123 });`
-* `this.x = 123;`
+- `this.set('x', 123);`
+- `this.setProperties({ x: 123 });`
+- `this.x = 123;`
 
 Note that other side effects like network requests should be avoided as well.
 
@@ -46,5 +46,5 @@ export default Component.extend({
 
 This rule takes an optional object containing:
 
-* `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `true`)
-* `boolean` -- `checkPlainGetters` -- whether the rule should check plain (non-computed) getters in native classes for side effects (default `true`)
+- `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `true`)
+- `boolean` -- `checkPlainGetters` -- whether the rule should check plain (non-computed) getters in native classes for side effects (default `true`)

--- a/docs/rules/no-string-prototype-extensions.md
+++ b/docs/rules/no-string-prototype-extensions.md
@@ -58,10 +58,10 @@ dasherize('myString');
 
 ## References
 
-* [Ember prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
-* [Ember String prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0236-deprecation-ember-string/)
+- [Ember prototype extensions documentation](https://guides.emberjs.com/release/configuring-ember/disabling-prototype-extensions/)
+- [Ember String prototype extensions deprecation RFC](https://rfcs.emberjs.com/id/0236-deprecation-ember-string/)
 
 ## Related Rules
 
-* [no-array-prototype-extensions](no-array-prototype-extensions.md)
-* [no-function-prototype-extensions](no-function-prototype-extensions.md)
+- [no-array-prototype-extensions](no-array-prototype-extensions.md)
+- [no-function-prototype-extensions](no-function-prototype-extensions.md)

--- a/docs/rules/no-test-and-then.md
+++ b/docs/rules/no-test-and-then.md
@@ -30,5 +30,5 @@ test('behaves correctly', async function (assert) {
 
 ## Migration
 
-* [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
-* [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule
+- [async-await-codemod](https://github.com/sgilroy/async-await-codemod) can help convert async function calls / promise chains to use `await`
+- [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) has transforms such as [click](https://github.com/simonihmig/ember-test-helpers-codemod/blob/master/transforms/acceptance/transforms/click.js) that can be modified to call `makeAwait()` and `dropAndThen()` on the function calls that you're trying to bring into compliance with this rule

--- a/docs/rules/no-test-module-for.md
+++ b/docs/rules/no-test-module-for.md
@@ -30,7 +30,7 @@ module('Test Name', function (hooks) {
 
 A short guide for how each of the legacy APIs converts to the new APIs:
 
-* `moduleFor`, `moduleForModel`
+- `moduleFor`, `moduleForModel`
 
     ```js
     import { module, test } from 'qunit';
@@ -41,7 +41,7 @@ A short guide for how each of the legacy APIs converts to the new APIs:
     });
     ```
 
-* `moduleForComponent`
+- `moduleForComponent`
 
     ```js
     import { module, test } from 'qunit';
@@ -52,7 +52,7 @@ A short guide for how each of the legacy APIs converts to the new APIs:
     });
     ```
 
-* `moduleForAcceptance`
+- `moduleForAcceptance`
 
     ```js
     import { module, test } from 'qunit';
@@ -65,6 +65,6 @@ A short guide for how each of the legacy APIs converts to the new APIs:
 
 ## References
 
-* [moduleFor* deprecation notice from ember-qunit 4.5.0](https://github.com/emberjs/ember-qunit/blob/master/CHANGELOG.md#rocket-enhancement-1)
+- [moduleFor* deprecation notice from ember-qunit 4.5.0](https://github.com/emberjs/ember-qunit/blob/master/CHANGELOG.md#rocket-enhancement-1)
 
-* Codemod for automated upgrade of tests: [ember-qunit-codemod](https://github.com/ember-codemods/ember-qunit-codemod)
+- Codemod for automated upgrade of tests: [ember-qunit-codemod](https://github.com/ember-codemods/ember-qunit-codemod)

--- a/docs/rules/no-test-support-import.md
+++ b/docs/rules/no-test-support-import.md
@@ -52,4 +52,4 @@ This is meant as an addition to the [no-test-import-export](no-test-import-expor
 
 ## Related Rules
 
-* [no-test-import-export](no-test-import-export.md)
+- [no-test-import-export](no-test-import-export.md)

--- a/docs/rules/no-test-this-render.md
+++ b/docs/rules/no-test-this-render.md
@@ -44,4 +44,4 @@ test('baz', function (assert) {
 
 ## References
 
-* [Rendering Helpers on `@ember/test-helpers`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#rendering-helpers).
+- [Rendering Helpers on `@ember/test-helpers`](https://github.com/emberjs/ember-test-helpers/blob/master/API.md#rendering-helpers).

--- a/docs/rules/no-unnecessary-index-route.md
+++ b/docs/rules/no-unnecessary-index-route.md
@@ -24,10 +24,10 @@ this.route('blog-posts');
 
 ## References
 
-* [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
+- [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
 
 ## Related Rules
 
-* [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
-* [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
-* [routes-segments-snake-case](routes-segments-snake-case.md)
+- [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
+- [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
+- [routes-segments-snake-case](routes-segments-snake-case.md)

--- a/docs/rules/no-unnecessary-route-path-option.md
+++ b/docs/rules/no-unnecessary-route-path-option.md
@@ -28,11 +28,11 @@ this.route('blog-posts', { path: '/blog' });
 
 ## References
 
-* [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
+- [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
 
 ## Related Rules
 
-* [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
-* [no-unnecessary-index-route](no-unnecessary-index-route.md)
-* [route-path-style](route-path-style.md)
-* [routes-segments-snake-case](routes-segments-snake-case.md)
+- [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
+- [no-unnecessary-index-route](no-unnecessary-index-route.md)
+- [route-path-style](route-path-style.md)
+- [routes-segments-snake-case](routes-segments-snake-case.md)

--- a/docs/rules/no-unnecessary-service-injection-argument.md
+++ b/docs/rules/no-unnecessary-service-injection-argument.md
@@ -43,9 +43,9 @@ export default Component.extend({
 
 ## Related Rules
 
-* [no-implicit-service-injection-argument](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-implicit-service-injection-argument.md) is the opposite of this rule
+- [no-implicit-service-injection-argument](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-implicit-service-injection-argument.md) is the opposite of this rule
 
 ## References
 
-* Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
-* Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec
+- Ember [Services](https://guides.emberjs.com/release/applications/services/) guide
+- Ember [inject](https://api.emberjs.com/ember/release/functions/@ember%2Fservice/inject) function spec

--- a/docs/rules/no-volatile-computed-properties.md
+++ b/docs/rules/no-volatile-computed-properties.md
@@ -33,7 +33,7 @@ const Person = EmberObject.extend({
 
 ## References
 
-* [Deprecation RFC](https://github.com/emberjs/rfcs/blob/master/text/0370-deprecate-computed-volatile.md)
-* [Deprecation list](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile)
-* [Volatile spec](https://api.emberjs.com/ember/release/classes/ComputedProperty/methods/volatile?anchor=volatile)
-* [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)
+- [Deprecation RFC](https://github.com/emberjs/rfcs/blob/master/text/0370-deprecate-computed-volatile.md)
+- [Deprecation list](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile)
+- [Volatile spec](https://api.emberjs.com/ember/release/classes/ComputedProperty/methods/volatile?anchor=volatile)
+- [Computed property spec](https://api.emberjs.com/ember/release/classes/ComputedProperty)

--- a/docs/rules/prefer-ember-test-helpers.md
+++ b/docs/rules/prefer-ember-test-helpers.md
@@ -6,9 +6,9 @@ This rule ensures the correct Ember test helper is imported when using methods t
 
 There are currently 3 Ember test helper methods that have a native window counterpart:
 
-* blur
-* find
-* focus
+- blur
+- find
+- focus
 
 If these methods are not properly imported from Ember's test-helpers suite, and the native window method version is used instead, any intended asynchronous functions won't work as intended, which can cause tests to fail silently.
 
@@ -62,5 +62,5 @@ test('foo', async (assert) => {
 
 ## References
 
-* [Web API Window Methods](https://developer.mozilla.org/en-US/docs/Web/API/Window#Methods)
-* [Ember Test Helpers API Methods](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)
+- [Web API Window Methods](https://developer.mozilla.org/en-US/docs/Web/API/Window#Methods)
+- [Ember Test Helpers API Methods](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -6,10 +6,10 @@
 
 It is preferred to use Ember's computed property macros as opposed to manually writing out logic in a computed property function. Reasons include:
 
-* Conciseness
-* Readability
-* Reduced chance of typos
-* Reduced chance of missing dependencies
+- Conciseness
+- Readability
+- Reduced chance of typos
+- Reduced chance of missing dependencies
 
 Note that by default, this rule only applies in classic classes (i.e. `Component.extend({})`) and not in native JavaScript classes with decorators (read more about the `includeNativeGetters` option in the configuration section of this doc).
 
@@ -119,13 +119,13 @@ export default Component.extend({
 
 This rule takes an optional object containing:
 
-* `boolean` -- `includeNativeGetters` -- whether the rule should check and autofix computed properties with native getters (i.e. `@computed() get someProp() {}`) to use computed property macros (default `false`). This is off by default because in the Ember Octane world, the better improvement would be to keep the native getter and use tracked properties instead of computed properties.
+- `boolean` -- `includeNativeGetters` -- whether the rule should check and autofix computed properties with native getters (i.e. `@computed() get someProp() {}`) to use computed property macros (default `false`). This is off by default because in the Ember Octane world, the better improvement would be to keep the native getter and use tracked properties instead of computed properties.
 
 ## References
 
-* [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
-* [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
+- [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
+- [Spec](https://api.emberjs.com/ember/release/modules/@ember%2Fobject#functions-computed) for computed property macros
 
 ## Related Rules
 
-* [no-incorrect-computed-macros](no-incorrect-computed-macros.md)
+- [no-incorrect-computed-macros](no-incorrect-computed-macros.md)

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -10,10 +10,10 @@ Computed properties should have their property dependencies listed out so that t
 
 This rule requires dependencies to be declared statically in computed properties. Properties accessed within the computed property function that are not listed out are assumed to be missing dependencies. Various forms of accessing properties will be detected including:
 
-* `this.get('property')`
-* `this.getProperties('a', 'b')`
-* `Ember.get(this, 'property')`
-* `this.property` (ES5 getter)
+- `this.get('property')`
+- `this.getProperties('a', 'b')`
+- `Ember.get(this, 'property')`
+- `this.property` (ES5 getter)
 
 This rule has an autofixer that will automatically add missing dependencies to computed properties.
 
@@ -47,9 +47,9 @@ export default EmberObject.extend({
 
 This rule takes an optional object containing:
 
-* `boolean` -- `allowDynamicKeys` -- whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties (default `true`)
-* `boolean` -- `requireServiceNames` -- whether the rule should require injected service names to be listed as dependency keys in computed properties (default `false`)
+- `boolean` -- `allowDynamicKeys` -- whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties (default `true`)
+- `boolean` -- `requireServiceNames` -- whether the rule should require injected service names to be listed as dependency keys in computed properties (default `false`)
 
 ## References
 
-* [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties
+- [Guide](https://guides.emberjs.com/release/object-model/computed-properties/) for computed properties

--- a/docs/rules/require-fetch-import.md
+++ b/docs/rules/require-fetch-import.md
@@ -29,10 +29,10 @@ const result = fetch('/something');
 
 ## Migration
 
-* Add `import fetch from 'fetch';` to all files that need it
+- Add `import fetch from 'fetch';` to all files that need it
 
 ## References
 
-* [@ember/test-waiters](https://github.com/emberjs/ember-test-waiters) addon
+- [@ember/test-waiters](https://github.com/emberjs/ember-test-waiters) addon
 
 [ember-fetch]: https://github.com/ember-cli/ember-fetch/

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -77,9 +77,9 @@ To avoid false positives from relying on implicit returns in some code branches,
 
 ## Related Rules
 
-* [consistent-return] from eslint
-* [getter-return] from eslint
-* [no-setter-return] from eslint
+- [consistent-return] from eslint
+- [getter-return] from eslint
+- [no-setter-return] from eslint
 
 [consistent-return]: https://eslint.org/docs/rules/consistent-return
 [getter-return]: https://eslint.org/docs/rules/getter-return

--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -92,5 +92,5 @@ class Foo extends Component {
 
 This rule takes an optional object containing:
 
-* `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `false`)
-* `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `true`)
+- `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `false`)
+- `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `true`)

--- a/docs/rules/require-tagless-components.md
+++ b/docs/rules/require-tagless-components.md
@@ -93,7 +93,7 @@ export default class MyComponent extends Component {}
 
 ## Caveats
 
-* Rule does not catch cases where a Mixin is included to configure the `tagName` property.
+- Rule does not catch cases where a Mixin is included to configure the `tagName` property.
 
 ## Fixing This Rule
 
@@ -106,11 +106,11 @@ Note that you might want to wrap the component template in an additional element
 
 ## When Not To Use It
 
-* If you are not prepared to convert your components to be tag-less, wrapping the associated template in a tag and applying `...attributes` where appropriate, you should not enable this rule.
+- If you are not prepared to convert your components to be tag-less, wrapping the associated template in a tag and applying `...attributes` where appropriate, you should not enable this rule.
 
 ## Further Reading
 
-* [Glimmer Components](https://glimmerjs.com/guides/components-and-actions)
-  * Glimmer components are "the future" for Ember, and are _always_ tagless. Using them now, or changing your Ember components to be tagless, helps to modernize your codebase and prepare for a point in the future where components _never_ have a wrapper element.
-* [RFC #311 "Angle Bracket Invocation" (HTML Attributes section)](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html#html-attributes)
-  * Discusses forwarding attributes on a component to a DOM element using `...attributes`
+- [Glimmer Components](https://glimmerjs.com/guides/components-and-actions)
+  - Glimmer components are "the future" for Ember, and are _always_ tagless. Using them now, or changing your Ember components to be tagless, helps to modernize your codebase and prepare for a point in the future where components _never_ have a wrapper element.
+- [RFC #311 "Angle Bracket Invocation" (HTML Attributes section)](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html#html-attributes)
+  - Discusses forwarding attributes on a component to a DOM element using `...attributes`

--- a/docs/rules/route-path-style.md
+++ b/docs/rules/route-path-style.md
@@ -40,11 +40,11 @@ this.route('blog_posts', { path: '/blog-posts' });
 
 ## References
 
-* [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
-* [Keep a simple URL structure](https://support.google.com/webmasters/answer/76329) article by Google
+- [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
+- [Keep a simple URL structure](https://support.google.com/webmasters/answer/76329) article by Google
 
 ## Related Rules
 
-* [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
-* [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
-* [routes-segments-snake-case](routes-segments-snake-case.md)
+- [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
+- [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
+- [routes-segments-snake-case](routes-segments-snake-case.md)

--- a/docs/rules/routes-segments-snake-case.md
+++ b/docs/rules/routes-segments-snake-case.md
@@ -20,10 +20,10 @@ this.route('tree', { path: ':tree_id' });
 
 ## References
 
-* [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
+- [Ember Routing Guide](https://guides.emberjs.com/release/routing/)
 
 ## Related Rules
 
-* [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
-* [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
-* [route-path-style](route-path-style.md)
+- [no-capital-letters-in-routes](no-capital-letters-in-routes.md)
+- [no-unnecessary-route-path-option](no-unnecessary-route-path-option.md)
+- [route-path-style](route-path-style.md)

--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -43,5 +43,5 @@ setProperties(object, { foo: 'bar', baz: 'qux' });
 
 This rule takes an optional object containing:
 
-* `boolean` -- `ignoreThisExpressions` -- setting to `true` allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`.
-* `boolean` -- `ignoreNonThisExpressions` -- setting to  `true` allows use of non-Ember objects like `server.get()` and `map.set()`.
+- `boolean` -- `ignoreThisExpressions` -- setting to `true` allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`.
+- `boolean` -- `ignoreNonThisExpressions` -- setting to  `true` allows use of non-Ember objects like `server.get()` and `map.set()`.


### PR DESCRIPTION
Before this change, whatever list style was used first in a file would be enforced for that file. Now, let's standardize on dashes. This is all autofixed by the lint rule.

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md004---unordered-list-style

This is also the [standard enforced by prettier for markdown](https://github.com/prettier/prettier/issues/4251) which we may adopt later.