### PR TITLE
Switch to config file for `eslint-doc-generator`

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,0 +1,7 @@
+/** @type {import('eslint-doc-generator').GenerateOptions} */
+module.exports = {
+  ruleDocSectionInclude: ['Examples'],
+  ruleDocTitleFormat: 'prefix-name',
+  ruleListSplit: 'meta.docs.category',
+  urlConfigs: 'https://github.com/ember-cli/eslint-plugin-ember#-configurations',
+};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watchAll",
     "update": "node ./scripts/update-rules.js && node ./scripts/list-jquery-methods.js && npm-run-all update:eslint-docs",
-    "update:eslint-docs": "eslint-doc-generator --rule-list-split meta.docs.category --rule-doc-section-include Examples --rule-doc-title-format prefix-name --url-configs \"https://github.com/ember-cli/eslint-plugin-ember#-configurations\""
+    "update:eslint-docs": "eslint-doc-generator"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
Easier to work with. Has TypeScript types. Allows function options.

https://github.com/bmish/eslint-doc-generator#configuration-file