### PR TITLE
Avoid in-place sorting in `sortBy` autofixer in `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -429,14 +429,15 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         let sortFn;
 
         if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
-          const comparisonFnInString = `${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`;
+           const comparisonFnInString = (key) =>
+            `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
 
           sortFn =
             callArgs[0].type === 'Identifier' || callArgs[0].type === 'Literal'
-              ? `(a, b) => ${comparisonFnInString}`
+              ? `(a, b) => ${comparisonFnInString(argsText)}`
               : `(a, b) => {
               const key = ${argsText};
-              return ${comparisonFnInString};
+              return ${comparisonFnInString('key')};
             }`;
         } else {
           // Loop through keys if there are more than one argument

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -427,7 +427,6 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         const argsText = callArgs.map((arg) => sourceCode.getText(arg)).join(', ');
 
         let sortFn;
-        
         const comparisonFnInString = (key) =>
           `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
 

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -429,7 +429,6 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         let sortFn;
         const comparisonFnInString = (key) =>
           `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
-
         if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
           sortFn =
             callArgs[0].type === 'Identifier' || callArgs[0].type === 'Literal'

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -429,14 +429,14 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         let sortFn;
 
         if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
-          const comparisionFnInString = `${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`;
+          const comparisonFnInString = `${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`;
 
           sortFn =
             callArgs[0].type === 'Identifier' || callArgs[0].type === 'Literal'
-              ? `(a, b) => ${comparisionFnInString}`
+              ? `(a, b) => ${comparisonFnInString}`
               : `(a, b) => {
               const key = ${argsText};
-              return ${comparisionFnInString};
+              return ${comparisonFnInString};
             }`;
         } else {
           // Loop through keys if there are more than one argument

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -432,12 +432,8 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
 
         // Loop through keys if more than one of them.
         const sortFn =
-          callArgs.length === 1
-            ? `(a, b) => {
-            const key = ${argsText};
-            ${compareValueCheckText}
-            return 0;
-          }`
+          callArgs.length === 1 && callArgs[0].type !== 'SpreadElement'
+            ? `(a, b) => ${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`
             : `(a, b) => {
           for (const key of [${argsText}]) {
             ${compareValueCheckText}
@@ -446,6 +442,8 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         }`;
 
         fixes.push(
+          // Duplicate array
+          fixer.replaceText(calleeObj, `[...${sourceCode.getText(calleeObj)}]`),
           fixer.replaceText(calleeProp, 'sort'),
           // Replacing the content starting from open parenthesis to close parenthesis
           fixer.replaceTextRange([openParenToken.range[0], closeParenToken.range[1]], `(${sortFn})`)

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -443,7 +443,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
           // Loop through keys if there are more than one argument
           sortFn = `(a, b) => {
             for (const key of [${argsText}]) {
-              const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
+              const compareValue = ${comparisonFnInString('key')};
               if (compareValue) {
                 return compareValue;
               }

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -427,11 +427,11 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         const argsText = callArgs.map((arg) => sourceCode.getText(arg)).join(', ');
 
         let sortFn;
+        
+        const comparisonFnInString = (key) =>
+          `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
 
         if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
-          const comparisonFnInString = (key) =>
-            `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
-
           sortFn =
             callArgs[0].type === 'Identifier' || callArgs[0].type === 'Literal'
               ? `(a, b) => ${comparisonFnInString(argsText)}`

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -429,7 +429,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         let sortFn;
 
         if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
-           const comparisonFnInString = (key) =>
+          const comparisonFnInString = (key) =>
             `${importedCompareName}(${importedGetName}(a, ${key}), ${importedGetName}(b, ${key}))`;
 
           sortFn =

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -432,12 +432,12 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
           const comparisionFnInString = `${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`;
 
           sortFn =
-            callArgs[0].type === 'CallExpression'
-              ? `(a, b) => {
+            callArgs[0].type === 'Identifier' || callArgs[0].type === 'Literal'
+              ? `(a, b) => ${comparisionFnInString}`
+              : `(a, b) => {
               const key = ${argsText};
               return ${comparisionFnInString};
-            }`
-              : `(a, b) => ${comparisionFnInString}`;
+            }`;
         } else {
           // Loop through keys if there are more than one argument
           sortFn = `(a, b) => {

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -424,22 +424,32 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         // default to `compare` if the `compare` hasn't already been imported.
         const importedGetName = options.importedGetName ?? 'get';
 
-        const compareValueCheckText = `const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
-            if (compareValue) {
-              return compareValue;
-            }`;
         const argsText = callArgs.map((arg) => sourceCode.getText(arg)).join(', ');
 
-        // Loop through keys if more than one of them.
-        const sortFn =
-          callArgs.length === 1 && callArgs[0].type !== 'SpreadElement'
-            ? `(a, b) => ${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`
-            : `(a, b) => {
-          for (const key of [${argsText}]) {
-            ${compareValueCheckText}
-          }
-          return 0;
-        }`;
+        let sortFn;
+
+        if (callArgs.length === 1 && callArgs[0].type !== 'SpreadElement') {
+          const comparisionFnInString = `${importedCompareName}(${importedGetName}(a, ${argsText}), ${importedGetName}(b, ${argsText}))`;
+
+          sortFn =
+            callArgs[0].type === 'CallExpression'
+              ? `(a, b) => {
+              const key = ${argsText};
+              return ${comparisionFnInString};
+            }`
+              : `(a, b) => ${comparisionFnInString}`;
+        } else {
+          // Loop through keys if there are more than one argument
+          sortFn = `(a, b) => {
+            for (const key of [${argsText}]) {
+              const compareValue = ${importedCompareName}(${importedGetName}(a, key), ${importedGetName}(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
+            }
+            return 0;
+          }`;
+        }
 
         fixes.push(
           // Duplicate array

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -850,7 +850,7 @@ import { compare } from '@ember/utils';
 import { compare } from '@ember/utils';
 [...something].sort((a, b) => {
               const key = getKey();
-              return compare(get(a, getKey()), get(b, getKey()));
+              return compare(get(a, key), get(b, key));
             })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -832,7 +832,7 @@ import { set as s } from '@custom/object';
       code: "something.sortBy('abc', 'def')",
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
-something.sort((a, b) => {
+[...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -848,14 +848,23 @@ something.sort((a, b) => {
       code: 'something.sortBy(getKey())',
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
-something.sort((a, b) => {
-            const key = getKey();
+[...something].sort((a, b) => compare(get(a, getKey()), get(b, getKey())))`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Spread element as argument
+      code: 'something.sortBy(...abc)',
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
+[...something].sort((a, b) => {
+          for (const key of [...abc]) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
               return compareValue;
             }
-            return 0;
-          })`,
+          }
+          return 0;
+        })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -863,7 +872,7 @@ something.sort((a, b) => {
       code: "something.sortBy('abc', def)",
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
-something.sort((a, b) => {
+[...something].sort((a, b) => {
           for (const key of ['abc', def]) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -880,7 +889,7 @@ something.sort((a, b) => {
       something.sortBy('abc', 'def')`,
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -897,7 +906,7 @@ import { compare } from '@ember/utils';
       something.sortBy('abc', 'def')`,
       output: `import { get } from '@ember/object';
 import { compare as comp } from '@ember/utils';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = comp(get(a, key), get(b, key));
             if (compareValue) {
@@ -915,7 +924,7 @@ import { compare as comp } from '@ember/utils';
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -934,7 +943,7 @@ import { compare as comp } from '@custom/utils';
       output: `import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       import { get } from '@ember/object';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -954,7 +963,7 @@ import { compare as comp } from '@custom/utils';
 import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       import { get as g } from '@custom/object';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(get(a, key), get(b, key));
             if (compareValue) {
@@ -973,7 +982,7 @@ import { compare as comp } from '@custom/utils';
       output: `import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       import { get as g } from '@ember/object';
-      something.sort((a, b) => {
+      [...something].sort((a, b) => {
           for (const key of ['abc', 'def']) {
             const compareValue = compare(g(a, key), g(b, key));
             if (compareValue) {

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -833,22 +833,33 @@ import { set as s } from '@custom/object';
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
 [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      // Single argument.
+      // Single call expression argument.
       code: 'something.sortBy(getKey())',
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
-[...something].sort((a, b) => compare(get(a, getKey()), get(b, getKey())))`,
+[...something].sort((a, b) => {
+              const key = getKey();
+              return compare(get(a, getKey()), get(b, getKey()));
+            })`,
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
+      // Single non CallExpression argument.
+      code: "something.sortBy('abc')",
+      output: `import { get } from '@ember/object';
+import { compare } from '@ember/utils';
+[...something].sort((a, b) => compare(get(a, 'abc'), get(b, 'abc')))`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -857,14 +868,14 @@ import { compare } from '@ember/utils';
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
 [...something].sort((a, b) => {
-          for (const key of [...abc]) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of [...abc]) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -873,14 +884,14 @@ import { compare } from '@ember/utils';
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
 [...something].sort((a, b) => {
-          for (const key of ['abc', def]) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', def]) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -890,14 +901,14 @@ import { compare } from '@ember/utils';
       output: `import { get } from '@ember/object';
 import { compare } from '@ember/utils';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -907,14 +918,14 @@ import { compare } from '@ember/utils';
       output: `import { get } from '@ember/object';
 import { compare as comp } from '@ember/utils';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = comp(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = comp(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -925,14 +936,14 @@ import { compare as comp } from '@ember/utils';
 import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -944,14 +955,14 @@ import { compare as comp } from '@custom/utils';
 import { compare as comp } from '@custom/utils';
       import { get } from '@ember/object';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -964,14 +975,14 @@ import { compare } from '@ember/utils';
 import { compare as comp } from '@custom/utils';
       import { get as g } from '@custom/object';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(get(a, key), get(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(get(a, key), get(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
@@ -983,14 +994,14 @@ import { compare as comp } from '@custom/utils';
 import { compare as comp } from '@custom/utils';
       import { get as g } from '@ember/object';
       [...something].sort((a, b) => {
-          for (const key of ['abc', 'def']) {
-            const compareValue = compare(g(a, key), g(b, key));
-            if (compareValue) {
-              return compareValue;
+            for (const key of ['abc', 'def']) {
+              const compareValue = compare(g(a, key), g(b, key));
+              if (compareValue) {
+                return compareValue;
+              }
             }
-          }
-          return 0;
-        })`,
+            return 0;
+          })`,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {


### PR DESCRIPTION
## Summary
Bug fixes for `sortBy` autofixer.

## Description
This PR contains the following changes
- **Bug:** The ember's `sortBy` method on the array will shallow clone the array and then run sort on the cloned copy of the array. However, the cloning part of the array got missed out in the original implementation of the auto-fixer. Used spread operator to clone the array.
- **Optimization:** When a single argument is passed to sortBy, there is no need to store the compare function output and instead directly return the output of compare function.