### PR TITLE
Simpler autofix for `sortBy` with single arg for `no-array-prototype-extension` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -423,12 +423,23 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         // default to `compare` if the `compare` hasn't already been imported.
         const importedGetName = options.importedGetName ?? 'get';
 
-        const sortFn = `(a, b) => {
-          for (const key of [${callArgs.map((arg) => sourceCode.getText(arg)).join(', ')}]) {
-            const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
+        const compareValueCheckText = `const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
             if (compareValue) {
               return compareValue;
-            }
+            }`;
+        const argsText = callArgs.map((arg) => sourceCode.getText(arg)).join(', ');
+
+        // Loop through keys if more than one of them.
+        const sortFn =
+          callArgs.length === 1
+            ? `(a, b) => {
+            const key = ${argsText};
+            ${compareValueCheckText}
+            return 0;
+          }`
+            : `(a, b) => {
+          for (const key of [${argsText}]) {
+            ${compareValueCheckText}
           }
           return 0;
         }`;

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -800,6 +800,21 @@ something.sort((a, b) => {
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // Single argument.
+      code: 'something.sortBy(getKey())',
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
+something.sort((a, b) => {
+            const key = getKey();
+            const compareValue = compare(get(a, key), get(b, key));
+            if (compareValue) {
+              return compareValue;
+            }
+            return 0;
+          })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // Arguments other than strings
       code: "something.sortBy('abc', def)",
       output: `import { get } from '@ember/object';


### PR DESCRIPTION
Fixes #1634.

CC: @tgvrssanthosh