### PR TITLE
Ignore Ember Data `store` service calls in `no-array-prototype-extensions` rule

### DIFF
--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -27,6 +27,7 @@ To reduce false positives, the rule ignores some common known-non-array classes/
 - `localStorage.clear()` / `sessionStorage.clear()`
 - `Promise.any()` / `Promise.reject()`
 - Lodash / jQuery
+- Ember Data `this.store` service
 - etc
 
 If you run into additional false positives, please file a bug or submit a PR to add it to the rule's hardcoded ignore list.

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -598,6 +598,22 @@ function applyFix(callExpressionNode, fixer, context, options = {}) {
   }
 }
 
+/**
+ * Check for a call on `this.store` which we can assume is the Ember Data store service.
+ * We don't check for an initialization as the service could be implicitly injected: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-implicit-injections.md
+ */
+function isThisStoreCall(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'MemberExpression' &&
+    node.callee.object.object.type === 'ThisExpression' &&
+    node.callee.object.property.type === 'Identifier' &&
+    node.callee.object.property.name === 'store' &&
+    node.callee.property.type === 'Identifier' // Any function call on the store service.
+  );
+}
+
 //----------------------------------------------------------------------------------------------
 // General rule - Don't use Ember's array prototype extensions like .any(), .pushObject() or .firstObject
 //----------------------------------------------------------------------------------------------
@@ -695,6 +711,15 @@ module.exports = {
         ) {
           // Ignore when we can tell the variable was initialized to an instance of a non-array class.
           // Example: const foo = new Set();
+          return;
+        }
+
+        if (
+          (nodeInitializedTo.type === 'AwaitExpression' &&
+            isThisStoreCall(nodeInitializedTo.argument)) ||
+          isThisStoreCall(nodeInitializedTo)
+        ) {
+          // Found call on the Ember Data this.store class.
           return;
         }
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -226,6 +226,25 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       array.without(2)
     `,
 
+    // Ember Data call with await.
+    `
+    class MyClass {
+      async _fetch(query) {
+        const response = await this.store.query('foo-bar', query);
+        return response.toArray();
+      }
+    }
+    `,
+    // Ember Data call without await.
+    `
+    class MyClass {
+      _fetch(query) {
+        const response = this.store.peekAll('foo-bar', query);
+        return response.toArray();
+      }
+    }
+    `,
+
     // TODO: handle non-Identifier property names:
     'foo["clear"]();',
   ],


### PR DESCRIPTION
Partially fixes #1561. Helps reduce false positives.

TODO:

- [ ] Explain why Ember Data calls should be ignored