### PR TITLE
Add `any` to `some` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 |:--------|:------------|:---------------|:-----------|:---------------|
 | [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions | ✅ |  |  |
 | [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 | ✅ |  |  |
-| [no-array-prototype-extensions](./docs/rules/no-array-prototype-extensions.md) | disallow usage of Ember's `Array` prototype extensions |  |  |  |
+| [no-array-prototype-extensions](./docs/rules/no-array-prototype-extensions.md) | disallow usage of Ember's `Array` prototype extensions |  | 🔧 |  |
 | [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions | ✅ |  |  |
 | [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins | ✅ |  |  |
 | [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins | ✅ |  |  |

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -1,5 +1,7 @@
 # no-array-prototype-extensions
 
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 
 The prototype extensions for the `Array` object were deprecated in [RFC #848](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions).

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -145,6 +145,24 @@ function variableNameToWords(name) {
     .split(' ');
 }
 
+/**
+ * Returns the fixing object if it can be fixable otherwise returns an empty array.
+ *
+ * @param {Object} callExpressionNode The call expression AST node.
+ * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
+ * @returns {Object|[]}
+ */
+function applyFix(callExpressionNode, fixer) {
+  const propertyName = callExpressionNode.callee.property.name;
+
+  switch (propertyName) {
+    case 'any':
+      return fixer.replaceText(callExpressionNode.callee.property, 'some');
+    default:
+      return [];
+  }
+}
+
 //----------------------------------------------------------------------------------------------
 // General rule - Don't use Ember's array prototype extensions like .any(), .pushObject() or .firstObject
 //----------------------------------------------------------------------------------------------
@@ -159,7 +177,7 @@ module.exports = {
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-array-prototype-extensions.md',
     },
-    fixable: null,
+    fixable: 'code',
     schema: [],
     messages: {
       main: ERROR_MESSAGE,
@@ -253,7 +271,13 @@ module.exports = {
         }
 
         if (EXTENSION_METHODS.has(node.callee.property.name)) {
-          context.report({ node, messageId: 'main' });
+          context.report({
+            node,
+            messageId: 'main',
+            fix(fixer) {
+              return applyFix(node, fixer);
+            },
+          });
         }
 
         // Example: someArray.replace(1, 2, [1, 2, 3]);

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -326,7 +326,7 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     },
     {
       code: 'something.any()',
-      output: null,
+      output: 'something.some()',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `any` with `some`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `any` with the native array method `some`.

## Testing
Modified test case to check if the right output is generated after the fix.
