### PR TITLE
Add `objectAt` to `map` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -272,6 +272,21 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'objectsAt': {
+      if (callArgs.length > 0) {
+        return [
+          fixer.insertTextBefore(
+            callExpressionNode,
+            `[${callArgs
+              .map((arg) => sourceCode.getText(arg))
+              .join(', ')}].map((ind) => ${sourceCode.getText(calleeObj)}[ind])`
+          ),
+          fixer.remove(callExpressionNode),
+        ];
+      }
+
+      return [];
+    }
     case 'sortBy': {
       const fixes = [];
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -545,8 +545,14 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.objectsAt()',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.objectsAt(1, 2)',
+      output: '[1, 2].map((ind) => something[ind])',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `objectAt` with `map`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `objectAt` with the native array method `map`.

## Testing
Modified test case to check if the right output is generated after the fix.