### PR TITLE
Add `compact` to `filter` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -152,12 +152,41 @@ function variableNameToWords(name) {
  * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
  * @returns {Object|[]}
  */
-function applyFix(callExpressionNode, fixer) {
+function applyFix(callExpressionNode, fixer, context) {
   const propertyName = callExpressionNode.callee.property.name;
 
   switch (propertyName) {
     case 'any':
       return fixer.replaceText(callExpressionNode.callee.property, 'some');
+    case 'compact': {
+      const calleePropertyNode = callExpressionNode.callee.property;
+      const compactArgs = callExpressionNode.arguments;
+      const fixes = [];
+
+      // Get the open and close parenthesis tokens
+      const openParenToken = context.getSourceCode().getTokenAfter(calleePropertyNode, {
+        filter(token) {
+          return token.type === 'Punctuator' && token.value === '(';
+        },
+      });
+      const closeParenToken = context.getSourceCode().getLastToken(callExpressionNode, {
+        filter(token) {
+          return token.type === 'Punctuator' && token.value === ')';
+        },
+      });
+
+      if (openParenToken && closeParenToken) {
+        fixes.push(
+          fixer.replaceText(calleePropertyNode, 'filter'),
+          // Replacing the content starting from open parenthesis to close parenthesis
+          fixer.replaceTextRange(
+            [openParenToken.range[0], closeParenToken.range[1]],
+            '(item => item !== undefined && item !== null)'
+          )
+        );
+      }
+      return fixes;
+    }
     default:
       return [];
   }
@@ -275,7 +304,7 @@ module.exports = {
             node,
             messageId: 'main',
             fix(fixer) {
-              return applyFix(node, fixer);
+              return applyFix(node, fixer, context);
             },
           });
         }

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { getName, getNodeOrNodeFromVariable } = require('../utils/utils');
-const { isClassPropertyOrPropertyDefinition } = require('../utils/types');
+const { isClassPropertyOrPropertyDefinition, isPunctuator } = require('../utils/types');
 const { getImportIdentifier } = require('../utils/import');
 const Stack = require('../utils/stack');
 
@@ -152,6 +152,8 @@ function variableNameToWords(name) {
  * @param {Object} callExpressionNode The call expression AST node.
  * @param {Object} fixer The ESLint fixer object which will be used to apply fixes.
  * @param {Object} context The ESlint context object which contains some helper utils
+ * @param {Object} [options] An object that contains additional information
+ * @param {String} [options.importedGetName] The name of the imported get specifier from @ember/object package
  * @returns {Object|[]}
  */
 function applyFix(callExpressionNode, fixer, context, options = {}) {
@@ -162,17 +164,19 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       return fixer.replaceText(callExpressionNode.callee.property, 'some');
     case 'compact': {
       const calleePropertyNode = callExpressionNode.callee.property;
+      const sourceCode = context.getSourceCode();
       const fixes = [];
 
-      // Get the open and close parenthesis tokens
-      const openParenToken = context.getSourceCode().getTokenAfter(calleePropertyNode, {
+      // Get the open parenthesis immediately after the callee name
+      const openParenToken = sourceCode.getTokenAfter(calleePropertyNode, {
         filter(token) {
-          return token.type === 'Punctuator' && token.value === '(';
+          return isPunctuator(token) && token.value === '(';
         },
       });
-      const closeParenToken = context.getSourceCode().getLastToken(callExpressionNode, {
+      // Get the close parenthesis from the end of the callExpressionNode
+      const closeParenToken = sourceCode.getLastToken(callExpressionNode, {
         filter(token) {
-          return token.type === 'Punctuator' && token.value === ')';
+          return isPunctuator(token) && token.value === ')';
         },
       });
 

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const { getName, getNodeOrNodeFromVariable } = require('../utils/utils');
-const { isClassPropertyOrPropertyDefinition, isPunctuator } = require('../utils/types');
+const { isClassPropertyOrPropertyDefinition } = require('../utils/types');
 const { getImportIdentifier } = require('../utils/import');
 const Stack = require('../utils/stack');
 
 const ERROR_MESSAGE = "Don't use Ember's array prototype extensions";
+const TOKEN_TYPES = {
+  PUNCTUATOR: 'Punctuator',
+};
 
 const EXTENSION_METHODS = new Set([
   /**
@@ -171,13 +174,13 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       // Get the open parenthesis immediately after the callee name
       const openParenToken = sourceCode.getTokenAfter(calleePropertyNode, {
         filter(token) {
-          return isPunctuator(token) && token.value === '(';
+          return token.type === TOKEN_TYPES.PUNCTUATOR && token.value === '(';
         },
       });
       // Get the close parenthesis from the end of the callExpressionNode
       const closeParenToken = sourceCode.getLastToken(callExpressionNode, {
         filter(token) {
-          return isPunctuator(token) && token.value === ')';
+          return token.type === TOKEN_TYPES.PUNCTUATOR && token.value === ')';
         },
       });
 

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -160,7 +160,6 @@ function applyFix(callExpressionNode, fixer, context) {
       return fixer.replaceText(callExpressionNode.callee.property, 'some');
     case 'compact': {
       const calleePropertyNode = callExpressionNode.callee.property;
-      const compactArgs = callExpressionNode.arguments;
       const fixes = [];
 
       // Get the open and close parenthesis tokens

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -165,6 +165,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
     case 'compact': {
       const calleePropertyNode = callExpressionNode.callee.property;
       const sourceCode = context.getSourceCode();
+      const callArgs = callExpressionNode.arguments;
       const fixes = [];
 
       // Get the open parenthesis immediately after the callee name
@@ -180,7 +181,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         },
       });
 
-      if (openParenToken && closeParenToken) {
+      if (openParenToken && closeParenToken && callArgs.length === 0) {
         fixes.push(
           fixer.replaceText(calleePropertyNode, 'filter'),
           // Replacing the content starting from open parenthesis to close parenthesis

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -39,6 +39,7 @@ module.exports = {
   isThisExpression,
   isUnaryExpression,
   isVariableDeclarator,
+  isPunctuator,
 };
 
 /**
@@ -414,4 +415,14 @@ function isUnaryExpression(node) {
  */
 function isVariableDeclarator(node) {
   return node !== undefined && node.type === 'VariableDeclarator';
+}
+
+/**
+ * Check whether or not a token is a Punctuator.
+ *
+ * @param {Object} token The token to check.
+ * @returns {boolean} Whether or not the token is a Punctuator.
+ */
+function isPunctuator(token) {
+  return token?.type === 'Punctuator';
 }

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -39,7 +39,6 @@ module.exports = {
   isThisExpression,
   isUnaryExpression,
   isVariableDeclarator,
-  isPunctuator,
 };
 
 /**
@@ -415,14 +414,4 @@ function isUnaryExpression(node) {
  */
 function isVariableDeclarator(node) {
   return node !== undefined && node.type === 'VariableDeclarator';
-}
-
-/**
- * Check whether or not a token is a Punctuator.
- *
- * @param {Object} token The token to check.
- * @returns {boolean} Whether or not the token is a Punctuator.
- */
-function isPunctuator(token) {
-  return token?.type === 'Punctuator';
 }

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -321,7 +321,13 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     },
     {
       code: 'something.compact()',
-      output: null,
+      output: 'something.filter(item => item !== undefined && item !== null)',
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Invalid as compact function doesn't support any params. Autofixer removes all the arguments and include the right callback
+      code: 'something.compact(1, getVal(), 3)',
+      output: 'something.filter(item => item !== undefined && item !== null)',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -397,6 +397,12 @@ set.filter(item => get(item, "age") === 18);`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of params are passed, skipping auto-fixing
+      code: 'something.compact(1, getVal(), 3)',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       code: 'something.any()',
       output: 'something.some()',
       errors: [{ messageId: 'main', type: 'CallExpression' }],

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -397,12 +397,6 @@ set.filter(item => get(item, "age") === 18);`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      // Invalid as compact function doesn't support any params. Autofixer removes all the arguments and include the right callback
-      code: 'something.compact(1, getVal(), 3)',
-      output: 'something.filter(item => item !== undefined && item !== null)',
-      errors: [{ messageId: 'main', type: 'CallExpression' }],
-    },
-    {
       code: 'something.any()',
       output: 'something.some()',
       errors: [{ messageId: 'main', type: 'CallExpression' }],


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `compact` with `filter`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `compact` with the native array method `filter`.

## Testing
Modified test case to check if the right output is generated after the fix.
