### PR TITLE
Fix `no-array-prototype extensions` undefined error from trying to access callee from non-CallExpression

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -752,6 +752,7 @@ module.exports = {
         if (
           node.type === 'CallExpression' &&
           importedEmberArrayName &&
+          nodeInitializedTo.callee &&
           nodeInitializedTo.callee.type === 'Identifier' &&
           importedEmberArrayName === nodeInitializedTo.callee.name
         ) {

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -752,7 +752,7 @@ module.exports = {
         if (
           node.type === 'CallExpression' &&
           importedEmberArrayName &&
-          nodeInitializedTo.callee &&
+          nodeInitializedTo.type === 'CallExpression' &&
           nodeInitializedTo.callee.type === 'Identifier' &&
           importedEmberArrayName === nodeInitializedTo.callee.name
         ) {


### PR DESCRIPTION
Fixes https://github.com/ember-cli/eslint-plugin-ember/issues/1771.

Note: At this time, we've identified a way to reproduce the issue, but it's also an existing false positive. We will push this fix out without a test case so that this error can be resolved. Meanwhile, a new issue has been created to track the existing false positive: https://github.com/ember-cli/eslint-plugin-ember/issues/1807