### PR TITLE
Add `reject` to `filter` autofixer for no-array-prototype-extensions rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -313,9 +313,10 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       if (callArgs.length > 0 && callArgs.length < 3) {
         return [
           fixer.replaceText(calleeProp, 'filter'),
+          // TODO: Switch to `Reflect.apply` once Ember v3 LTS support ends: https://emberjs.com/releases/lts/
           fixer.replaceText(
             callArgs[0],
-            `function() { return !(${sourceCode.getText(callArgs[0])}).apply(this, arguments); }`
+            `function(...args) { return !(${sourceCode.getText(callArgs[0])}).apply(this, args); }`
           ),
         ];
       }

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -272,6 +272,18 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return [];
     }
+    case 'reject': {
+      if (callArgs.length > 0 && callArgs.length < 3) {
+        return [
+          fixer.replaceText(calleeProp, 'filter'),
+          fixer.replaceText(
+            callArgs[0],
+            `function() { return !(${sourceCode.getText(callArgs[0])}).apply(this, arguments); }`
+          ),
+        ];
+      }
+      return [];
+    }
     case 'sortBy': {
       const fixes = [];
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -550,8 +550,23 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.reject()',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Single argument is passed
+      code: 'something.reject(function(el) { return el.isFlagged; })',
+      output:
+        'something.filter(function() { return !(function(el) { return el.isFlagged; }).apply(this, arguments); })',
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Two arguments are passed
+      code: 'something.reject(function(el) { return el.isFlagged && this.isFlagged; }, {isFlagged: true})',
+      output:
+        'something.filter(function() { return !(function(el) { return el.isFlagged && this.isFlagged; }).apply(this, arguments); }, {isFlagged: true})',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -641,14 +641,14 @@ import { get as g } from 'dummy';
       // Single argument is passed
       code: 'something.reject(function(el) { return el.isFlagged; })',
       output:
-        'something.filter(function() { return !(function(el) { return el.isFlagged; }).apply(this, arguments); })',
+        'something.filter(function(...args) { return !(function(el) { return el.isFlagged; }).apply(this, args); })',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
       // Two arguments are passed
       code: 'something.reject(function(el) { return el.isFlagged && this.isFlagged; }, {isFlagged: true})',
       output:
-        'something.filter(function() { return !(function(el) { return el.isFlagged && this.isFlagged; }).apply(this, arguments); }, {isFlagged: true})',
+        'something.filter(function(...args) { return !(function(el) { return el.isFlagged && this.isFlagged; }).apply(this, args); }, {isFlagged: true})',
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `reject` with `filter`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `reject` with the native array method `filter`.

## Testing
Modified test case to check if the right output is generated after the fix.