### PR TITLE
Fix setup for eslint-remote-tester for testing our rules against other repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ npm-debug.log
 .vscode
 
 # eslint-remote-tester
-.cache-eslint-remote-tester
 eslint-remote-tester-results

--- a/eslint-remote-tester.config.js
+++ b/eslint-remote-tester.config.js
@@ -1,7 +1,7 @@
 /* eslint filenames/match-regex:off */
-const { getPathIgnorePattern } = require('eslint-remote-tester-repositories');
 const fs = require('fs');
 
+/** @type {import('eslint-remote-tester').Config} */
 module.exports = {
   /** Repositories to scan */
   repositories: [
@@ -28,9 +28,6 @@ module.exports = {
     'typed-ember/ember-cli-typescript',
   ],
 
-  /** Optional pattern used to exclude paths */
-  pathIgnorePattern: getPathIgnorePattern(),
-
   /** Extensions of files under scanning */
   extensions: ['js', 'ts'],
 
@@ -40,6 +37,7 @@ module.exports = {
   /** ESLint configuration */
   eslintrc: {
     plugins: ['ember'],
+
     // Enable all of our rules.
     rules: Object.fromEntries(
       fs
@@ -58,5 +56,12 @@ module.exports = {
           return [ruleName, value];
         })
     ),
+
+    overrides: [
+      {
+        files: ['*.ts'],
+        parser: '@typescript-eslint/parser',
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^45.0.1",
     "eslint-remote-tester": "^3.0.0",
-    "eslint-remote-tester-repositories": "^1.0.0",
     "jest": "^29.1.2",
     "jquery": "^3.5.1",
     "jsdom": "^20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,11 +2800,6 @@ eslint-plugin-unicorn@^45.0.1:
     semver "^7.3.8"
     strip-indent "^3.0.0"
 
-eslint-remote-tester-repositories@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-remote-tester-repositories/-/eslint-remote-tester-repositories-1.0.0.tgz#92b2b035bec17a39fcb4a018ad22b31c2e707a5b"
-  integrity sha512-2tngPTc/zT/nyUZKZYkNCLCgSIvAsWDaaC3ce9zlYLijlmPd9ka70Logxiazu9NwS4cIaXTzTLGupr2u7m7+cw==
-
 eslint-remote-tester@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-remote-tester/-/eslint-remote-tester-3.0.0.tgz#aa9b357d65250245f1d6556b4decaf993e2c72f4"


### PR DESCRIPTION
Follow-up to: 
* https://github.com/ember-cli/eslint-plugin-ember/pull/1730

Based on learnings from:
* https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/335

Extracted bug fixes that were detected by this PR:

* https://github.com/ember-cli/eslint-plugin-ember/pull/1870
* https://github.com/ember-cli/eslint-plugin-ember/pull/1869
* #1871