### PR TITLE
Ignore direct instantiation of `EmberArray` in `no-array-prototype-extensions` rule

### DIFF
--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -117,6 +117,15 @@ export default class SampleComponent extends Component {
 }
 ```
 
+```js
+/** Direct usage of `@ember/array` **/
+/** Use A() is OK **/
+import { A } from '@ember/array';
+
+let arr = A(['a', 'a', 'b', 'b']);
+arr.uniq();
+```
+
 ## References
 
 - [EmberArray](https://api.emberjs.com/ember/release/classes/EmberArray)

--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -122,7 +122,7 @@ export default class SampleComponent extends Component {
 /** Use A() is OK **/
 import { A } from '@ember/array';
 
-let arr = A(['a', 'a', 'b', 'b']);
+const arr = A(['a', 'a', 'b', 'b']);
 arr.uniq();
 ```
 

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -719,12 +719,11 @@ module.exports = {
           return;
         }
 
-        // ignore ember array initialization with A([]) or EmberArray([])
+        // Direct usage of `@ember/array` is allowed.
         if (
           node.type === 'CallExpression' &&
-          nodeInitializedTo.callee &&
           importedEmberArrayName &&
-          nodeInitializedTo.callee.name &&
+          nodeInitializedTo.callee.type === 'Identifier' &&
           importedEmberArrayName === nodeInitializedTo.callee.name
         ) {
           return;

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -621,6 +621,7 @@ module.exports = {
     let importedGetName;
     let importedSetName;
     let importedCompareName;
+    let importedEmberArrayName;
 
     // Track some information about the current class we're inside.
     const classStack = new Stack();
@@ -634,6 +635,10 @@ module.exports = {
         if (node.source.value === '@ember/utils') {
           importedCompareName =
             importedCompareName || getImportIdentifier(node, '@ember/utils', 'compare');
+        }
+        if (node.source.value === '@ember/array') {
+          importedEmberArrayName =
+            importedEmberArrayName || getImportIdentifier(node, '@ember/array', 'A');
         }
       },
       /**
@@ -717,9 +722,10 @@ module.exports = {
         // ignore ember array initialization with A([]) or EmberArray([])
         if (
           node.type === 'CallExpression' &&
-          nodeInitializedTo &&
           nodeInitializedTo.callee &&
-          (nodeInitializedTo.callee.name === 'A' || nodeInitializedTo.callee.name === 'EmberArray')
+          importedEmberArrayName &&
+          nodeInitializedTo.callee.name &&
+          importedEmberArrayName === nodeInitializedTo.callee.name
         ) {
           return;
         }

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -714,6 +714,16 @@ module.exports = {
           return;
         }
 
+        // ignore ember array initialization with A([]) or EmberArray([])
+        if (
+          node.type === 'CallExpression' &&
+          nodeInitializedTo &&
+          nodeInitializedTo.callee &&
+          (nodeInitializedTo.callee.name === 'A' || nodeInitializedTo.callee.name === 'EmberArray')
+        ) {
+          return;
+        }
+
         if (EXTENSION_METHODS.has(node.callee.property.name)) {
           context.report({
             node,

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -210,6 +210,11 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       const array = A([1, 2, 3])
       array.toArray()
     `,
+      `
+      import { A } from '@ember/array'
+
+      A([1, 2, 3]).toArray();
+    `,
     `
       import { A as SomeWeirdName } from '@ember/array'
 

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -203,7 +203,23 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       parser: require.resolve('@typescript-eslint/parser'),
     },
 
-    // TODO: handle non-Identifier property names:
+    // function definition with Ember Array initialization.
+    `
+      function myFunction(){
+        const array = A([1, 2, 3])
+
+        array.toArray()
+      }
+      `,
+    `
+      function myFunction(){
+        const array = EmberArray([1, 2, 3])
+
+        array.without(2)
+      }
+      `,
+
+    // // TODO: handle non-Identifier property names:
     'foo["clear"]();',
   ],
   invalid: [

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -203,23 +203,21 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       parser: require.resolve('@typescript-eslint/parser'),
     },
 
-    // function definition with Ember Array initialization.
+    // Methods called directly on EmberArray.
     `
-      function myFunction(){
-        const array = A([1, 2, 3])
+      import { A } from '@ember/array'
 
-        array.toArray()
-      }
-      `,
+      const array = A([1, 2, 3])
+      array.toArray()
+    `,
     `
-      function myFunction(){
-        const array = EmberArray([1, 2, 3])
+      import { A as SomeWeirdName } from '@ember/array'
 
-        array.without(2)
-      }
-      `,
+      const array = SomeWeirdName([1, 2, 3])
+      array.without(2)
+    `,
 
-    // // TODO: handle non-Identifier property names:
+    // TODO: handle non-Identifier property names:
     'foo["clear"]();',
   ],
   invalid: [

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -210,7 +210,7 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       const array = A([1, 2, 3])
       array.toArray()
     `,
-      `
+     `
       import { A } from '@ember/array'
 
       A([1, 2, 3]).toArray();

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -210,7 +210,7 @@ ruleTester.run('no-array-prototype-extensions', rule, {
       const array = A([1, 2, 3])
       array.toArray()
     `,
-     `
+    `
       import { A } from '@ember/array'
 
       A([1, 2, 3]).toArray();


### PR DESCRIPTION
## Overview
Partially fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1561. Helps reduce false positives.

Direct instantiation of Ember arrays ie:
```
function myFunction(){
  const array = A([1, 2, 3])
  array.toArray()
}
```

are not deprecated so they should be allowed by the linter.