### PR TITLE
Add `uniqBy` to `reduce` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -339,9 +339,24 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       const fixes = [];
 
       if (callArgs.length === 1) {
-        const arg = sourceCode.getText(callArgs[0]);
+        const argInString = sourceCode.getText(callArgs[0]);
         // default to `get` if the `get` hasn't already been imported.
         const importedGetName = options.importedGetName ?? 'get';
+
+        let isFunctionArg;
+        let isLiteralArg;
+
+        switch (callArgs[0].type) {
+          case 'ArrowFunctionExpression':
+          case 'FunctionExpression':
+            isFunctionArg = true;
+            break;
+          case 'Literal':
+            isLiteralArg = true;
+            break;
+          default:
+            break;
+        }
 
         const uniqByFn = `([uniqArr, itemsSet, getterFn], item) => {
           const val = getterFn(item);
@@ -352,11 +367,16 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
           return [uniqArr, itemsSet, getterFn];
         }`;
 
-        const reducerInitialValueArr = [
-          '[]',
-          'new Set()',
-          `typeof ${arg} === 'function' ? ${arg} : (item) => ${importedGetName}(item, ${arg})`,
-        ];
+        let getterFnInText;
+        if (isLiteralArg) {
+          getterFnInText = `(item) => ${importedGetName}(item, ${argInString})`;
+        } else if (isFunctionArg) {
+          getterFnInText = argInString;
+        } else {
+          getterFnInText = `typeof ${argInString} === 'function' ? ${argInString} : (item) => ${importedGetName}(item, ${argInString})`;
+        }
+
+        const reducerInitialValueArr = ['[]', 'new Set()', getterFnInText];
 
         fixes.push(
           fixer.replaceText(calleeProp, 'reduce'),

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -348,14 +348,17 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
         switch (callArgs[0].type) {
           case 'ArrowFunctionExpression':
-          case 'FunctionExpression':
+          case 'FunctionExpression': {
             isFunctionArg = true;
             break;
-          case 'Literal':
+          }
+          case 'Literal': {
             isLiteralArg = true;
             break;
-          default:
+          }
+          default: {
             break;
+          }
         }
 
         const uniqByFn = `([uniqArr, itemsSet, getterFn], item) => {

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -335,6 +335,48 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'uniqBy': {
+      const fixes = [];
+
+      if (callArgs.length === 1) {
+        const arg = sourceCode.getText(callArgs[0]);
+        // default to `compare` if the `compare` hasn't already been imported.
+        const importedGetName = options.importedGetName ?? 'get';
+
+        const uniqByFn = `([uniqArr, itemsSet, getterFn], item) => {
+          const val = getterFn(item);
+          if (!itemsSet.has(val)) {
+            itemsSet.add(val);
+            uniqArr.push(item);
+          }
+          return [uniqArr, itemsSet, getterFn];
+        }`;
+
+        const reducerInitialValue = [
+          '[]',
+          'new Set()',
+          `typeof ${arg} === 'function' ? ${arg} : (item) => ${importedGetName}(item, ${arg})`,
+        ];
+
+        fixes.push(
+          fixer.replaceText(calleeProp, 'reduce'),
+          // Replacing the content starting from open parenthesis to close parenthesis
+          fixer.replaceTextRange(
+            [openParenToken.range[0], closeParenToken.range[1]],
+            `(${uniqByFn}, [${reducerInitialValue.join(', ')}])[0]`
+          )
+        );
+
+        // Add `get` import statement only if it is not imported already
+        if (!options.importedGetName) {
+          fixes.push(insertImportDeclaration(sourceCode, fixer, '@ember/object', importedGetName));
+        }
+
+        return fixes;
+      }
+
+      return [];
+    }
     case 'without': {
       if (callArgs.length === 1) {
         const argText = sourceCode.getText(callArgs[0]);

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -340,7 +340,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       if (callArgs.length === 1) {
         const arg = sourceCode.getText(callArgs[0]);
-        // default to `compare` if the `compare` hasn't already been imported.
+        // default to `get` if the `get` hasn't already been imported.
         const importedGetName = options.importedGetName ?? 'get';
 
         const uniqByFn = `([uniqArr, itemsSet, getterFn], item) => {
@@ -352,7 +352,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
           return [uniqArr, itemsSet, getterFn];
         }`;
 
-        const reducerInitialValue = [
+        const reducerInitialValueArr = [
           '[]',
           'new Set()',
           `typeof ${arg} === 'function' ? ${arg} : (item) => ${importedGetName}(item, ${arg})`,
@@ -363,7 +363,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
           // Replacing the content starting from open parenthesis to close parenthesis
           fixer.replaceTextRange(
             [openParenToken.range[0], closeParenToken.range[1]],
-            `(${uniqByFn}, [${reducerInitialValue.join(', ')}])[0]`
+            `(${uniqByFn}, [${reducerInitialValueArr.join(', ')}])[0]`
           )
         );
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -756,7 +756,7 @@ something.reduce(([uniqArr, itemsSet, getterFn], item) => {
             uniqArr.push(item);
           }
           return [uniqArr, itemsSet, getterFn];
-        }, [[], new Set(), typeof 1 === 'function' ? 1 : (item) => get(item, 1)])[0]`,
+        }, [[], new Set(), (item) => get(item, 1)])[0]`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -785,7 +785,7 @@ something.reduce(([uniqArr, itemsSet, getterFn], item) => {
             uniqArr.push(item);
           }
           return [uniqArr, itemsSet, getterFn];
-        }, [[], new Set(), typeof 'abc' === 'function' ? 'abc' : (item) => get(item, 'abc')])[0].sort()`,
+        }, [[], new Set(), (item) => get(item, 'abc')])[0].sort()`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -801,7 +801,7 @@ import { get as g } from '@custom/object';
             uniqArr.push(item);
           }
           return [uniqArr, itemsSet, getterFn];
-        }, [[], new Set(), typeof 'abc' === 'function' ? 'abc' : (item) => get(item, 'abc')])[0].sort()`,
+        }, [[], new Set(), (item) => get(item, 'abc')])[0].sort()`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -816,7 +816,54 @@ import { get as g } from '@custom/object';
             uniqArr.push(item);
           }
           return [uniqArr, itemsSet, getterFn];
-        }, [[], new Set(), typeof 'abc' === 'function' ? 'abc' : (item) => g(item, 'abc')])[0]`,
+        }, [[], new Set(), (item) => g(item, 'abc')])[0]`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When arrow function expression is passed as argument
+      code: `import { get as g } from '@ember/object';
+      something.uniqBy(() => true)`,
+      output: `import { get as g } from '@ember/object';
+      something.reduce(([uniqArr, itemsSet, getterFn], item) => {
+          const val = getterFn(item);
+          if (!itemsSet.has(val)) {
+            itemsSet.add(val);
+            uniqArr.push(item);
+          }
+          return [uniqArr, itemsSet, getterFn];
+        }, [[], new Set(), () => true])[0]`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When function expression is passed as argument
+      code: `import { get as g } from '@ember/object';
+      something.uniqBy(function test() { return true; })`,
+      output: `import { get as g } from '@ember/object';
+      something.reduce(([uniqArr, itemsSet, getterFn], item) => {
+          const val = getterFn(item);
+          if (!itemsSet.has(val)) {
+            itemsSet.add(val);
+            uniqArr.push(item);
+          }
+          return [uniqArr, itemsSet, getterFn];
+        }, [[], new Set(), function test() { return true; }])[0]`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When function expression is passed as argument
+      code: `function test() { return true; }
+      import { get as g } from '@ember/object';
+      something.uniqBy(test)`,
+      output: `function test() { return true; }
+      import { get as g } from '@ember/object';
+      something.reduce(([uniqArr, itemsSet, getterFn], item) => {
+          const val = getterFn(item);
+          if (!itemsSet.has(val)) {
+            itemsSet.add(val);
+            uniqArr.push(item);
+          }
+          return [uniqArr, itemsSet, getterFn];
+        }, [[], new Set(), typeof test === 'function' ? test : (item) => g(item, test)])[0]`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `uniqBy` with `reduce`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `uniqBy` with the native array method `reduce`.

## Testing
Modified test case to check if the right output is generated after the fix.