### PR TITLE
Don't lose optional chaining with `objectAt` in autofix for `no-array-prototype-extensions` rule

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -317,8 +317,10 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       if (callArgs.length === 1) {
         return [
           fixer.insertTextBefore(
-            callExpressionNode, 
-            `${sourceCode.getText(calleeObj)}${callExpressionNode.callee.optional ? '?.' : ''}[${sourceCode.getText(callArgs[0])}]` 
+            callExpressionNode,
+            `${sourceCode.getText(calleeObj)}${
+              callExpressionNode.callee.optional ? '?.' : ''
+            }[${sourceCode.getText(callArgs[0])}]`
           ),
           fixer.remove(callExpressionNode),
         ];

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -318,8 +318,8 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         return [
           fixer.insertTextBefore(
             callExpressionNode, 
-            callExpressionNode.callee.type === 'OptionalMemberExpression' 
-              ? `?.${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]` 
+            callExpressionNode.callee.optional
+              ? `${sourceCode.getText(calleeObj)}?.[${sourceCode.getText(callArgs[0])}]` 
               : `${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]`
           ),
           fixer.remove(callExpressionNode),

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -318,9 +318,7 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
         return [
           fixer.insertTextBefore(
             callExpressionNode, 
-            callExpressionNode.callee.optional
-              ? `${sourceCode.getText(calleeObj)}?.[${sourceCode.getText(callArgs[0])}]` 
-              : `${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]`
+            `${sourceCode.getText(calleeObj)}${callExpressionNode.callee.optional ? '?.' : ''}[${sourceCode.getText(callArgs[0])}]` 
           ),
           fixer.remove(callExpressionNode),
         ];

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -317,8 +317,10 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
       if (callArgs.length === 1) {
         return [
           fixer.insertTextBefore(
-            callExpressionNode,
-            `${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]`
+            callExpressionNode, 
+            callExpressionNode.callee.type === 'OptionalMemberExpression' 
+              ? `?.${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]` 
+              : `${sourceCode.getText(calleeObj)}[${sourceCode.getText(callArgs[0])}]`
           ),
           fixer.remove(callExpressionNode),
         ];

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -703,6 +703,12 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      // Function call in optional chaining
+      code: 'something.somethingElse?.objectAt(1)',
+      output: 'something.somethingElse?.[1]',
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // When unexpected number of arguments are passed, auto-fixer will not run
       code: 'something.objectsAt()',
       output: null,

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -697,6 +697,11 @@ import { get as g } from 'dummy';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
+      code: 'something?.objectAt(1)',
+      output: 'something?.[1]',
+      errors: [{ messageId: 'main', type: 'CallExpression' }],
+    },
+    {
       // Function call in chain
       code: 'something.somethingElse.objectAt(1)',
       output: 'something.somethingElse[1]',


### PR DESCRIPTION
### Summary
Add optional chaining support to `objectAt` auto-fixer.

### Detail
Right now the `objectAt` auto-fixer in no-array-prototype-extensions will remove the optional chaining operator(?.). So this PR will use `callExpressionNode.callee.optional` to check the optional chaining use case and keep the optional chaining operator.

For example, the following template
const response = this.demoResponses?.objectAt(questionIndex);

Before:
const response = this.demoResponses[questionIndex];

After:
const response = this.demoResponses?.[questionIndex];

### Testing Done
Add two new test cases to check the optional chaining use case.
All test cases passed.