### PR TITLE
Add `toArray` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -264,6 +264,20 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'toArray': {
+      const calleeObj = callExpressionNode.callee.object;
+      const callArgs = callExpressionNode.arguments;
+      const sourceCode = context.getSourceCode();
+
+      if (callArgs.length === 0) {
+        return [
+          fixer.insertTextBefore(callExpressionNode, `[...${sourceCode.getText(calleeObj)}]`),
+          fixer.remove(callExpressionNode),
+        ];
+      }
+
+      return [];
+    }
     default: {
       return [];
     }

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -533,8 +533,19 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      code: 'something.toArray()',
+      // When unexpected number of params are passed, we will skip auto-fixing
+      code: 'something.toArray(1)',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.toArray()',
+      output: '[...something]',
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.somethingElse.toArray()',
+      output: '[...something.somethingElse]',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which fixes the `toArray` usage.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will fix the usage of `toArray` method.

## Testing
Modified test case to check if the right output is generated after the fix.
