### PR TITLE
Bump ember-template-imports to `v3.4.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@glimmer/syntax": "^0.84.2",
     "css-tree": "^2.0.4",
     "ember-rfc176-data": "^0.3.15",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.4.1",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.2.0",
     "lodash.camelcase": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,10 +2489,10 @@ ember-rfc176-data@^0.3.15:
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.18.tgz#bb6fdcef49999981317ea81b6cc9210fb4108d65"
   integrity sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==
 
-ember-template-imports@^3.1.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/ember-template-imports/-/ember-template-imports-3.4.0.tgz#c40757e2d41e289ce08c0fe80671000bf216e0ef"
-  integrity sha512-3Cwcj3NXA129g3ZhmrQ/nYOxksFonTmB/qxyaSNTHrLBSoc93UZys47hBz13DlcfoeSCCrNt2Qpq1j890I04PQ==
+ember-template-imports@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/ember-template-imports/-/ember-template-imports-3.4.1.tgz#bd400ddda2c2cad35ded53b35da1c0972452cde8"
+  integrity sha512-KXnBFTAVxCfXnSCUgd/iuic9ajWbmFkRUBEeorJAMqxvougsPoK22s5ygE9O3GnzYdPpMwn+8v+/NAGy8HRBGA==
   dependencies:
     babel-import-util "^0.2.0"
     broccoli-stew "^3.0.0"


### PR DESCRIPTION
When using `eslint-plugin-ember` with pnpm, there are more reports when dependencies are not met. This happens when installing `eslint-plugin-ember` but not installing `ember-cli-htmlbars`, here is a screenshot:

<img width="343" alt="Bildschirmfoto 2023-02-01 um 17 33 36" src="https://user-images.githubusercontent.com/283700/216104416-fd682622-97e8-4752-a441-c5d4ff974872.png">

That is `eslint-plugin-ember` depends on `ember-template-imports` which prior to `v3.4` had listed `ember-cli-htmlbars` as a required peer dependency. This was removed with this commit: https://github.com/ember-template-imports/ember-template-imports/commit/d1c4bd3928d44ad330829202158ca66c7f12b7f0 and first released in `v3.4.0` (`v3.4.1` is the latest release as of now).

Dependabot already updated to version `3.4.0` and a PR #1764 for `3.4.1` is open. Functionality should already be checked by CI. Yet, for end-users receiving this upstream change from `ember-template-imports`, this requires a version bump in `package.json` - which this PR includes.

Let me know how I can help drive this forward, I'm trying to keep my pnpm install warning free 😂 