### PR TITLE
Add `sortBy` to `sort` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -278,16 +278,12 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       if (callArgs.length > 0) {
         // default to `compare` if the `compare` hasn't already been imported.
         const importedCompareName = options.importedCompareName ?? 'compare';
+        // default to `compare` if the `compare` hasn't already been imported.
+        const importedGetName = options.importedGetName ?? 'get';
 
         const sortFn = `(a, b) => {
-          const sortKeys = [${callArgs.map((arg) => sourceCode.getText(arg)).join(', ')}];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = ${importedCompareName}(propA, propB);
-
+          for (const key of [${callArgs.map((arg) => sourceCode.getText(arg)).join(', ')}]) {
+            const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
             if (compareValue) {
               return compareValue;
             }
@@ -302,6 +298,11 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         );
 
         // Add `get` import statement only if it is not imported already
+        if (!options.importedGetName) {
+          fixes.push(insertImportDeclaration(sourceCode, fixer, '@ember/object', importedGetName));
+        }
+
+        // Add `compare` import statement only if it is not imported already
         if (!options.importedCompareName) {
           fixes.push(
             insertImportDeclaration(sourceCode, fixer, '@ember/utils', importedCompareName)

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -272,6 +272,45 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'sortBy': {
+      const fixes = [];
+
+      if (callArgs.length > 0) {
+        // default to `compare` if the `compare` hasn't already been imported.
+        const importedCompareName = options.importedCompareName ?? 'compare';
+
+        const sortFn = `(a, b) => {
+          const sortKeys = [${callArgs.map((arg) => sourceCode.getText(arg)).join(', ')}];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = ${importedCompareName}(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        }`;
+
+        fixes.push(
+          fixer.replaceText(calleeProp, 'sort'),
+          // Replacing the content starting from open parenthesis to close parenthesis
+          fixer.replaceTextRange([openParenToken.range[0], closeParenToken.range[1]], `(${sortFn})`)
+        );
+
+        // Add `get` import statement only if it is not imported already
+        if (!options.importedCompareName) {
+          fixes.push(
+            insertImportDeclaration(sourceCode, fixer, '@ember/utils', importedCompareName)
+          );
+        }
+      }
+
+      return fixes;
+    }
     case 'toArray': {
       if (callArgs.length === 0) {
         return [
@@ -338,6 +377,7 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     let importedGetName;
+    let importedCompareName;
 
     // Track some information about the current class we're inside.
     const classStack = new Stack();
@@ -346,6 +386,10 @@ module.exports = {
       ImportDeclaration(node) {
         if (node.source.value === '@ember/object') {
           importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
+        }
+        if (node.source.value === '@ember/utils') {
+          importedCompareName =
+            importedCompareName || getImportIdentifier(node, '@ember/utils', 'compare');
         }
       },
       /**
@@ -432,6 +476,7 @@ module.exports = {
             messageId: 'main',
             fix(fixer) {
               return applyFix(node, fixer, context, {
+                importedCompareName,
                 importedGetName,
               });
             },

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -573,16 +573,11 @@ import { get as g } from 'dummy';
     {
       // Arguments containing strings
       code: "something.sortBy('abc', 'def')",
-      output: `import { compare } from '@ember/utils';
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
 something.sort((a, b) => {
-          const sortKeys = ['abc', 'def'];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = compare(propA, propB);
-
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
               return compareValue;
             }
@@ -594,16 +589,11 @@ something.sort((a, b) => {
     {
       // Arguments other than strings
       code: "something.sortBy('abc', def)",
-      output: `import { compare } from '@ember/utils';
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
 something.sort((a, b) => {
-          const sortKeys = ['abc', def];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = compare(propA, propB);
-
+          for (const key of ['abc', def]) {
+            const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
               return compareValue;
             }
@@ -616,16 +606,11 @@ something.sort((a, b) => {
       // When compare method is already imported from @ember/utils.
       code: `import { compare } from '@ember/utils';
       something.sortBy('abc', 'def')`,
-      output: `import { compare } from '@ember/utils';
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
       something.sort((a, b) => {
-          const sortKeys = ['abc', 'def'];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = compare(propA, propB);
-
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
               return compareValue;
             }
@@ -638,16 +623,11 @@ something.sort((a, b) => {
       // When compare method is already imported with alias from @ember/utils.
       code: `import { compare as comp } from '@ember/utils';
       something.sortBy('abc', 'def')`,
-      output: `import { compare as comp } from '@ember/utils';
+      output: `import { get } from '@ember/object';
+import { compare as comp } from '@ember/utils';
       something.sort((a, b) => {
-          const sortKeys = ['abc', 'def'];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = comp(propA, propB);
-
+          for (const key of ['abc', 'def']) {
+            const compareValue = comp(get(a, key), get(b, key));
             if (compareValue) {
               return compareValue;
             }
@@ -660,17 +640,70 @@ something.sort((a, b) => {
       // When compare method is already imported from a package other than @ember/utils.
       code: `import { compare as comp } from '@custom/utils';
       something.sortBy('abc', 'def')`,
-      output: `import { compare } from '@ember/utils';
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       something.sort((a, b) => {
-          const sortKeys = ['abc', 'def'];
-          for (let i = 0; i < sortKeys.length; i++) {
-            let key = sortKeys[i];
-            let propA = get(a, key);
-            let propB = get(b, key);
-            // return 1 or -1 else continue to the next sortKey
-            let compareValue = compare(propA, propB);
-
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(get(a, key), get(b, key));
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported from @ember/object.
+      code: `import { compare as comp } from '@custom/utils';
+      import { get } from '@ember/object';
+      something.sortBy('abc', 'def')`,
+      output: `import { compare } from '@ember/utils';
+import { compare as comp } from '@custom/utils';
+      import { get } from '@ember/object';
+      something.sort((a, b) => {
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(get(a, key), get(b, key));
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported from a package other than @ember/object.
+      code: `import { compare as comp } from '@custom/utils';
+      import { get as g } from '@custom/object';
+      something.sortBy('abc', 'def')`,
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
+import { compare as comp } from '@custom/utils';
+      import { get as g } from '@custom/object';
+      something.sort((a, b) => {
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(get(a, key), get(b, key));
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported with an alias from @ember/object package.
+      code: `import { compare as comp } from '@custom/utils';
+      import { get as g } from '@ember/object';
+      something.sortBy('abc', 'def')`,
+      output: `import { compare } from '@ember/utils';
+import { compare as comp } from '@custom/utils';
+      import { get as g } from '@ember/object';
+      something.sort((a, b) => {
+          for (const key of ['abc', 'def']) {
+            const compareValue = compare(g(a, key), g(b, key));
             if (compareValue) {
               return compareValue;
             }

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -565,6 +565,7 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.sortBy()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -570,6 +570,115 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // Arguments containing strings
+      code: "something.sortBy('abc', 'def')",
+      output: `import { compare } from '@ember/utils';
+something.sort((a, b) => {
+          const sortKeys = ['abc', 'def'];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = compare(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Arguments other than strings
+      code: "something.sortBy('abc', def)",
+      output: `import { compare } from '@ember/utils';
+something.sort((a, b) => {
+          const sortKeys = ['abc', def];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = compare(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When compare method is already imported from @ember/utils.
+      code: `import { compare } from '@ember/utils';
+      something.sortBy('abc', 'def')`,
+      output: `import { compare } from '@ember/utils';
+      something.sort((a, b) => {
+          const sortKeys = ['abc', 'def'];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = compare(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When compare method is already imported with alias from @ember/utils.
+      code: `import { compare as comp } from '@ember/utils';
+      something.sortBy('abc', 'def')`,
+      output: `import { compare as comp } from '@ember/utils';
+      something.sort((a, b) => {
+          const sortKeys = ['abc', 'def'];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = comp(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When compare method is already imported from a package other than @ember/utils.
+      code: `import { compare as comp } from '@custom/utils';
+      something.sortBy('abc', 'def')`,
+      output: `import { compare } from '@ember/utils';
+import { compare as comp } from '@custom/utils';
+      something.sort((a, b) => {
+          const sortKeys = ['abc', 'def'];
+          for (let i = 0; i < sortKeys.length; i++) {
+            let key = sortKeys[i];
+            let propA = get(a, key);
+            let propB = get(b, key);
+            // return 1 or -1 else continue to the next sortKey
+            let compareValue = compare(propA, propB);
+
+            if (compareValue) {
+              return compareValue;
+            }
+          }
+          return 0;
+        })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // When unexpected number of params are passed, we will skip auto-fixing
       code: 'something.toArray(1)',
       output: null,


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `sortBy` with `sort`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `sortBy` with the native array method `sort`.

## Testing
Modified test case to check if the right output is generated after the fix.