### PR TITLE
Add `filterBy` to `filter` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -1,5 +1,7 @@
 # no-array-prototype-extensions
 
+🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 
 The prototype extensions for the `Array` object were deprecated in [RFC #848](https://rfcs.emberjs.com/id/0848-deprecate-array-prototype-extensions).

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -150,6 +150,7 @@ function variableNameToWords(name) {
  *
  * @param {Object} callExpressionNode The call expression AST node.
  * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
+ * @param {Object} context The ESlint context object which contains some helper utils
  * @returns {Object|[]}
  */
 function applyFix(callExpressionNode, fixer, context) {
@@ -161,19 +162,35 @@ function applyFix(callExpressionNode, fixer, context) {
     case 'filterBy': {
       const callArgs = callExpressionNode.arguments;
       const sourceCode = context.getSourceCode();
+      const hasSecondArg = callArgs.length > 1;
+      const firstArg = callArgs[0];
+      const secondArg = callArgs[1];
 
-      return [
+      const fixes = [
         fixer.replaceText(callExpressionNode.callee.property, 'filter'),
         fixer.insertTextBefore(sourceCode.ast, "import { get } from '@ember/object';\n"),
+        // Replace the first argument with the necessary condition
+        // If the filterBy contains two arguments, the property (first argument) value will be compared against the second argument
+        // If the filterBy contains only one argument, the property's truthy value is used to filter
         fixer.replaceText(
-          callArgs[0],
-          `item => get(item, ${sourceCode.getText(callArgs[0])}) === ${sourceCode.getText(
-            callArgs[1]
-          )}`
+          firstArg,
+          hasSecondArg
+            ? `item => get(item, ${sourceCode.getText(firstArg)}) === ${sourceCode.getText(
+                secondArg
+              )}`
+            : `item => get(item, ${sourceCode.getText(firstArg)})`
         ),
-        fixer.removeRange([callArgs[0].range[1], callArgs[1].range[0]]),
-        fixer.remove(callArgs[1]),
       ];
+
+      if (hasSecondArg) {
+        fixes.push(
+          // Required to get rid of `, ` followed by the first argument since the second argument will be removed
+          fixer.removeRange([firstArg.range[1], secondArg.range[0]]),
+          fixer.remove(secondArg)
+        );
+      }
+
+      return fixes;
     }
     default:
       return [];

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -152,12 +152,29 @@ function variableNameToWords(name) {
  * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
  * @returns {Object|[]}
  */
-function applyFix(callExpressionNode, fixer) {
+function applyFix(callExpressionNode, fixer, context) {
   const propertyName = callExpressionNode.callee.property.name;
 
   switch (propertyName) {
     case 'any':
       return fixer.replaceText(callExpressionNode.callee.property, 'some');
+    case 'filterBy': {
+      const callArgs = callExpressionNode.arguments;
+      const sourceCode = context.getSourceCode();
+
+      return [
+        fixer.replaceText(callExpressionNode.callee.property, 'filter'),
+        fixer.insertTextBefore(sourceCode.ast, "import { get } from '@ember/object';\n"),
+        fixer.replaceText(
+          callArgs[0],
+          `item => get(item, ${sourceCode.getText(callArgs[0])}) === ${sourceCode.getText(
+            callArgs[1]
+          )}`
+        ),
+        fixer.removeRange([callArgs[0].range[1], callArgs[1].range[0]]),
+        fixer.remove(callArgs[1]),
+      ];
+    }
     default:
       return [];
   }
@@ -275,7 +292,7 @@ module.exports = {
             node,
             messageId: 'main',
             fix(fixer) {
-              return applyFix(node, fixer);
+              return applyFix(node, fixer, context);
             },
           });
         }

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -145,6 +145,24 @@ function variableNameToWords(name) {
     .split(' ');
 }
 
+/**
+ * Returns the fixing object if it can be fixable otherwise returns an empty array.
+ *
+ * @param {Object} callExpressionNode The call expression AST node.
+ * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
+ * @returns {Object|[]}
+ */
+function applyFix(callExpressionNode, fixer) {
+  const propertyName = callExpressionNode.callee.property.name;
+
+  switch (propertyName) {
+    case 'any':
+      return fixer.replaceText(callExpressionNode.callee.property, 'some');
+    default:
+      return [];
+  }
+}
+
 //----------------------------------------------------------------------------------------------
 // General rule - Don't use Ember's array prototype extensions like .any(), .pushObject() or .firstObject
 //----------------------------------------------------------------------------------------------
@@ -159,7 +177,7 @@ module.exports = {
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/no-array-prototype-extensions.md',
     },
-    fixable: null,
+    fixable: 'code',
     schema: [],
     messages: {
       main: ERROR_MESSAGE,
@@ -253,7 +271,13 @@ module.exports = {
         }
 
         if (EXTENSION_METHODS.has(node.callee.property.name)) {
-          context.report({ node, messageId: 'main' });
+          context.report({
+            node,
+            messageId: 'main',
+            fix(fixer) {
+              return applyFix(node, fixer);
+            },
+          });
         }
 
         // Example: someArray.replace(1, 2, [1, 2, 3]);

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -2,6 +2,7 @@
 
 const { getName, getNodeOrNodeFromVariable } = require('../utils/utils');
 const { isClassPropertyOrPropertyDefinition } = require('../utils/types');
+const { getImportIdentifier } = require('../utils/import');
 const Stack = require('../utils/stack');
 
 const ERROR_MESSAGE = "Don't use Ember's array prototype extensions";
@@ -153,7 +154,7 @@ function variableNameToWords(name) {
  * @param {Object} context The ESlint context object which contains some helper utils
  * @returns {Object|[]}
  */
-function applyFix(callExpressionNode, fixer, context) {
+function applyFix(callExpressionNode, fixer, context, options = {}) {
   const propertyName = callExpressionNode.callee.property.name;
 
   switch (propertyName) {
@@ -165,22 +166,33 @@ function applyFix(callExpressionNode, fixer, context) {
       const hasSecondArg = callArgs.length > 1;
       const firstArg = callArgs[0];
       const secondArg = callArgs[1];
+      // default to "get" if the `get` hasn't already been imported.
+      const importedGetName = options.importedGetName ?? 'get';
 
       const fixes = [
         fixer.replaceText(callExpressionNode.callee.property, 'filter'),
-        fixer.insertTextBefore(sourceCode.ast, "import { get } from '@ember/object';\n"),
         // Replace the first argument with the necessary condition
         // If the filterBy contains two arguments, the property (first argument) value will be compared against the second argument
         // If the filterBy contains only one argument, the property's truthy value is used to filter
         fixer.replaceText(
           firstArg,
           hasSecondArg
-            ? `item => get(item, ${sourceCode.getText(firstArg)}) === ${sourceCode.getText(
-                secondArg
-              )}`
-            : `item => get(item, ${sourceCode.getText(firstArg)})`
+            ? `item => ${importedGetName}(item, ${sourceCode.getText(
+                firstArg
+              )}) === ${sourceCode.getText(secondArg)}`
+            : `item => ${importedGetName}(item, ${sourceCode.getText(firstArg)})`
         ),
       ];
+
+      // Add `get` import statement only if it is not imported already
+      if (!options.importedGetName) {
+        fixes.push(
+          fixer.insertTextBefore(
+            sourceCode.ast,
+            `import { ${importedGetName} } from '@ember/object';\n`
+          )
+        );
+      }
 
       if (hasSecondArg) {
         fixes.push(
@@ -221,11 +233,17 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
+    let importedGetName;
 
     // Track some information about the current class we're inside.
     const classStack = new Stack();
 
     return {
+      ImportDeclaration(node) {
+        if (node.source.value === '@ember/object') {
+          importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
+        }
+      },
       /**
        * Cover cases when `EXTENSION_METHODS` is getting called.
        * Example: something.filterBy();
@@ -309,7 +327,9 @@ module.exports = {
             node,
             messageId: 'main',
             fix(fixer) {
-              return applyFix(node, fixer, context);
+              return applyFix(node, fixer, context, {
+                importedGetName,
+              });
             },
           });
         }

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -234,6 +234,7 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // filterBy with two arguments
       code: `
       const arr = [];
 
@@ -252,6 +253,21 @@ const arr = [];
       }
 
       arr.filter(item => get(item, "age") === getAge());
+      `,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // filterBy with one argument
+      code: `
+      const arr = [];
+
+      arr.filterBy("age");
+      `,
+      output: `
+      import { get } from '@ember/object';
+const arr = [];
+
+      arr.filter(item => get(item, "age"));
       `,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -234,9 +234,32 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      code: `
+      const arr = [];
+
+      function getAge() {
+        return 16;
+      }
+
+      arr.filterBy("age", getAge());
+      `,
+      output: `
+      import { get } from '@ember/object';
+const arr = [];
+
+      function getAge() {
+        return 16;
+      }
+
+      arr.filter(item => get(item, "age") === getAge());
+      `,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // Set in variable name but not a Set function.
-      code: 'set.filterBy()',
-      output: null,
+      code: 'set.filterBy("age", 18);',
+      output: `import { get } from '@ember/object';
+set.filter(item => get(item, "age") === 18);`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -326,7 +326,7 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     },
     {
       code: 'something.any()',
-      output: null,
+      output: 'something.some()',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -272,6 +272,39 @@ const arr = [];
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // filterBy with one argument and `get` import statement already imported
+      code: `
+      import { get as g } from '@ember/object';
+      const arr = [];
+
+      arr.filterBy("age");
+      `,
+      output: `
+      import { get as g } from '@ember/object';
+      const arr = [];
+
+      arr.filter(item => g(item, "age"));
+      `,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // filterBy with one argument and `get` import statement imported from a different package
+      code: `
+      import { get as g } from 'dummy';
+      const arr = [];
+
+      arr.filterBy("age");
+      `,
+      output: `
+      import { get } from '@ember/object';
+import { get as g } from 'dummy';
+      const arr = [];
+
+      arr.filter(item => get(item, "age"));
+      `,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // Set in variable name but not a Set function.
       code: 'set.filterBy("age", 18);',
       output: `import { get } from '@ember/object';


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `filterBy` with `filter`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `filterBy` with the native array method `filter`.

## Testing
Modified test case to check if the right output is generated after the fix.
