### PR TITLE
Automate docs with eslint-doc-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,171 +49,166 @@ module.exports = {
 | ✅ | [recommended](./lib/recommended-rules.js) | enables the `recommended` rules |
 
 ## 🍟 Rules
+<!-- begin auto-generated rules list -->
 
-Rules are grouped by category to help you understand their purpose. Each rule has emojis denoting:
-
-- What configuration it belongs to
-- 🔧 if some problems reported by the rule are automatically fixable by the `--fix` [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) option
-- 💡 if some problems reported by the rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions)
-
-<!--RULES_TABLE_START-->
+✅ Enabled in the `recommended` [configuration](https://github.com/ember-cli/eslint-plugin-ember#-configurations).\
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 ### Components
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [no-attrs-in-components](./docs/rules/no-attrs-in-components.md) | disallow usage of `this.attrs` in components | ✅ |  |  |
-| [no-attrs-snapshot](./docs/rules/no-attrs-snapshot.md) | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks | ✅ |  |  |
-| [no-classic-components](./docs/rules/no-classic-components.md) | enforce using Glimmer components | ✅ |  |  |
-| [no-component-lifecycle-hooks](./docs/rules/no-component-lifecycle-hooks.md) | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. | ✅ |  |  |
-| [no-on-calls-in-components](./docs/rules/no-on-calls-in-components.md) | disallow usage of `on` to call lifecycle hooks in components | ✅ |  |  |
-| [require-tagless-components](./docs/rules/require-tagless-components.md) | disallow using the wrapper element of a component | ✅ |  |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                                                          | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [no-attrs-in-components](docs/rules/no-attrs-in-components.md)                                                                                       | disallow usage of `this.attrs` in components                                                                                         | ✅  |     |     |
+| [no-attrs-snapshot](docs/rules/no-attrs-snapshot.md)                                                                                                 | disallow use of attrs snapshot in the `didReceiveAttrs` and `didUpdateAttrs` component hooks                                         | ✅  |     |     |
+| [no-classic-components](docs/rules/no-classic-components.md)                                                                                         | enforce using Glimmer components                                                                                                     | ✅  |     |     |
+| [no-component-lifecycle-hooks](docs/rules/no-component-lifecycle-hooks.md)                                                                           | disallow usage of "classic" ember component lifecycle hooks. Render modifiers or custom functional modifiers should be used instead. | ✅  |     |     |
+| [no-on-calls-in-components](docs/rules/no-on-calls-in-components.md)                                                                                 | disallow usage of `on` to call lifecycle hooks in components                                                                         | ✅  |     |     |
+| [require-tagless-components](docs/rules/require-tagless-components.md)                                                                               | disallow using the wrapper element of a component                                                                                    | ✅  |     |     |
 
 ### Computed Properties
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [computed-property-getters](./docs/rules/computed-property-getters.md) | enforce the consistent use of getters in computed properties |  |  |  |
-| [no-arrow-function-computed-properties](./docs/rules/no-arrow-function-computed-properties.md) | disallow arrow functions in computed properties | ✅ |  |  |
-| [no-assignment-of-untracked-properties-used-in-tracking-contexts](./docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md) | disallow assignment of untracked properties that are used as computed property dependencies | ✅ | 🔧 |  |
-| [no-computed-properties-in-native-classes](./docs/rules/no-computed-properties-in-native-classes.md) | disallow using computed properties in native classes | ✅ |  |  |
-| [no-deeply-nested-dependent-keys-with-each](./docs/rules/no-deeply-nested-dependent-keys-with-each.md) | disallow usage of deeply-nested computed property dependent keys with `@each` | ✅ |  |  |
-| [no-duplicate-dependent-keys](./docs/rules/no-duplicate-dependent-keys.md) | disallow repeating computed property dependent keys | ✅ | 🔧 |  |
-| [no-incorrect-computed-macros](./docs/rules/no-incorrect-computed-macros.md) | disallow incorrect usage of computed property macros | ✅ | 🔧 |  |
-| [no-invalid-dependent-keys](./docs/rules/no-invalid-dependent-keys.md) | disallow invalid dependent keys in computed properties | ✅ | 🔧 |  |
-| [no-side-effects](./docs/rules/no-side-effects.md) | disallow unexpected side effects in computed properties | ✅ |  |  |
-| [no-volatile-computed-properties](./docs/rules/no-volatile-computed-properties.md) | disallow volatile computed properties | ✅ |  |  |
-| [require-computed-macros](./docs/rules/require-computed-macros.md) | require using computed property macros when possible | ✅ | 🔧 |  |
-| [require-computed-property-dependencies](./docs/rules/require-computed-property-dependencies.md) | require dependencies to be declared statically in computed properties | ✅ | 🔧 |  |
-| [require-return-from-computed](./docs/rules/require-return-from-computed.md) | disallow missing return statements in computed properties | ✅ |  |  |
-| [use-brace-expansion](./docs/rules/use-brace-expansion.md) | enforce usage of brace expansion in computed property dependent keys | ✅ |  |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                 | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------ | :-- | :-- | :-- |
+| [computed-property-getters](docs/rules/computed-property-getters.md)                                                                                                                                                                                                                                                                                                   | enforce the consistent use of getters in computed properties                                |     |     |     |
+| [no-arrow-function-computed-properties](docs/rules/no-arrow-function-computed-properties.md)                                                                                                                                                                                                                                                                           | disallow arrow functions in computed properties                                             | ✅  |     |     |
+| [no-assignment-of-untracked-properties-used-in-tracking-contexts](docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md)                                                                                                                                                                                                                       | disallow assignment of untracked properties that are used as computed property dependencies | ✅  | 🔧  |     |
+| [no-computed-properties-in-native-classes](docs/rules/no-computed-properties-in-native-classes.md)                                                                                                                                                                                                                                                                     | disallow using computed properties in native classes                                        | ✅  |     |     |
+| [no-deeply-nested-dependent-keys-with-each](docs/rules/no-deeply-nested-dependent-keys-with-each.md)                                                                                                                                                                                                                                                                   | disallow usage of deeply-nested computed property dependent keys with `@each`               | ✅  |     |     |
+| [no-duplicate-dependent-keys](docs/rules/no-duplicate-dependent-keys.md)                                                                                                                                                                                                                                                                                               | disallow repeating computed property dependent keys                                         | ✅  | 🔧  |     |
+| [no-incorrect-computed-macros](docs/rules/no-incorrect-computed-macros.md)                                                                                                                                                                                                                                                                                             | disallow incorrect usage of computed property macros                                        | ✅  | 🔧  |     |
+| [no-invalid-dependent-keys](docs/rules/no-invalid-dependent-keys.md)                                                                                                                                                                                                                                                                                                   | disallow invalid dependent keys in computed properties                                      | ✅  | 🔧  |     |
+| [no-side-effects](docs/rules/no-side-effects.md)                                                                                                                                                                                                                                                                                                                       | disallow unexpected side effects in computed properties                                     | ✅  |     |     |
+| [no-volatile-computed-properties](docs/rules/no-volatile-computed-properties.md)                                                                                                                                                                                                                                                                                       | disallow volatile computed properties                                                       | ✅  |     |     |
+| [require-computed-macros](docs/rules/require-computed-macros.md)                                                                                                                                                                                                                                                                                                       | require using computed property macros when possible                                        | ✅  | 🔧  |     |
+| [require-computed-property-dependencies](docs/rules/require-computed-property-dependencies.md)                                                                                                                                                                                                                                                                         | require dependencies to be declared statically in computed properties                       | ✅  | 🔧  |     |
+| [require-return-from-computed](docs/rules/require-return-from-computed.md)                                                                                                                                                                                                                                                                                             | disallow missing return statements in computed properties                                   | ✅  |     |     |
+| [use-brace-expansion](docs/rules/use-brace-expansion.md)                                                                                                                                                                                                                                                                                                               | enforce usage of brace expansion in computed property dependent keys                        | ✅  |     |     |
 
 ### Controllers
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [alias-model-in-controller](./docs/rules/alias-model-in-controller.md) | enforce aliasing model in controllers |  |  |  |
-| [avoid-using-needs-in-controllers](./docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers | ✅ |  |  |
-| [no-controllers](./docs/rules/no-controllers.md) | disallow non-essential controllers |  |  |  |
+| Name                                                                               | Description                           | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------- | :------------------------------------ | :-- | :-- | :-- |
+| [alias-model-in-controller](docs/rules/alias-model-in-controller.md)               | enforce aliasing model in controllers |     |     |     |
+| [avoid-using-needs-in-controllers](docs/rules/avoid-using-needs-in-controllers.md) | disallow using `needs` in controllers | ✅  |     |     |
+| [no-controllers](docs/rules/no-controllers.md)                                     | disallow non-essential controllers    |     |     |     |
 
 ### Deprecations
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [closure-actions](./docs/rules/closure-actions.md) | enforce usage of closure actions | ✅ |  |  |
-| [new-module-imports](./docs/rules/new-module-imports.md) | enforce using "New Module Imports" from Ember RFC #176 | ✅ |  |  |
-| [no-array-prototype-extensions](./docs/rules/no-array-prototype-extensions.md) | disallow usage of Ember's `Array` prototype extensions |  | 🔧 |  |
-| [no-function-prototype-extensions](./docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions | ✅ |  |  |
-| [no-mixins](./docs/rules/no-mixins.md) | disallow the usage of mixins | ✅ |  |  |
-| [no-new-mixins](./docs/rules/no-new-mixins.md) | disallow the creation of new mixins | ✅ |  |  |
-| [no-observers](./docs/rules/no-observers.md) | disallow usage of observers | ✅ |  |  |
-| [no-old-shims](./docs/rules/no-old-shims.md) | disallow usage of old shims for modules | ✅ | 🔧 |  |
-| [no-string-prototype-extensions](./docs/rules/no-string-prototype-extensions.md) | disallow usage of `String` prototype extensions | ✅ |  |  |
+| Name                                                                               | Description                                               | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------- | :-------------------------------------------------------- | :-- | :-- | :-- |
+| [closure-actions](docs/rules/closure-actions.md)                                   | enforce usage of closure actions                          | ✅  |     |     |
+| [new-module-imports](docs/rules/new-module-imports.md)                             | enforce using "New Module Imports" from Ember RFC #176    | ✅  |     |     |
+| [no-array-prototype-extensions](docs/rules/no-array-prototype-extensions.md)       | disallow usage of Ember's `Array` prototype extensions    |     | 🔧  |     |
+| [no-function-prototype-extensions](docs/rules/no-function-prototype-extensions.md) | disallow usage of Ember's `function` prototype extensions | ✅  |     |     |
+| [no-mixins](docs/rules/no-mixins.md)                                               | disallow the usage of mixins                              | ✅  |     |     |
+| [no-new-mixins](docs/rules/no-new-mixins.md)                                       | disallow the creation of new mixins                       | ✅  |     |     |
+| [no-observers](docs/rules/no-observers.md)                                         | disallow usage of observers                               | ✅  |     |     |
+| [no-old-shims](docs/rules/no-old-shims.md)                                         | disallow usage of old shims for modules                   | ✅  | 🔧  |     |
+| [no-string-prototype-extensions](docs/rules/no-string-prototype-extensions.md)     | disallow usage of `String` prototype extensions           | ✅  |     |     |
 
 ### Ember Data
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [no-empty-attrs](./docs/rules/no-empty-attrs.md) | disallow usage of empty attributes in Ember Data models |  |  |  |
-| [use-ember-data-rfc-395-imports](./docs/rules/use-ember-data-rfc-395-imports.md) | enforce usage of `@ember-data/` package imports instead `ember-data` | ✅ | 🔧 |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                          | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------- | :-- | :-- | :-- |
+| [no-empty-attrs](docs/rules/no-empty-attrs.md)                                                                                                                   | disallow usage of empty attributes in Ember Data models              |     |     |     |
+| [use-ember-data-rfc-395-imports](docs/rules/use-ember-data-rfc-395-imports.md)                                                                                   | enforce usage of `@ember-data/` package imports instead `ember-data` | ✅  | 🔧  |     |
 
 ### Ember Object
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [avoid-leaking-state-in-ember-objects](./docs/rules/avoid-leaking-state-in-ember-objects.md) | disallow state leakage | ✅ |  |  |
-| [no-get-with-default](./docs/rules/no-get-with-default.md) | disallow usage of the Ember's `getWithDefault` function | ✅ | 🔧 |  |
-| [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions | ✅ | 🔧 |  |
-| [no-proxies](./docs/rules/no-proxies.md) | disallow using array or object proxies |  |  |  |
-| [no-try-invoke](./docs/rules/no-try-invoke.md) | disallow usage of the Ember's `tryInvoke` util | ✅ |  |  |
-| [require-super-in-lifecycle-hooks](./docs/rules/require-super-in-lifecycle-hooks.md) | require super to be called in lifecycle hooks | ✅ | 🔧 |  |
-| [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |  | 🔧 |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                    | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [avoid-leaking-state-in-ember-objects](docs/rules/avoid-leaking-state-in-ember-objects.md)                                                                                                           | disallow state leakage                                                         | ✅  |     |     |
+| [no-get](docs/rules/no-get.md)                                                                                                                                                                       | require using ES5 getters instead of Ember's `get` / `getProperties` functions | ✅  | 🔧  |     |
+| [no-get-with-default](docs/rules/no-get-with-default.md)                                                                                                                                             | disallow usage of the Ember's `getWithDefault` function                        | ✅  | 🔧  |     |
+| [no-proxies](docs/rules/no-proxies.md)                                                                                                                                                               | disallow using array or object proxies                                         |     |     |     |
+| [no-try-invoke](docs/rules/no-try-invoke.md)                                                                                                                                                         | disallow usage of the Ember's `tryInvoke` util                                 | ✅  |     |     |
+| [require-super-in-lifecycle-hooks](docs/rules/require-super-in-lifecycle-hooks.md)                                                                                                                   | require super to be called in lifecycle hooks                                  | ✅  | 🔧  |     |
+| [use-ember-get-and-set](docs/rules/use-ember-get-and-set.md)                                                                                                                                         | enforce usage of `Ember.get` and `Ember.set`                                   |     | 🔧  |     |
 
 ### Ember Octane
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [classic-decorator-hooks](./docs/rules/classic-decorator-hooks.md) | enforce using correct hooks for both classic and non-classic classes | ✅ |  |  |
-| [classic-decorator-no-classic-methods](./docs/rules/classic-decorator-no-classic-methods.md) | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` | ✅ |  |  |
-| [no-actions-hash](./docs/rules/no-actions-hash.md) | disallow the actions hash in components, controllers, and routes | ✅ |  |  |
-| [no-classic-classes](./docs/rules/no-classic-classes.md) | disallow "classic" classes in favor of native JS classes | ✅ |  |  |
-| [no-ember-super-in-es-classes](./docs/rules/no-ember-super-in-es-classes.md) | disallow use of `this._super` in ES class methods | ✅ | 🔧 |  |
-| [no-empty-glimmer-component-classes](./docs/rules/no-empty-glimmer-component-classes.md) | disallow empty backing classes for Glimmer components | ✅ |  |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                                    | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [classic-decorator-hooks](docs/rules/classic-decorator-hooks.md)                                                                                                                                     | enforce using correct hooks for both classic and non-classic classes                                           | ✅  |     |     |
+| [classic-decorator-no-classic-methods](docs/rules/classic-decorator-no-classic-methods.md)                                                                                                           | disallow usage of classic APIs such as `get`/`set` in classes that aren't explicitly decorated with `@classic` | ✅  |     |     |
+| [no-actions-hash](docs/rules/no-actions-hash.md)                                                                                                                                                     | disallow the actions hash in components, controllers, and routes                                               | ✅  |     |     |
+| [no-classic-classes](docs/rules/no-classic-classes.md)                                                                                                                                               | disallow "classic" classes in favor of native JS classes                                                       | ✅  |     |     |
+| [no-ember-super-in-es-classes](docs/rules/no-ember-super-in-es-classes.md)                                                                                                                           | disallow use of `this._super` in ES class methods                                                              | ✅  | 🔧  |     |
+| [no-empty-glimmer-component-classes](docs/rules/no-empty-glimmer-component-classes.md)                                                                                                               | disallow empty backing classes for Glimmer components                                                          | ✅  |     |     |
 
 ### jQuery
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [jquery-ember-run](./docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop | ✅ |  |  |
-| [no-global-jquery](./docs/rules/no-global-jquery.md) | disallow usage of global jQuery object | ✅ |  |  |
-| [no-jquery](./docs/rules/no-jquery.md) | disallow any usage of jQuery | ✅ |  |  |
+| Name                                               | Description                                        | ✅  | 🔧  | 💡  |
+| :------------------------------------------------- | :------------------------------------------------- | :-- | :-- | :-- |
+| [jquery-ember-run](docs/rules/jquery-ember-run.md) | disallow usage of jQuery without an Ember run loop | ✅  |     |     |
+| [no-global-jquery](docs/rules/no-global-jquery.md) | disallow usage of global jQuery object             | ✅  |     |     |
+| [no-jquery](docs/rules/no-jquery.md)               | disallow any usage of jQuery                       | ✅  |     |     |
 
 ### Miscellaneous
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [named-functions-in-promises](./docs/rules/named-functions-in-promises.md) | enforce usage of named functions in promises |  |  |  |
-| [no-html-safe](./docs/rules/no-html-safe.md) | disallow the use of `htmlSafe` |  |  |  |
-| [no-incorrect-calls-with-inline-anonymous-functions](./docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md) | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce` | ✅ |  |  |
-| [no-invalid-debug-function-arguments](./docs/rules/no-invalid-debug-function-arguments.md) | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. | ✅ |  |  |
-| [no-restricted-property-modifications](./docs/rules/no-restricted-property-modifications.md) | disallow modifying the specified properties |  | 🔧 |  |
-| [require-fetch-import](./docs/rules/require-fetch-import.md) | enforce explicit import for `fetch()` |  |  |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                                                   | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [named-functions-in-promises](docs/rules/named-functions-in-promises.md)                                                                                                                                                                                                                 | enforce usage of named functions in promises                                                                                  |     |     |     |
+| [no-html-safe](docs/rules/no-html-safe.md)                                                                                                                                                                                                                                               | disallow the use of `htmlSafe`                                                                                                |     |     |     |
+| [no-incorrect-calls-with-inline-anonymous-functions](docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md)                                                                                                                                                                   | disallow inline anonymous functions as arguments to `debounce`, `once`, and `scheduleOnce`                                    | ✅  |     |     |
+| [no-invalid-debug-function-arguments](docs/rules/no-invalid-debug-function-arguments.md)                                                                                                                                                                                                 | disallow usages of Ember's `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order. | ✅  |     |     |
+| [no-restricted-property-modifications](docs/rules/no-restricted-property-modifications.md)                                                                                                                                                                                               | disallow modifying the specified properties                                                                                   |     | 🔧  |     |
+| [require-fetch-import](docs/rules/require-fetch-import.md)                                                                                                                                                                                                                               | enforce explicit import for `fetch()`                                                                                         |     |     |     |
 
 ### Routes
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [no-capital-letters-in-routes](./docs/rules/no-capital-letters-in-routes.md) | disallow routes with uppercased letters in router.js | ✅ |  |  |
-| [no-controller-access-in-routes](./docs/rules/no-controller-access-in-routes.md) | disallow routes from accessing the controller outside of setupController/resetController | ✅ |  |  |
-| [no-private-routing-service](./docs/rules/no-private-routing-service.md) | disallow injecting the private routing service | ✅ |  |  |
-| [no-shadow-route-definition](./docs/rules/no-shadow-route-definition.md) | enforce no route path definition shadowing | ✅ |  |  |
-| [no-unnecessary-index-route](./docs/rules/no-unnecessary-index-route.md) | disallow unnecessary `index` route definition |  |  |  |
-| [no-unnecessary-route-path-option](./docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option | ✅ | 🔧 |  |
-| [route-path-style](./docs/rules/route-path-style.md) | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths |  |  | 💡 |
-| [routes-segments-snake-case](./docs/rules/routes-segments-snake-case.md) | enforce usage of snake_cased dynamic segments in routes | ✅ |  |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                              | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [no-capital-letters-in-routes](docs/rules/no-capital-letters-in-routes.md)                                                                                                   | disallow routes with uppercased letters in router.js                                     | ✅  |     |     |
+| [no-controller-access-in-routes](docs/rules/no-controller-access-in-routes.md)                                                                                               | disallow routes from accessing the controller outside of setupController/resetController | ✅  |     |     |
+| [no-private-routing-service](docs/rules/no-private-routing-service.md)                                                                                                       | disallow injecting the private routing service                                           | ✅  |     |     |
+| [no-shadow-route-definition](docs/rules/no-shadow-route-definition.md)                                                                                                       | enforce no route path definition shadowing                                               | ✅  |     |     |
+| [no-unnecessary-index-route](docs/rules/no-unnecessary-index-route.md)                                                                                                       | disallow unnecessary `index` route definition                                            |     |     |     |
+| [no-unnecessary-route-path-option](docs/rules/no-unnecessary-route-path-option.md)                                                                                           | disallow unnecessary usage of the route `path` option                                    | ✅  | 🔧  |     |
+| [route-path-style](docs/rules/route-path-style.md)                                                                                                                           | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths          |     |     | 💡  |
+| [routes-segments-snake-case](docs/rules/routes-segments-snake-case.md)                                                                                                       | enforce usage of snake_cased dynamic segments in routes                                  | ✅  |     |     |
 
 ### Services
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [no-implicit-service-injection-argument](./docs/rules/no-implicit-service-injection-argument.md) | disallow omitting the injected service name argument |  | 🔧 |  |
-| [no-restricted-service-injections](./docs/rules/no-restricted-service-injections.md) | disallow injecting certain services under certain paths |  |  |  |
-| [no-unnecessary-service-injection-argument](./docs/rules/no-unnecessary-service-injection-argument.md) | disallow unnecessary argument when injecting services |  | 🔧 |  |
-| [no-unused-services](./docs/rules/no-unused-services.md) | disallow unused service injections (see rule doc for limitations) |  |  | 💡 |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                       | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------- | :-- | :-- | :-- |
+| [no-implicit-service-injection-argument](docs/rules/no-implicit-service-injection-argument.md)                                                                                                                                     | disallow omitting the injected service name argument              |     | 🔧  |     |
+| [no-restricted-service-injections](docs/rules/no-restricted-service-injections.md)                                                                                                                                                 | disallow injecting certain services under certain paths           |     |     |     |
+| [no-unnecessary-service-injection-argument](docs/rules/no-unnecessary-service-injection-argument.md)                                                                                                                               | disallow unnecessary argument when injecting services             |     | 🔧  |     |
+| [no-unused-services](docs/rules/no-unused-services.md)                                                                                                                                                                             | disallow unused service injections (see rule doc for limitations) |     |     | 💡  |
 
 ### Stylistic Issues
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [order-in-components](./docs/rules/order-in-components.md) | enforce proper order of properties in components |  | 🔧 |  |
-| [order-in-controllers](./docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |  | 🔧 |  |
-| [order-in-models](./docs/rules/order-in-models.md) | enforce proper order of properties in models |  | 🔧 |  |
-| [order-in-routes](./docs/rules/order-in-routes.md) | enforce proper order of properties in routes |  | 🔧 |  |
+| Name                                                       | Description                                       | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------- | :------------------------------------------------ | :-- | :-- | :-- |
+| [order-in-components](docs/rules/order-in-components.md)   | enforce proper order of properties in components  |     | 🔧  |     |
+| [order-in-controllers](docs/rules/order-in-controllers.md) | enforce proper order of properties in controllers |     | 🔧  |     |
+| [order-in-models](docs/rules/order-in-models.md)           | enforce proper order of properties in models      |     | 🔧  |     |
+| [order-in-routes](docs/rules/order-in-routes.md)           | enforce proper order of properties in routes      |     | 🔧  |     |
 
 ### Testing
 
-| Name    | Description | ✅ | 🔧 | 💡 |
-|:--------|:------------|:---------------|:-----------|:---------------|
-| [no-current-route-name](./docs/rules/no-current-route-name.md) | disallow usage of the `currentRouteName()` test helper |  |  |  |
-| [no-ember-testing-in-module-scope](./docs/rules/no-ember-testing-in-module-scope.md) | disallow use of `Ember.testing` in module scope | ✅ |  |  |
-| [no-invalid-test-waiters](./docs/rules/no-invalid-test-waiters.md) | disallow incorrect usage of test waiter APIs | ✅ |  |  |
-| [no-legacy-test-waiters](./docs/rules/no-legacy-test-waiters.md) | disallow the use of the legacy test waiter APIs | ✅ |  |  |
-| [no-noop-setup-on-error-in-before](./docs/rules/no-noop-setup-on-error-in-before.md) | disallows using no-op setupOnerror in `before` or `beforeEach` | ✅ | 🔧 |  |
-| [no-pause-test](./docs/rules/no-pause-test.md) | disallow usage of the `pauseTest` helper in tests | ✅ |  |  |
-| [no-replace-test-comments](./docs/rules/no-replace-test-comments.md) | disallow 'Replace this with your real tests' comments in test files |  |  |  |
-| [no-restricted-resolver-tests](./docs/rules/no-restricted-resolver-tests.md) | disallow the use of patterns that use the restricted resolver in tests | ✅ |  |  |
-| [no-settled-after-test-helper](./docs/rules/no-settled-after-test-helper.md) | disallow usage of `await settled()` right after test helper that calls it internally | ✅ | 🔧 |  |
-| [no-test-and-then](./docs/rules/no-test-and-then.md) | disallow usage of the `andThen` test wait helper | ✅ |  |  |
-| [no-test-import-export](./docs/rules/no-test-import-export.md) | disallow importing of "-test.js" in a test file and exporting from a test file | ✅ |  |  |
-| [no-test-module-for](./docs/rules/no-test-module-for.md) | disallow usage of `moduleFor`, `moduleForComponent`, etc | ✅ |  |  |
-| [no-test-support-import](./docs/rules/no-test-support-import.md) | disallow importing of "test-support" files in production code. | ✅ |  |  |
-| [no-test-this-render](./docs/rules/no-test-this-render.md) | disallow usage of the `this.render` in tests, recommending to use @ember/test-helpers' `render` instead. | ✅ |  |  |
-| [prefer-ember-test-helpers](./docs/rules/prefer-ember-test-helpers.md) | enforce usage of `@ember/test-helpers` methods over native window methods | ✅ |  |  |
-| [require-valid-css-selector-in-test-helpers](./docs/rules/require-valid-css-selector-in-test-helpers.md) | disallow using invalid CSS selectors in test helpers | ✅ | 🔧 |  |
+| Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description                                                                                              | ✅  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [no-current-route-name](docs/rules/no-current-route-name.md)                                                                                                                                                                             | disallow usage of the `currentRouteName()` test helper                                                   |     |     |     |
+| [no-ember-testing-in-module-scope](docs/rules/no-ember-testing-in-module-scope.md)                                                                                                                                                       | disallow use of `Ember.testing` in module scope                                                          | ✅  |     |     |
+| [no-invalid-test-waiters](docs/rules/no-invalid-test-waiters.md)                                                                                                                                                                         | disallow incorrect usage of test waiter APIs                                                             | ✅  |     |     |
+| [no-legacy-test-waiters](docs/rules/no-legacy-test-waiters.md)                                                                                                                                                                           | disallow the use of the legacy test waiter APIs                                                          | ✅  |     |     |
+| [no-noop-setup-on-error-in-before](docs/rules/no-noop-setup-on-error-in-before.md)                                                                                                                                                       | disallows using no-op setupOnerror in `before` or `beforeEach`                                           | ✅  | 🔧  |     |
+| [no-pause-test](docs/rules/no-pause-test.md)                                                                                                                                                                                             | disallow usage of the `pauseTest` helper in tests                                                        | ✅  |     |     |
+| [no-replace-test-comments](docs/rules/no-replace-test-comments.md)                                                                                                                                                                       | disallow 'Replace this with your real tests' comments in test files                                      |     |     |     |
+| [no-restricted-resolver-tests](docs/rules/no-restricted-resolver-tests.md)                                                                                                                                                               | disallow the use of patterns that use the restricted resolver in tests                                   | ✅  |     |     |
+| [no-settled-after-test-helper](docs/rules/no-settled-after-test-helper.md)                                                                                                                                                               | disallow usage of `await settled()` right after test helper that calls it internally                     | ✅  | 🔧  |     |
+| [no-test-and-then](docs/rules/no-test-and-then.md)                                                                                                                                                                                       | disallow usage of the `andThen` test wait helper                                                         | ✅  |     |     |
+| [no-test-import-export](docs/rules/no-test-import-export.md)                                                                                                                                                                             | disallow importing of "-test.js" in a test file and exporting from a test file                           | ✅  |     |     |
+| [no-test-module-for](docs/rules/no-test-module-for.md)                                                                                                                                                                                   | disallow usage of `moduleFor`, `moduleForComponent`, etc                                                 | ✅  |     |     |
+| [no-test-support-import](docs/rules/no-test-support-import.md)                                                                                                                                                                           | disallow importing of "test-support" files in production code.                                           | ✅  |     |     |
+| [no-test-this-render](docs/rules/no-test-this-render.md)                                                                                                                                                                                 | disallow usage of the `this.render` in tests, recommending to use @ember/test-helpers' `render` instead. | ✅  |     |     |
+| [prefer-ember-test-helpers](docs/rules/prefer-ember-test-helpers.md)                                                                                                                                                                     | enforce usage of `@ember/test-helpers` methods over native window methods                                | ✅  |     |     |
+| [require-valid-css-selector-in-test-helpers](docs/rules/require-valid-css-selector-in-test-helpers.md)                                                                                                                                   | disallow using invalid CSS selectors in test helpers                                                     | ✅  | 🔧  |     |
 
-<!--RULES_TABLE_END-->
-
-For the simplified list of rules, [go here](./lib/index.js).
+<!-- end auto-generated rules list -->
 
 ## 🍻 Contribution Guide
 

--- a/docs/rules/alias-model-in-controller.md
+++ b/docs/rules/alias-model-in-controller.md
@@ -1,4 +1,6 @@
-# alias-model-in-controller
+# ember/alias-model-in-controller
+
+<!-- end auto-generated rule header -->
 
 It makes code more readable if the model has the same name as a subject.
 

--- a/docs/rules/avoid-leaking-state-in-ember-objects.md
+++ b/docs/rules/avoid-leaking-state-in-ember-objects.md
@@ -1,6 +1,8 @@
-# avoid-leaking-state-in-ember-objects
+# ember/avoid-leaking-state-in-ember-objects
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Don't use arrays and objects as default properties in classic classes or mixins. In native classes, it is safe to assign objects to fields.
 

--- a/docs/rules/avoid-using-needs-in-controllers.md
+++ b/docs/rules/avoid-using-needs-in-controllers.md
@@ -1,6 +1,8 @@
-# avoid-using-needs-in-controllers
+# ember/avoid-using-needs-in-controllers
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Avoid using `needs` to load other controllers. Inject the required controller instead. `needs` was deprecated in ember 1.x and removed in 2.0.
 

--- a/docs/rules/classic-decorator-hooks.md
+++ b/docs/rules/classic-decorator-hooks.md
@@ -1,6 +1,8 @@
-# classic-decorator-hooks
+# ember/classic-decorator-hooks
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Use the correct lifecycle hooks in classic and non-classic classes. Classic
 classes should use `init`, and non-classic classes should use `constructor`.

--- a/docs/rules/classic-decorator-no-classic-methods.md
+++ b/docs/rules/classic-decorator-no-classic-methods.md
@@ -1,6 +1,8 @@
-# classic-decorator-no-classic-methods
+# ember/classic-decorator-no-classic-methods
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallows the use of the following classic API methods within a class:
 

--- a/docs/rules/closure-actions.md
+++ b/docs/rules/closure-actions.md
@@ -1,6 +1,8 @@
-# closure-actions
+# ember/closure-actions
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Always use closure actions (according to DDAU convention). Exception: only when you need bubbling.
 

--- a/docs/rules/computed-property-getters.md
+++ b/docs/rules/computed-property-getters.md
@@ -1,4 +1,6 @@
-# computed-property-getters
+# ember/computed-property-getters
+
+<!-- end auto-generated rule header -->
 
 Enforce the consistent use of getters in computed properties.
 

--- a/docs/rules/jquery-ember-run.md
+++ b/docs/rules/jquery-ember-run.md
@@ -1,6 +1,8 @@
-# jquery-ember-run
+# ember/jquery-ember-run
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Don’t use jQuery without the Ember Run Loop.
 

--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -1,4 +1,6 @@
-# named-functions-in-promises
+# ember/named-functions-in-promises
+
+<!-- end auto-generated rule header -->
 
 Use named functions defined on objects to handle promises.
 

--- a/docs/rules/new-module-imports.md
+++ b/docs/rules/new-module-imports.md
@@ -1,6 +1,8 @@
-# new-module-imports
+# ember/new-module-imports
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Use "New Module Imports" from Ember RFC #176.
 

--- a/docs/rules/no-actions-hash.md
+++ b/docs/rules/no-actions-hash.md
@@ -1,6 +1,8 @@
-# no-actions-hash
+# ember/no-actions-hash
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallows the actions hash in components and controllers.
 

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -1,6 +1,8 @@
-# no-array-prototype-extensions
+# ember/no-array-prototype-extensions
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 

--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -1,6 +1,8 @@
-# no-arrow-function-computed-properties
+# ember/no-arrow-function-computed-properties
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Arrow functions should not be used in computed properties because they are unable to access other properties (using `this.property`) of the same object. Accidental usage can thus lead to bugs.
 

--- a/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
+++ b/docs/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.md
@@ -1,8 +1,10 @@
-# no-assignment-of-untracked-properties-used-in-tracking-contexts
+# ember/no-assignment-of-untracked-properties-used-in-tracking-contexts
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Ember 3.13 added an assertion that fires when using assignment `this.x = 123` on an untracked property that is used in a tracking context such as a computed property.
 

--- a/docs/rules/no-attrs-in-components.md
+++ b/docs/rules/no-attrs-in-components.md
@@ -1,6 +1,8 @@
-# no-attrs-in-components
+# ember/no-attrs-in-components
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Do not use `this.attrs`.
 

--- a/docs/rules/no-attrs-snapshot.md
+++ b/docs/rules/no-attrs-snapshot.md
@@ -1,6 +1,8 @@
-# no-attrs-snapshot
+# ember/no-attrs-snapshot
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallow use of attrs snapshot in `didReceiveAttrs` and `didUpdateAttrs`.
 

--- a/docs/rules/no-capital-letters-in-routes.md
+++ b/docs/rules/no-capital-letters-in-routes.md
@@ -1,6 +1,8 @@
-# no-capital-letters-in-routes
+# ember/no-capital-letters-in-routes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Raise an error when there is a route with upper-cased letters in router.js.
 

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -1,6 +1,8 @@
-# no-classic-classes
+# ember/no-classic-classes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallow "classic" classes in favor of native JS classes.
 

--- a/docs/rules/no-classic-components.md
+++ b/docs/rules/no-classic-components.md
@@ -1,6 +1,8 @@
-# no-classic-components
+# ember/no-classic-components
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This rule aims to enforce Glimmer components instead of classic ones. We should migrate to Glimmer components because
 they have few advantages:

--- a/docs/rules/no-component-lifecycle-hooks.md
+++ b/docs/rules/no-component-lifecycle-hooks.md
@@ -1,6 +1,8 @@
-# no-component-lifecycle-hooks
+# ember/no-component-lifecycle-hooks
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallow usage of "classic" ember component lifecycle hooks.
 

--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -1,6 +1,8 @@
-# no-computed-properties-in-native-classes
+# ember/no-computed-properties-in-native-classes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Since the beginning of Ember's existence, Computed Properties (CPs) have been used to accomplish reactivity in the framework. With Ember Octane, new features were introduced including Glimmer components, native JavaScript classes and Tracked Properties. With Ember Octane's new programming model, CPs are no longer needed. If using native JavaScript classes, Tracked Properties should be used instead as they give us the same benefit of CPs but with less boilerplate and more flexibility.
 

--- a/docs/rules/no-controller-access-in-routes.md
+++ b/docs/rules/no-controller-access-in-routes.md
@@ -1,6 +1,8 @@
-# no-controller-access-in-routes
+# ember/no-controller-access-in-routes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Accessing the controller in a route outside of `setupController`/`resetController` hooks (where it is passed as an argument) is discouraged.
 

--- a/docs/rules/no-controllers.md
+++ b/docs/rules/no-controllers.md
@@ -1,4 +1,6 @@
-# no-controllers
+# ember/no-controllers
+
+<!-- end auto-generated rule header -->
 
 Some people may prefer to avoid the use of controllers in their applications, typically in favor of components which can be more portable and easier to test.
 

--- a/docs/rules/no-current-route-name.md
+++ b/docs/rules/no-current-route-name.md
@@ -1,4 +1,6 @@
-# no-current-route-name
+# ember/no-current-route-name
+
+<!-- end auto-generated rule header -->
 
 The route name is something which is not visible to the user, so it can be
 considered an implementation detail. The URL however is visible to the user, so

--- a/docs/rules/no-deeply-nested-dependent-keys-with-each.md
+++ b/docs/rules/no-deeply-nested-dependent-keys-with-each.md
@@ -1,6 +1,8 @@
-# no-deeply-nested-dependent-keys-with-each
+# ember/no-deeply-nested-dependent-keys-with-each
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallows usage of deeply-nested computed property dependent keys with `@each`.
 

--- a/docs/rules/no-duplicate-dependent-keys.md
+++ b/docs/rules/no-duplicate-dependent-keys.md
@@ -1,8 +1,10 @@
-# no-duplicate-dependent-keys
+# ember/no-duplicate-dependent-keys
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Disallow repeating dependent keys.
 

--- a/docs/rules/no-ember-super-in-es-classes.md
+++ b/docs/rules/no-ember-super-in-es-classes.md
@@ -1,8 +1,10 @@
-# no-ember-super-in-es-classes
+# ember/no-ember-super-in-es-classes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 `this._super` is not allowed in ES class methods.
 

--- a/docs/rules/no-ember-testing-in-module-scope.md
+++ b/docs/rules/no-ember-testing-in-module-scope.md
@@ -1,6 +1,8 @@
-# no-ember-testing-in-module-scope
+# ember/no-ember-testing-in-module-scope
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 `Ember.testing` is not allowed in modules scope.
 

--- a/docs/rules/no-empty-attrs.md
+++ b/docs/rules/no-empty-attrs.md
@@ -1,4 +1,6 @@
-# no-empty-attrs
+# ember/no-empty-attrs
+
+<!-- end auto-generated rule header -->
 
 Be explicit with Ember data attribute types.
 

--- a/docs/rules/no-empty-glimmer-component-classes.md
+++ b/docs/rules/no-empty-glimmer-component-classes.md
@@ -1,6 +1,8 @@
-# no-empty-glimmer-component-classes
+# ember/no-empty-glimmer-component-classes
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This rule will catch and prevent the use of empty backing classes for Glimmer components.
 

--- a/docs/rules/no-function-prototype-extensions.md
+++ b/docs/rules/no-function-prototype-extensions.md
@@ -1,6 +1,8 @@
-# no-function-prototype-extensions
+# ember/no-function-prototype-extensions
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 

--- a/docs/rules/no-get-with-default.md
+++ b/docs/rules/no-get-with-default.md
@@ -1,8 +1,10 @@
-# no-get-with-default
+# ember/no-get-with-default
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 This rule attempts to catch and prevent the use of `getWithDefault`.
 

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -1,8 +1,10 @@
-# no-get
+# ember/no-get
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Starting in Ember 3.1, native ES5 getters are available, which eliminates much of the need to use `get` / `getProperties` on Ember objects.
 

--- a/docs/rules/no-global-jquery.md
+++ b/docs/rules/no-global-jquery.md
@@ -1,6 +1,8 @@
-# no-global-jquery
+# ember/no-global-jquery
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Do not use global `$` or `jQuery`.
 

--- a/docs/rules/no-html-safe.md
+++ b/docs/rules/no-html-safe.md
@@ -1,4 +1,6 @@
-# no-html-safe
+# ember/no-html-safe
+
+<!-- end auto-generated rule header -->
 
 `htmlSafe` marks a string as safe for unescaped output with Ember templates so you can render it as HTML. `htmlSafe` does **not** perform input sanitization. While useful this can inadvertently open you up to Cross-site Scripting (XSS) vulnerabilities, especially if the string was generated from user input or some other untrusted source. **You should only ever use `htmlSafe` with trusted or sanitized input**.
 

--- a/docs/rules/no-implicit-service-injection-argument.md
+++ b/docs/rules/no-implicit-service-injection-argument.md
@@ -1,6 +1,8 @@
-# no-implicit-service-injection-argument
+# ember/no-implicit-service-injection-argument
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 This rule disallows omitting the service name argument when injecting a service. Instead, the filename of the service should be used (i.e. `service-name` when the service lives at `app/services/service-name.js`).
 

--- a/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
+++ b/docs/rules/no-incorrect-calls-with-inline-anonymous-functions.md
@@ -1,6 +1,8 @@
-# no-incorrect-calls-with-inline-anonymous-functions
+# ember/no-incorrect-calls-with-inline-anonymous-functions
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 The following functions keep track of the function references they have been passed:
 

--- a/docs/rules/no-incorrect-computed-macros.md
+++ b/docs/rules/no-incorrect-computed-macros.md
@@ -1,8 +1,10 @@
-# no-incorrect-computed-macros
+# ember/no-incorrect-computed-macros
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 This rule attempts to find incorrect usages of computed property macros, such as calling them with the incorrect number of arguments.
 

--- a/docs/rules/no-invalid-debug-function-arguments.md
+++ b/docs/rules/no-invalid-debug-function-arguments.md
@@ -1,6 +1,8 @@
-# no-invalid-debug-function-arguments
+# ember/no-invalid-debug-function-arguments
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Catch usages of Ember&#39;s `assert()` / `warn()` / `deprecate()` functions that have the arguments passed in the wrong order.
 

--- a/docs/rules/no-invalid-dependent-keys.md
+++ b/docs/rules/no-invalid-dependent-keys.md
@@ -1,8 +1,10 @@
-# no-invalid-dependent-keys
+# ember/no-invalid-dependent-keys
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Dependent keys used for computed properties have to be valid.
 

--- a/docs/rules/no-invalid-test-waiters.md
+++ b/docs/rules/no-invalid-test-waiters.md
@@ -1,6 +1,8 @@
-# no-invalid-test-waiters
+# ember/no-invalid-test-waiters
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Prevents invalid usage of test waiters.
 

--- a/docs/rules/no-jquery.md
+++ b/docs/rules/no-jquery.md
@@ -1,6 +1,8 @@
-# no-jquery
+# ember/no-jquery
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This rule attempts to catch and prevent any usage of jQuery.
 

--- a/docs/rules/no-legacy-test-waiters.md
+++ b/docs/rules/no-legacy-test-waiters.md
@@ -1,6 +1,8 @@
-# no-legacy-test-waiters
+# ember/no-legacy-test-waiters
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Prevents the use of the legacy test waiter APIs.
 

--- a/docs/rules/no-mixins.md
+++ b/docs/rules/no-mixins.md
@@ -1,6 +1,8 @@
-# no-mixins
+# ember/no-mixins
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Using mixins to share code appears easy at first. But they add significant complexity as a project grows. Furthermore, the [Octane programming model](https://guides.emberjs.com/release/upgrading/current-edition/) eliminates the need to use them in favor of native class semantics and other primitives.
 

--- a/docs/rules/no-new-mixins.md
+++ b/docs/rules/no-new-mixins.md
@@ -1,6 +1,8 @@
-# no-new-mixins
+# ember/no-new-mixins
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Using mixins to share code appears easy at first. But they add significant complexity as a project grows. Furthermore, the [Octane programming model](https://guides.emberjs.com/release/upgrading/current-edition/) eliminates the need to use them in favor of native class semantics and other primitives.
 

--- a/docs/rules/no-noop-setup-on-error-in-before.md
+++ b/docs/rules/no-noop-setup-on-error-in-before.md
@@ -1,8 +1,10 @@
-# no-noop-setup-on-error-in-before
+# ember/no-noop-setup-on-error-in-before
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Disallows use of no-op `setupOnerror` in `before`/`beforeEach` since it could mask errors or rejections in tests unintentionally
 

--- a/docs/rules/no-observers.md
+++ b/docs/rules/no-observers.md
@@ -1,6 +1,8 @@
-# no-observers
+# ember/no-observers
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 You should avoid observers for the following reasons:
 

--- a/docs/rules/no-old-shims.md
+++ b/docs/rules/no-old-shims.md
@@ -1,8 +1,10 @@
-# no-old-shims
+# ember/no-old-shims
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Don't use import paths from `ember-cli-shims`.
 

--- a/docs/rules/no-on-calls-in-components.md
+++ b/docs/rules/no-on-calls-in-components.md
@@ -1,6 +1,8 @@
-# no-on-calls-in-components
+# ember/no-on-calls-in-components
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Prevents using `.on()` in favour of component's lifecycle hooks.
 

--- a/docs/rules/no-pause-test.md
+++ b/docs/rules/no-pause-test.md
@@ -1,6 +1,8 @@
-# no-pause-test
+# ember/no-pause-test
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallow use of `pauseTest` helper in tests.
 

--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -1,6 +1,8 @@
-# no-private-routing-service
+# ember/no-private-routing-service
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallow the use of:
 

--- a/docs/rules/no-proxies.md
+++ b/docs/rules/no-proxies.md
@@ -1,4 +1,6 @@
-# no-proxies
+# ember/no-proxies
+
+<!-- end auto-generated rule header -->
 
 You may want to disallow the use of Ember proxy objects (`ObjectProxy`, `ArrayProxy`) in your application for a number of reasons:
 

--- a/docs/rules/no-replace-test-comments.md
+++ b/docs/rules/no-replace-test-comments.md
@@ -1,4 +1,6 @@
-# no-replace-test-comments
+# ember/no-replace-test-comments
+
+<!-- end auto-generated rule header -->
 
 Ember developers using blueprints to generate classes should write real tests.
 

--- a/docs/rules/no-restricted-property-modifications.md
+++ b/docs/rules/no-restricted-property-modifications.md
@@ -1,6 +1,8 @@
-# no-restricted-property-modifications
+# ember/no-restricted-property-modifications
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 There are some properties, especially globally-injected ones, that you may want to treat as read-only, and ensure that no one modifies them.
 

--- a/docs/rules/no-restricted-resolver-tests.md
+++ b/docs/rules/no-restricted-resolver-tests.md
@@ -1,6 +1,8 @@
-# no-restricted-resolver-tests
+# ember/no-restricted-resolver-tests
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Don't use constructs or configuration that use the restricted resolver in tests.
 

--- a/docs/rules/no-restricted-service-injections.md
+++ b/docs/rules/no-restricted-service-injections.md
@@ -1,4 +1,6 @@
-# no-restricted-service-injections
+# ember/no-restricted-service-injections
+
+<!-- end auto-generated rule header -->
 
 In some parts of your application, you may prefer to disallow certain services from being injected. This can be useful for:
 

--- a/docs/rules/no-settled-after-test-helper.md
+++ b/docs/rules/no-settled-after-test-helper.md
@@ -1,8 +1,10 @@
-# no-settled-after-test-helper
+# ember/no-settled-after-test-helper
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Most of the test helper functions in
 [`@ember/test-helpers`](https://github.com/emberjs/ember-test-helpers) call

--- a/docs/rules/no-shadow-route-definition.md
+++ b/docs/rules/no-shadow-route-definition.md
@@ -1,6 +1,8 @@
-# no-shadow-route-definition
+# ember/no-shadow-route-definition
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Enforce no route path definition shadowing in Router.
 

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -1,6 +1,8 @@
-# no-side-effects
+# ember/no-side-effects
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 When using computed properties, do not introduce side effects. Side effects make it much more difficult to reason about the origin of changes.
 

--- a/docs/rules/no-string-prototype-extensions.md
+++ b/docs/rules/no-string-prototype-extensions.md
@@ -1,6 +1,8 @@
-# no-string-prototype-extensions
+# ember/no-string-prototype-extensions
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 By default, Ember extends certain native JavaScript objects with additional methods. This can lead to problems in some situations. One example is relying on these methods in an addon that is used inside an app that has the extensions disabled.
 

--- a/docs/rules/no-test-and-then.md
+++ b/docs/rules/no-test-and-then.md
@@ -1,6 +1,8 @@
-# no-test-and-then
+# ember/no-test-and-then
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Use `await` instead of `andThen` test wait helper.
 

--- a/docs/rules/no-test-import-export.md
+++ b/docs/rules/no-test-import-export.md
@@ -1,6 +1,8 @@
-# no-test-import-export
+# ember/no-test-import-export
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 No importing of test files.
 

--- a/docs/rules/no-test-module-for.md
+++ b/docs/rules/no-test-module-for.md
@@ -1,6 +1,8 @@
-# no-test-module-for
+# ember/no-test-module-for
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Use `module` instead of `moduleFor`.
 

--- a/docs/rules/no-test-support-import.md
+++ b/docs/rules/no-test-support-import.md
@@ -1,6 +1,8 @@
-# no-test-support-import
+# ember/no-test-support-import
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 No importing of test support files into non-test code..
 

--- a/docs/rules/no-test-this-render.md
+++ b/docs/rules/no-test-this-render.md
@@ -1,6 +1,8 @@
-# no-test-this-render
+# ember/no-test-this-render
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Ember's `this.render`/`this.clearRender` method and [`@ember/test-helpers`](https://github.com/emberjs/ember-test-helpers)'s `render`/`clearRender` method are equivalent, but using `@ember/test-helpers`' `render`/`clearRender` method is the recommended approach.
 

--- a/docs/rules/no-try-invoke.md
+++ b/docs/rules/no-try-invoke.md
@@ -1,6 +1,8 @@
-# no-try-invoke
+# ember/no-try-invoke
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This rule will catch and prevent the use of `tryInvoke`.
 

--- a/docs/rules/no-unnecessary-index-route.md
+++ b/docs/rules/no-unnecessary-index-route.md
@@ -1,4 +1,6 @@
-# no-unnecessary-index-route
+# ember/no-unnecessary-index-route
+
+<!-- end auto-generated rule header -->
 
 Disallow unnecessary `index` route definition.
 

--- a/docs/rules/no-unnecessary-route-path-option.md
+++ b/docs/rules/no-unnecessary-route-path-option.md
@@ -1,8 +1,10 @@
-# no-unnecessary-route-path-option
+# ember/no-unnecessary-route-path-option
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Disallow unnecessary route `path` option.
 

--- a/docs/rules/no-unnecessary-service-injection-argument.md
+++ b/docs/rules/no-unnecessary-service-injection-argument.md
@@ -1,6 +1,8 @@
-# no-unnecessary-service-injection-argument
+# ember/no-unnecessary-service-injection-argument
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Disallow unnecessary argument when injecting service.
 

--- a/docs/rules/no-unused-services.md
+++ b/docs/rules/no-unused-services.md
@@ -1,6 +1,8 @@
-# no-unused-services
+# ember/no-unused-services
 
-💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
 
 Disallow unused service injections.
 

--- a/docs/rules/no-volatile-computed-properties.md
+++ b/docs/rules/no-volatile-computed-properties.md
@@ -1,6 +1,8 @@
-# no-volatile-computed-properties
+# ember/no-volatile-computed-properties
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Volatile computed properties are deprecated as of Ember 3.9.
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -1,6 +1,8 @@
-# order-in-components
+# ember/order-in-components
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Note: this rule will not be added to the `recommended` configuration because it enforces an opinionated, stylistic preference.
 

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -1,6 +1,8 @@
-# order-in-controllers
+# ember/order-in-controllers
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Note: this rule will not be added to the `recommended` configuration because it enforces an opinionated, stylistic preference.
 

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -1,6 +1,8 @@
-# order-in-models
+# ember/order-in-models
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Note: this rule will not be added to the `recommended` configuration because it enforces an opinionated, stylistic preference.
 

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -1,6 +1,8 @@
-# order-in-routes
+# ember/order-in-routes
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Note: this rule will not be added to the `recommended` configuration because it enforces an opinionated, stylistic preference.
 

--- a/docs/rules/prefer-ember-test-helpers.md
+++ b/docs/rules/prefer-ember-test-helpers.md
@@ -1,6 +1,8 @@
-# prefer-ember-test-helpers
+# ember/prefer-ember-test-helpers
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This rule ensures the correct Ember test helper is imported when using methods that have a native window counterpart.
 

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -1,8 +1,10 @@
-# require-computed-macros
+# ember/require-computed-macros
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 It is preferred to use Ember's computed property macros as opposed to manually writing out logic in a computed property function. Reasons include:
 

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -1,8 +1,10 @@
-# require-computed-property-dependencies
+# ember/require-computed-property-dependencies
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Computed properties should have their property dependencies listed out so that they can recompute upon changes.
 

--- a/docs/rules/require-fetch-import.md
+++ b/docs/rules/require-fetch-import.md
@@ -1,4 +1,6 @@
-# require-fetch-import
+# ember/require-fetch-import
+
+<!-- end auto-generated rule header -->
 
 Using `fetch()` without importing it causes the browser to use the native,
 non-wrapped `window.fetch()`. This is generally fine, but makes testing harder

--- a/docs/rules/require-return-from-computed.md
+++ b/docs/rules/require-return-from-computed.md
@@ -1,6 +1,8 @@
-# require-return-from-computed
+# ember/require-return-from-computed
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Always return a value from a computed property function.
 

--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -1,8 +1,10 @@
-# require-super-in-lifecycle-hooks
+# ember/require-super-in-lifecycle-hooks
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Call super in lifecycle hooks.
 

--- a/docs/rules/require-tagless-components.md
+++ b/docs/rules/require-tagless-components.md
@@ -1,6 +1,8 @@
-# require-tagless-components
+# ember/require-tagless-components
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Disallows using the wrapper element of a component.
 

--- a/docs/rules/require-valid-css-selector-in-test-helpers.md
+++ b/docs/rules/require-valid-css-selector-in-test-helpers.md
@@ -1,8 +1,10 @@
-# require-valid-css-selector-in-test-helpers
+# ember/require-valid-css-selector-in-test-helpers
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Test helpers and querySelector methods should be called with valid CSS selectors. Most of the time invalid selectors will result in a failing test but that is not always the case.
 

--- a/docs/rules/route-path-style.md
+++ b/docs/rules/route-path-style.md
@@ -1,6 +1,8 @@
-# route-path-style
+# ember/route-path-style
 
-💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
 
 Enforces usage of kebab-case (instead of snake_case or camelCase) in route paths.
 

--- a/docs/rules/routes-segments-snake-case.md
+++ b/docs/rules/routes-segments-snake-case.md
@@ -1,6 +1,8 @@
-# routes-segments-snake-case
+# ember/routes-segments-snake-case
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 Dynamic segments in routes should use _snake case_, so Ember doesn't have to do extra serialization in order to resolve promises.
 

--- a/docs/rules/use-brace-expansion.md
+++ b/docs/rules/use-brace-expansion.md
@@ -1,6 +1,8 @@
-# use-brace-expansion
+# ember/use-brace-expansion
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
+
+<!-- end auto-generated rule header -->
 
 This allows much less redundancy and is easier to read.
 

--- a/docs/rules/use-ember-data-rfc-395-imports.md
+++ b/docs/rules/use-ember-data-rfc-395-imports.md
@@ -1,8 +1,10 @@
-# use-ember-data-rfc-395-imports
+# ember/use-ember-data-rfc-395-imports
 
-✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
+✅ This rule is enabled in the `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Use &#34;Ember Data Packages&#34; from Ember RFC #395.
 

--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -1,6 +1,8 @@
-# use-ember-get-and-set
+# ember/use-ember-get-and-set
 
-🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
 
 Use `Ember.get` and `Ember.set`.
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
   "scripts": {
     "changelog": "lerna-changelog",
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint '**/*.md'",
-    "lint:js": "eslint . --cache",
+    "lint:docs": "markdownlint \"**/*.md\"",
+    "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
+    "lint:js": "eslint --cache .",
     "lint:package-json": "npmPkgJsonLint .",
     "lint:package-json-sorting": "sort-package-json --check",
     "lint:package-json-sorting:fix": "sort-package-json package.json",
@@ -43,7 +44,8 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watchAll",
-    "update": "node ./scripts/update-rules.js && node ./scripts/list-jquery-methods.js"
+    "update": "node ./scripts/update-rules.js && node ./scripts/list-jquery-methods.js && npm-run-all update:eslint-docs",
+    "update:eslint-docs": "eslint-doc-generator --split-by meta.docs.category --rule-doc-section-include Examples --rule-doc-title-format prefix-name --url-configs \"https://github.com/ember-cli/eslint-plugin-ember#-configurations\""
   },
   "jest": {
     "coverageThreshold": {
@@ -78,6 +80,7 @@
     "@typescript-eslint/parser": "^5.31.0",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-doc-generator": "^0.15.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^5.0.1",
     "eslint-plugin-filenames": "^1.3.2",

--- a/tests/rule-setup.js
+++ b/tests/rule-setup.js
@@ -10,26 +10,6 @@ const RECOMMENDED_RULE_NAMES = Object.keys(recommendedRules).map((name) =>
   name.replace('ember/', '')
 );
 
-function getAllNamedOptions(jsonSchema) {
-  if (!jsonSchema) {
-    return [];
-  }
-
-  if (Array.isArray(jsonSchema)) {
-    return jsonSchema.flatMap(getAllNamedOptions);
-  }
-
-  if (jsonSchema.items) {
-    return getAllNamedOptions(jsonSchema.items);
-  }
-
-  if (jsonSchema.properties) {
-    return Object.keys(jsonSchema.properties);
-  }
-
-  return [];
-}
-
 describe('rules setup is correct', function () {
   it('should have a list of exported rules and rules directory that match', function () {
     const filePath = path.join(__dirname, '..', 'lib', 'rules');
@@ -96,82 +76,6 @@ describe('rules setup is correct', function () {
         .filter((file) => !file.startsWith('.') && file !== '_TEMPLATE_.md')
         .map((file) => file.replace('.md', ''))
     );
-  });
-
-  describe('rule documentation files', function () {
-    const MESSAGES = {
-      fixable:
-        '🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.',
-      configRecommended:
-        '✅ The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.',
-      hasSuggestions:
-        '💡 Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).',
-    };
-
-    for (const ruleName of RULE_NAMES) {
-      const rule = rules[ruleName];
-      const filePath = path.join(__dirname, '..', 'docs', 'rules', `${ruleName}.md`);
-      const file = readFileSync(filePath, 'utf8');
-      const lines = file.split('\n');
-
-      /* eslint-disable jest/no-conditional-expect */
-      // eslint-disable-next-line jest/valid-title
-      describe(ruleName, function () {
-        it('should have the right contents (title, examples, notices)', function () {
-          expect(file).toContain(`# ${ruleName}`); // Title header.
-          expect(file).toContain('## Examples'); // Examples section header.
-
-          // Check if the rule has configuration options.
-          if (
-            (Array.isArray(rule.meta.schema) && rule.meta.schema.length > 0) ||
-            (typeof rule.meta.schema === 'object' && Object.keys(rule.meta.schema).length > 0)
-          ) {
-            // Should have a configuration section header:
-            expect(file).toContain('## Configuration');
-
-            // Ensure all configuration options are mentioned.
-            for (const namedOption of getAllNamedOptions(rule.meta.schema)) {
-              expect(file).toContain(namedOption);
-            }
-          } else {
-            expect(file).not.toContain('## Configuration');
-          }
-
-          // Decide which notices should be shown at the top of the doc.
-          const expectedNotices = [];
-          const unexpectedNotices = [];
-          if (rule.meta.docs.recommended) {
-            expectedNotices.push('configRecommended');
-          } else {
-            unexpectedNotices.push('configRecommended');
-          }
-          if (rule.meta.fixable) {
-            expectedNotices.push('fixable');
-          } else {
-            unexpectedNotices.push('fixable');
-          }
-          if (rules[ruleName].meta.hasSuggestions) {
-            expectedNotices.push('hasSuggestions');
-          } else {
-            unexpectedNotices.push('hasSuggestions');
-          }
-
-          // Ensure that expected notices are present in the correct order.
-          let currentLineNumber = 1;
-          for (const expectedNotice of expectedNotices) {
-            expect(lines[currentLineNumber]).toBe('');
-            expect(lines[currentLineNumber + 1]).toStrictEqual(MESSAGES[expectedNotice]);
-            currentLineNumber += 2;
-          }
-
-          // Ensure that unexpected notices are not present.
-          for (const unexpectedNotice of unexpectedNotices) {
-            expect(file).not.toContain(MESSAGES[unexpectedNotice]);
-          }
-        });
-      });
-      /* eslint-enable jest/no-conditional-expect */
-    }
   });
 
   it('should mention all rules in the README', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,6 +1354,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/semver@^7.3.12":
+  version "7.3.12"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
+  integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1407,6 +1412,14 @@
     "@typescript-eslint/types" "5.40.1"
     "@typescript-eslint/visitor-keys" "5.40.1"
 
+"@typescript-eslint/scope-manager@5.41.0":
+  version "5.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.41.0.tgz#28e3a41d626288d0628be14cf9de8d49fc30fadf"
+  integrity sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==
+  dependencies:
+    "@typescript-eslint/types" "5.41.0"
+    "@typescript-eslint/visitor-keys" "5.41.0"
+
 "@typescript-eslint/types@5.30.7":
   version "5.30.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.7.tgz#18331487cc92d0f1fb1a6f580c8ec832528079d0"
@@ -1416,6 +1429,11 @@
   version "5.40.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.40.1.tgz#de37f4f64de731ee454bb2085d71030aa832f749"
   integrity sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==
+
+"@typescript-eslint/types@5.41.0":
+  version "5.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.41.0.tgz#6800abebc4e6abaf24cdf220fb4ce28f4ab09a85"
+  integrity sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==
 
 "@typescript-eslint/typescript-estree@5.30.7":
   version "5.30.7"
@@ -1443,6 +1461,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.41.0":
+  version "5.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.41.0.tgz#bf5c6b3138adbdc73ba4871d060ae12c59366c61"
+  integrity sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==
+  dependencies:
+    "@typescript-eslint/types" "5.41.0"
+    "@typescript-eslint/visitor-keys" "5.41.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/utils@^5.10.0":
   version "5.30.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.7.tgz#7135be070349e9f7caa262b0ca59dc96123351bb"
@@ -1454,6 +1485,20 @@
     "@typescript-eslint/typescript-estree" "5.30.7"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
+
+"@typescript-eslint/utils@^5.38.1":
+  version "5.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.41.0.tgz#f41ae5883994a249d00b2ce69f4188f3a23fa0f9"
+  integrity sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.41.0"
+    "@typescript-eslint/types" "5.41.0"
+    "@typescript-eslint/typescript-estree" "5.41.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
 
 "@typescript-eslint/visitor-keys@5.30.7":
   version "5.30.7"
@@ -1469,6 +1514,14 @@
   integrity sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==
   dependencies:
     "@typescript-eslint/types" "5.40.1"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.41.0":
+  version "5.41.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.41.0.tgz#d3510712bc07d5540160ed3c0f8f213b73e3bcd9"
+  integrity sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==
+  dependencies:
+    "@typescript-eslint/types" "5.41.0"
     eslint-visitor-keys "^3.3.0"
 
 abab@^2.0.6:
@@ -2111,6 +2164,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
+
 commander@~9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
@@ -2610,6 +2668,17 @@ eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
+eslint-doc-generator@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-0.15.0.tgz#7b5462023d299886caa5b8e18ad76d83c2f86a1e"
+  integrity sha512-gg1y955ZgAofpn4+DF7fhdB3nYf7pLJA7G5Ejh5PL8f9R1VZTRPfB6xfXuHa7KFXNjIW95s79a4SSQkjVzlkyQ==
+  dependencies:
+    "@typescript-eslint/utils" "^5.38.1"
+    camelcase "^7.0.0"
+    commander "^9.4.0"
+    markdown-table "^3.0.2"
+    type-fest "^3.0.0"
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -4666,6 +4735,11 @@ markdown-it@13.0.1:
     linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
+
+markdown-table@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.2.tgz#9b59eb2c1b22fe71954a65ff512887065a7bb57c"
+  integrity sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==
 
 markdownlint-cli@^0.32.0:
   version "0.32.2"
@@ -6752,6 +6826,11 @@ type-fest@^2.13.0, type-fest@^2.5.1:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
   integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
+
+type-fest@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.1.0.tgz#157b74044d9c27fd796b9c6aa46eae6658b1e9b8"
+  integrity sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
I built this CLI tool [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) for automating the generation of the README rules list and rule doc title/notices for ESLint plugins. It follows common documentation conventions from this and other top ESLint plugins and will help us standardize documentation across ESLint plugins (and generally improve the usability of our custom rules through better documentation and streamline the process of adding new rules).

This is a follow-up to the work I did to add the original notices in #715 #759 #944 and others. eslint-doc-generator is significantly more robust compared to the previous documentation generator script/tests which I have now removed. It has additional functionality (for example, the rules list legend is auto-generated, and the rules list will show additional columns of information when applicable) and 100% test coverage.

