### PR TITLE
Add `getEach` to `map` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -255,7 +255,8 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
       return fixes;
     }
-    case 'mapBy': {
+    case 'mapBy':
+    case 'getEach': {
       if (callArgs.length === 1) {
         const argText = sourceCode.getText(callArgs[0]);
         const fixes = [];

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -461,8 +461,52 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.getEach()',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When unexpected number of arguments are passed, auto-fixer will not run
+      code: 'something.getEach(1, 2)',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: "something.getEach('abc')",
+      output: `import { get } from '@ember/object';
+something.map(item => get(item, 'abc'))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.getEach(def)',
+      output: `import { get } from '@ember/object';
+something.map(item => get(item, def))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from `@ember/object` package
+      code: `import { get } from '@ember/object';
+      something.mapBy('abc')`,
+      output: `import { get } from '@ember/object';
+      something.map(item => get(item, 'abc'))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported as alias from `@ember/object` package
+      code: `import { get as g } from '@ember/object';
+      something.mapBy('abc')`,
+      output: `import { get as g } from '@ember/object';
+      something.map(item => g(item, 'abc'))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When `get` method is already imported from a other than `@ember/object`
+      code: `import { get as g } from 'dummy';
+      something.mapBy('abc')`,
+      output: `import { get } from '@ember/object';
+import { get as g } from 'dummy';
+      something.map(item => get(item, 'abc'))`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -487,7 +487,7 @@ something.map(item => get(item, def))`,
     {
       // When `get` method is already imported from `@ember/object` package
       code: `import { get } from '@ember/object';
-      something.mapBy('abc')`,
+      something.getEach('abc')`,
       output: `import { get } from '@ember/object';
       something.map(item => get(item, 'abc'))`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
@@ -495,7 +495,7 @@ something.map(item => get(item, def))`,
     {
       // When `get` method is already imported as alias from `@ember/object` package
       code: `import { get as g } from '@ember/object';
-      something.mapBy('abc')`,
+      something.getEach('abc')`,
       output: `import { get as g } from '@ember/object';
       something.map(item => g(item, 'abc'))`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
@@ -503,7 +503,7 @@ something.map(item => get(item, def))`,
     {
       // When `get` method is already imported from a other than `@ember/object`
       code: `import { get as g } from 'dummy';
-      something.mapBy('abc')`,
+      something.getEach('abc')`,
       output: `import { get } from '@ember/object';
 import { get as g } from 'dummy';
       something.map(item => get(item, 'abc'))`,


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `getEach` with `map`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `getEach` with the native array method `map`.

## Testing
Modified test case to check if the right output is generated after the fix.