### PR TITLE
Fix crash from attempting to access non-existent dependent key in `no-tracked-property-from-args` rule

### DIFF
--- a/lib/rules/no-tracked-properties-from-args.js
+++ b/lib/rules/no-tracked-properties-from-args.js
@@ -16,6 +16,7 @@ function visitClassPropertyOrPropertyDefinition(node, context, trackedImportName
   const hasThisArgsValue =
     node.value &&
     startsWithThisExpression(node.value) &&
+    nodeToDependentKey(node.value, context) &&
     nodeToDependentKey(node.value, context).split('.')[0] === 'args';
 
   if (hasTrackedDecorator && hasThisArgsValue) {

--- a/lib/rules/no-tracked-properties-from-args.js
+++ b/lib/rules/no-tracked-properties-from-args.js
@@ -16,8 +16,7 @@ function visitClassPropertyOrPropertyDefinition(node, context, trackedImportName
   const hasThisArgsValue =
     node.value &&
     startsWithThisExpression(node.value) &&
-    nodeToDependentKey(node.value, context) &&
-    nodeToDependentKey(node.value, context).split('.')[0] === 'args';
+    nodeToDependentKey(node.value, context)?.split('.')[0] === 'args';
 
   if (hasTrackedDecorator && hasThisArgsValue) {
     context.report({ node, messageId: 'main' });

--- a/lib/utils/property-getter.js
+++ b/lib/utils/property-getter.js
@@ -79,7 +79,7 @@ function isSimpleThisExpression(node) {
  * Example Output:  'x.y'
  *
  * @param {Node} node a MemberExpression node that looks like `this.x.y` or `this.get('x')`.
- * @returns {String} The dependent key of the input node (without `this.`).
+ * @returns {String | undefined} The dependent key of the input node (without `this.`).
  */
 function nodeToDependentKey(nodeWithThisExpression, context) {
   if (types.isCallExpression(nodeWithThisExpression)) {
@@ -89,7 +89,7 @@ function nodeToDependentKey(nodeWithThisExpression, context) {
     }
 
     // Looks like: this.someMethod()
-    return '';
+    return undefined;
   }
 
   const sourceCode = context.getSourceCode();

--- a/lib/utils/property-getter.js
+++ b/lib/utils/property-getter.js
@@ -83,8 +83,13 @@ function isSimpleThisExpression(node) {
  */
 function nodeToDependentKey(nodeWithThisExpression, context) {
   if (types.isCallExpression(nodeWithThisExpression)) {
-    // Looks like: this.get('property')
-    return nodeWithThisExpression.arguments[0].value;
+    if (nodeWithThisExpression.arguments[0]) {
+      // Looks like: this.get('property')
+      return nodeWithThisExpression.arguments[0].value;
+    }
+
+    // Looks like: this.someMethod()
+    return '';
   }
 
   const sourceCode = context.getSourceCode();

--- a/tests/helpers/faux-context.js
+++ b/tests/helpers/faux-context.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { parseForESLint } = require('../helpers/babel-eslint-parser');
-
+const { SourceCode } = require('eslint');
 /**
  * Builds a fake ESLint context object that's enough to satisfy the contract
  * expected by `getSourceModuleNameForIdentifier` and `isEmberCoreModule`
@@ -13,6 +13,7 @@ class FauxContext {
     this.ast = ast;
     this.filename = filename;
     this.report = report;
+    this.code = code;
   }
 
   /**
@@ -25,6 +26,10 @@ class FauxContext {
 
   getFilename() {
     return this.filename;
+  }
+
+  getSourceCode() {
+    return new SourceCode(this.code, this.ast);
   }
 }
 

--- a/tests/lib/rules/no-tracked-properties-from-args.js
+++ b/tests/lib/rules/no-tracked-properties-from-args.js
@@ -74,6 +74,13 @@ ruleTester.run('no-tracked-properties-from-args', rule, {
         notInitializedProperty;
       }
     `,
+    `
+      import { tracked as fooTracked } from '@glimmer/tracking';
+
+      class Test {
+        someProperty = this.someMethod();
+      }
+    `,
   ],
   invalid: [
     {

--- a/tests/lib/utils/property-getter-test.js
+++ b/tests/lib/utils/property-getter-test.js
@@ -68,6 +68,6 @@ describe('nodeToDependentKey', () => {
 
     context = new FauxContext('this.x()');
     node = context.ast.body[0].expression;
-    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBe('');
+    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBeUndefined();
   });
 });

--- a/tests/lib/utils/property-getter-test.js
+++ b/tests/lib/utils/property-getter-test.js
@@ -2,6 +2,7 @@
 
 const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const propertyGetterUtils = require('../../../lib/utils/property-getter');
+const { FauxContext } = require('../../helpers/faux-context');
 
 function parse(code) {
   return babelESLintParse(code).body[0].expression;
@@ -48,5 +49,25 @@ describe('isThisGetCall', () => {
     // True:
     expect(propertyGetterUtils.isThisGetCall(parse('this.get("property")'))).toBeTruthy();
     expect(propertyGetterUtils.isThisGetCall(parse('this.get("x.y")'))).toBeTruthy();
+  });
+});
+
+describe('nodeToDependentKey', () => {
+  it('behaves correctly', () => {
+    let context = new FauxContext('this.x');
+    let node = context.ast.body[0];
+    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBe('x');
+
+    context = new FauxContext('this.x.y');
+    node = context.ast.body[0];
+    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBe('x.y');
+
+    context = new FauxContext('this.get("x")');
+    node = context.ast.body[0].expression;
+    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBe('x');
+
+    context = new FauxContext('this.x()');
+    node = context.ast.body[0].expression;
+    expect(propertyGetterUtils.nodeToDependentKey(node, context)).toBe('');
   });
 });


### PR DESCRIPTION
Fixes #1734 

1. Open to initial feedback for a better route if this is not desirable. I can add some checks to the no-tracked-properties rule, but figure the current logic should be supported without failing.

```
const hasThisArgsValue =
    node.value &&
    startsWithThisExpression(node.value) &&
    nodeToDependentKey(node.value, context).split('.')[0] === 'args';
```

2. If this path sounds good as a solution, should we be returning the empty string (current) or method name instead?