### PR TITLE
Fix false positive with `Promise.any()` in `no-array-prototype-extensions` rule

### DIFF
--- a/docs/rules/no-array-prototype-extensions.md
+++ b/docs/rules/no-array-prototype-extensions.md
@@ -24,7 +24,9 @@ To reduce false positives, the rule ignores some common known-non-array classes/
 
 - `Set.clear()`
 - `Map.clear()`
-- `Promise.reject()`
+- `localStorage.clear()` / `sessionStorage.clear()`
+- `Promise.any()` / `Promise.reject()`
+- Lodash / jQuery
 - etc
 
 If you run into additional false positives, please file a bug or submit a PR to add it to the rule's hardcoded ignore list.

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -78,6 +78,10 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
   'Ember.RSVP.reject()',
   'Ember.RSVP.Promise.reject()',
 
+  // Promise.any()
+  'window.Promise.any()',
+  'Promise.any()',
+
   // *storage.clear()
   'window.localStorage.clear()',
   'window.sessionStorage.clear()',

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -52,6 +52,10 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'reject();',
     'this.reject();',
 
+    // Promise.any()
+    'Promise.any();',
+    'window.Promise.any();',
+
     // Global non-array class (RSVP.reject)
     'RSVP.reject();',
     'RSVP.reject("some reason");',


### PR DESCRIPTION
Fixes #1760