### PR TITLE
Add `setEach` to `forEach` autofixer for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -361,7 +361,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       const fixes = [];
 
       if (callArgs.length === 2) {
-        // default to `compare` if the `compare` hasn't already been imported.
+        // default to `set` if the `set` hasn't already been imported.
         const importedSetName = options.importedSetName ?? 'set';
 
         fixes.push(

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -158,6 +158,8 @@ function variableNameToWords(name) {
  * @param {Object} context The ESlint context object which contains some helper utils
  * @param {Object} [options] An object that contains additional information
  * @param {String} [options.importedGetName] The name of the imported get specifier from @ember/object package
+ * @param {String} [options.importedSetName] The name of the imported set specifier from @ember/object package
+ * @param {String} [options.importedCompareName] The name of the imported compare specifier from @ember/utils package
  * @returns {Object|[]}
  */
 // eslint-disable-next-line complexity
@@ -355,6 +357,34 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       }
       return fixes;
     }
+    case 'setEach': {
+      const fixes = [];
+
+      if (callArgs.length === 2) {
+        // default to `compare` if the `compare` hasn't already been imported.
+        const importedSetName = options.importedSetName ?? 'set';
+
+        fixes.push(
+          fixer.replaceText(calleeProp, 'forEach'),
+          // Replacing the content starting from open parenthesis to close parenthesis
+          fixer.replaceTextRange(
+            [openParenToken.range[0], closeParenToken.range[1]],
+            `(item => ${importedSetName}(item, ${callArgs
+              .map((arg) => sourceCode.getText(arg))
+              .join(', ')}))`
+          )
+        );
+
+        // Add `set` import statement only if it is not imported already
+        if (!options.importedSetName) {
+          fixes.push(insertImportDeclaration(sourceCode, fixer, '@ember/object', importedSetName));
+        }
+
+        return fixes;
+      }
+
+      return [];
+    }
     case 'sortBy': {
       const fixes = [];
 
@@ -539,6 +569,7 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     let importedGetName;
+    let importedSetName;
     let importedCompareName;
 
     // Track some information about the current class we're inside.
@@ -548,6 +579,7 @@ module.exports = {
       ImportDeclaration(node) {
         if (node.source.value === '@ember/object') {
           importedGetName = importedGetName || getImportIdentifier(node, '@ember/object', 'get');
+          importedSetName = importedSetName || getImportIdentifier(node, '@ember/object', 'set');
         }
         if (node.source.value === '@ember/utils') {
           importedCompareName =
@@ -640,6 +672,7 @@ module.exports = {
               return applyFix(node, fixer, context, {
                 importedCompareName,
                 importedGetName,
+                importedSetName,
               });
             },
           });

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -697,8 +697,46 @@ import { get as g } from '@custom/object';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.setEach()',
       output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When unexpected number of arguments are passed, auto-fixer will not run
+      code: 'something.setEach("abc")',
+      output: null,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      code: 'something.setEach("abc", 2)',
+      output: `import { set } from '@ember/object';
+something.forEach(item => set(item, "abc", 2))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported from @ember/object package.
+      code: `import { set } from '@ember/object';
+      something.setEach("abc", 2)`,
+      output: `import { set } from '@ember/object';
+      something.forEach(item => set(item, "abc", 2))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported as alias from @ember/object package.
+      code: `import { set as s } from '@ember/object';
+      something.setEach("abc", 2)`,
+      output: `import { set as s } from '@ember/object';
+      something.forEach(item => s(item, "abc", 2))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // When get method is already imported from a package other than @ember/object.
+      code: `import { set as s } from '@custom/object';
+      something.setEach("abc", 2)`,
+      output: `import { set } from '@ember/object';
+import { set as s } from '@custom/object';
+      something.forEach(item => set(item, "abc", 2))`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Added auto-fixer for `no-array-prototype-extensions` which replaces `setEach` with `forEach`.

## Description
Recently, the proposal to deprecate array prototype extensions has been approved and got merged. The plan is to add autoFixers to replace ember array prototype extensions with the native array methods. In this PR, an auto fixer has been added which will replace the ember array method `setEach` with the native array method `forEach`.

## Testing
Modified test case to check if the right output is generated after the fix.