### PR TITLE
Deprecate trivial node type check helpers

### DIFF
--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -1,5 +1,12 @@
 'use strict';
 
+/**
+ * Trivial helpers in this file that only check a node's existence and/or type are deprecated in favor of inlining that check.
+ * We don't need a function for every type of node.
+ * And as written, these functions won't correctly narrow the type of the node, which we would need if we incorporate TypeScript: https://github.com/ember-cli/eslint-plugin-ember/issues/1613
+ * TODO: we should inline these trivial checks and only check for node existence when it's actually a possibility a node might not exist.
+ */
+
 module.exports = {
   isAnyFunctionExpression,
   isArrayExpression,
@@ -56,6 +63,7 @@ function isAnyFunctionExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ArrayExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isArrayExpression(node) {
   return node !== undefined && node.type === 'ArrayExpression';
@@ -66,6 +74,7 @@ function isArrayExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ArrowFunctionExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isArrowFunctionExpression(node) {
   return node !== undefined && node.type === 'ArrowFunctionExpression';
@@ -76,6 +85,7 @@ function isArrowFunctionExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an AssignmentExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isAssignmentExpression(node) {
   return node.type === 'AssignmentExpression';
@@ -86,6 +96,7 @@ function isAssignmentExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an BinaryExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isBinaryExpression(node) {
   return node !== undefined && node.type === 'BinaryExpression';
@@ -96,6 +107,7 @@ function isBinaryExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an CallExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isCallExpression(node) {
   return node !== undefined && node.type === 'CallExpression';
@@ -125,6 +137,7 @@ function isCallWithFunctionExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a ClassDeclaration.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isClassDeclaration(node) {
   return node !== undefined && node.type === 'ClassDeclaration';
@@ -163,6 +176,7 @@ function isConciseArrowFunctionWithCallExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a ConditionalExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isConditionalExpression(node) {
   return node !== undefined && node.type === 'ConditionalExpression';
@@ -173,6 +187,7 @@ function isConditionalExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a Decorator.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isDecorator(node) {
   return node !== undefined && node.type === 'Decorator';
@@ -183,6 +198,7 @@ function isDecorator(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ExpressionStatement.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isExpressionStatement(node) {
   return node !== undefined && node.type === 'ExpressionStatement';
@@ -193,6 +209,7 @@ function isExpressionStatement(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a FunctionDeclaration
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isFunctionDeclaration(node) {
   return node !== undefined && node.type === 'FunctionDeclaration';
@@ -203,6 +220,7 @@ function isFunctionDeclaration(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an FunctionExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isFunctionExpression(node) {
   return node !== undefined && node.type === 'FunctionExpression';
@@ -213,6 +231,7 @@ function isFunctionExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an Identifier.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isIdentifier(node) {
   return node !== undefined && node.type === 'Identifier';
@@ -223,6 +242,7 @@ function isIdentifier(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ImportDeclaration.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isImportDeclaration(node) {
   return node !== undefined && node.type === 'ImportDeclaration';
@@ -233,6 +253,7 @@ function isImportDeclaration(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ImportDefaultSpecifier.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isImportDefaultSpecifier(node) {
   return node !== undefined && node.type === 'ImportDefaultSpecifier';
@@ -243,6 +264,7 @@ function isImportDefaultSpecifier(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an Literal.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isLiteral(node) {
   return node !== undefined && node.type === 'Literal';
@@ -253,6 +275,7 @@ function isLiteral(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an LogicalExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isLogicalExpression(node) {
   return node !== undefined && node.type === 'LogicalExpression';
@@ -263,6 +286,7 @@ function isLogicalExpression(node) {
  *
  * @param {Object} node The node to check.
  * @return {boolean} Whether or not the node is an MemberExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isMemberExpression(node) {
   return node !== undefined && node.type === 'MemberExpression';
@@ -273,6 +297,7 @@ function isMemberExpression(node) {
  *
  * @param {Object} node The node to check.
  * @return {boolean} Whether or not the node is a MethodDefinition.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isMethodDefinition(node) {
   return node !== undefined && node.type === 'MethodDefinition';
@@ -283,6 +308,7 @@ function isMethodDefinition(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an NewExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isNewExpression(node) {
   return node !== undefined && node.type === 'NewExpression';
@@ -293,6 +319,7 @@ function isNewExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ObjectExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isObjectExpression(node) {
   return node !== undefined && node.type === 'ObjectExpression';
@@ -303,6 +330,7 @@ function isObjectExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ObjectPattern.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isObjectPattern(node) {
   return node !== undefined && node.type === 'ObjectPattern';
@@ -313,6 +341,7 @@ function isObjectPattern(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an OptionalCallExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isOptionalCallExpression(node) {
   return node.type === 'OptionalCallExpression';
@@ -323,6 +352,7 @@ function isOptionalCallExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an OptionalMemberExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isOptionalMemberExpression(node) {
   return node.type === 'OptionalMemberExpression';
@@ -333,6 +363,7 @@ function isOptionalMemberExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an Property.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isProperty(node) {
   return node !== undefined && node.type === 'Property';
@@ -343,6 +374,7 @@ function isProperty(node) {
  *
  * @param {Object} node The node to check.
  * @return {Boolean} Whether or not the node is a ReturnStatement.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isReturnStatement(node) {
   return node !== undefined && node.type && node.type === 'ReturnStatement';
@@ -353,6 +385,7 @@ function isReturnStatement(node) {
  *
  * @param {Object} node The node to check.
  * @return {Boolean} Whether or not the node is a SpreadElement.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isSpreadElement(node) {
   return node !== undefined && node.type === 'SpreadElement';
@@ -371,6 +404,7 @@ function isStringLiteral(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a TaggedTemplateExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isTaggedTemplateExpression(node) {
   return node !== undefined && node.type === 'TaggedTemplateExpression';
@@ -381,6 +415,7 @@ function isTaggedTemplateExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a TemplateLiteral.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isTemplateLiteral(node) {
   return node !== undefined && node.type === 'TemplateLiteral';
@@ -391,6 +426,7 @@ function isTemplateLiteral(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an ThisExpression.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isThisExpression(node) {
   return node !== undefined && node.type === 'ThisExpression';
@@ -401,6 +437,7 @@ function isThisExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is an Literal.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isUnaryExpression(node) {
   return node !== undefined && node.type === 'UnaryExpression';
@@ -411,6 +448,7 @@ function isUnaryExpression(node) {
  *
  * @param {Object} node The node to check.
  * @returns {boolean} Whether or not the node is a VariableDeclarator.
+ * @deprecated trivial helpers are deprecated in favor of inlining the type check
  */
 function isVariableDeclarator(node) {
   return node !== undefined && node.type === 'VariableDeclarator';


### PR DESCRIPTION
This has come up a bunch recently and been an issue I have wanted to solve for a long time.

Trivial helpers in this file that only check a node's existence and/or type are deprecated in favor of inlining that check. We don't need a function for every type of node. We should inline these trivial checks and only check for node existence when it's actually a possibility a node might not exist.

And as written, these functions won't correctly narrow the type of the node, which we would need if we incorporate TypeScript: https://github.com/ember-cli/eslint-plugin-ember/issues/1613

Removing these trivial functions would also help prepare for future TypeScript incorporation:
* https://github.com/ember-cli/eslint-plugin-ember/issues/1613
* https://github.com/square/eslint-plugin-square/pull/723/files#r951635413