### PR TITLE
Explain why route shadowing should be avoided in `no-shadow-route-definition` rule doc

### DIFF
--- a/docs/rules/no-shadow-route-definition.md
+++ b/docs/rules/no-shadow-route-definition.md
@@ -8,7 +8,7 @@ Enforce no route path definition shadowing in Router.
 
 ## Rule Details
 
-This rule disallows defining shadowing route definitions.
+This rule disallows defining shadowing route definitions. Shadowing will result in the router failing to resolve the path of the shadowed route, leading to undesirable and incomprehensible behavior (e.g. hooks of the shadowed route not firing even though the URL matches its path).
 
 ## Examples
 


### PR DESCRIPTION
After a lengthy discussion and some trial-and-error on the ember discord about whether route shadowing would cause issues at all, we came to the conclusion that this rule should include some details about *why* route shadowing is undesirable.

Link to the discussion: https://discordapp.com/channels/480462759797063690/1074791252748402778
Minimal repro: https://github.com/spuxx1701/ember-route-shadowing
Stackblitz where we tried some funky stuff with route paths: https://stackblitz.com/edit/github-qivg2a?file=app%2Frouter.js