### PR TITLE
Add `isAny` and `isEvery` autofixers for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -226,8 +226,9 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
             replacementMethod = 'every';
             break;
           }
-          default:
+          default: {
             replacementMethod = 'filter';
+          }
         }
 
         // default to `get` if the `get` hasn't already been imported.

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -201,7 +201,9 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       return fixes;
     }
     case 'filterBy':
-    case 'findBy': {
+    case 'findBy':
+    case 'isAny':
+    case 'isEvery': {
       const fixes = [];
 
       if (callArgs.length > 0 && callArgs.length < 3) {
@@ -209,11 +211,30 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         const firstArg = callArgs[0];
         const secondArg = callArgs[1];
 
+        let replacementMethod;
+
+        switch (propertyName) {
+          case 'findBy': {
+            replacementMethod = 'find';
+            break;
+          }
+          case 'isAny': {
+            replacementMethod = 'some';
+            break;
+          }
+          case 'isEvery': {
+            replacementMethod = 'every';
+            break;
+          }
+          default:
+            replacementMethod = 'filter';
+        }
+
         // default to `get` if the `get` hasn't already been imported.
         const importedGetName = options.importedGetName ?? 'get';
 
         fixes.push(
-          fixer.replaceText(calleeProp, propertyName === 'findBy' ? 'find' : 'filter'),
+          fixer.replaceText(calleeProp, replacementMethod),
           // Replacing the content starting from open parenthesis to close parenthesis
           // If the findBy contains two arguments, the property (first argument) value will be compared against the second argument
           // If the filterBy contains only one argument, the property's truthy value is used to filter

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -471,13 +471,89 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.isAny()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      code: 'something.isAny("abc")',
+      output: `import { get } from '@ember/object';
+something.some(item => get(item, "abc"))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.isAny("abc", "def")',
+      output: `import { get } from '@ember/object';
+something.some(item => get(item, "abc") === "def")`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from '@ember/object' package
+      code: `import { get } from '@ember/object';
+      something.isAny('abc', def)`,
+      output: `import { get } from '@ember/object';
+      something.some(item => get(item, 'abc') === def)`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported with alias from '@ember/object' package
+      code: `import { get as g } from '@ember/object';
+      something.isAny(abc, 'def')`,
+      output: `import { get as g } from '@ember/object';
+      something.some(item => g(item, abc) === 'def')`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from a package other than '@ember/object'
+      code: `import { get as g } from '@custom/object';
+      something.isAny('abc', 'def')`,
+      output: `import { get } from '@ember/object';
+import { get as g } from '@custom/object';
+      something.some(item => get(item, 'abc') === 'def')`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.isEvery()',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.isEvery("abc")',
+      output: `import { get } from '@ember/object';
+something.every(item => get(item, "abc"))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.isEvery("abc", "def")',
+      output: `import { get } from '@ember/object';
+something.every(item => get(item, "abc") === "def")`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from '@ember/object' package
+      code: `import { get } from '@ember/object';
+      something.isEvery('abc', def)`,
+      output: `import { get } from '@ember/object';
+      something.every(item => get(item, 'abc') === def)`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported with alias from '@ember/object' package
+      code: `import { get as g } from '@ember/object';
+      something.isEvery(abc, 'def')`,
+      output: `import { get as g } from '@ember/object';
+      something.every(item => g(item, abc) === 'def')`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from a package other than '@ember/object'
+      code: `import { get as g } from '@custom/object';
+      something.isEvery('abc', 'def')`,
+      output: `import { get } from '@ember/object';
+import { get as g } from '@custom/object';
+      something.every(item => get(item, 'abc') === 'def')`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replacs `isAny` with `some` and `isEvery` with `every`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `isAny` with the native array method `some` and `isEvery` with the native array method `every`.

## Testing
Modified test case to check if the right output is generated after the fix.