### PR TITLE
Add `uniq` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -282,6 +282,19 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'uniq': {
+      if (callArgs.length === 0) {
+        return [
+          fixer.insertTextBefore(
+            callExpressionNode,
+            `[...new Set(${sourceCode.getText(calleeObj)})]`
+          ),
+          fixer.remove(callExpressionNode),
+        ];
+      }
+
+      return [];
+    }
     case 'without': {
       if (callArgs.length === 1) {
         const argText = sourceCode.getText(callArgs[0]);

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -587,7 +587,7 @@ import { get as g } from 'dummy';
     },
     {
       code: 'something.uniq()',
-      output: null,
+      output: '[...new Set(something)]',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -591,6 +591,12 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of params are passed, we will skip auto-fixing
+      code: 'something.uniq(1)',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       code: 'something.uniqBy()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which fixes `uniq`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `uniq`

## Testing
Modified test case to check if the right output is generated after the fix.
