### PR TITLE
[gjs] Return original diagnostic if transformed line matches original line in glimmer preprocessor

### DIFF
--- a/lib/preprocessors/glimmer.js
+++ b/lib/preprocessors/glimmer.js
@@ -104,6 +104,11 @@ function mapRange(messages, filename) {
   const originalLines = original.split('\n');
 
   return flattened.map((message) => {
+    if (lines[message.line - 1] === originalLines[message.line - 1]) {
+      // original line and transformed line match exactly. return original diagnostic message
+      return message;
+    }
+
     const line = lines[message.line - 1];
     const token = line.slice(message.column - 1, message.endColumn - 1);
 


### PR DESCRIPTION
This PR will fix part of the issue in #1659 where line/col numbers are reported as 0:0. The bug was typically caused by a few things:
1. the `token` had matches on multiple lines
2. multiple diagnostic messages mapped to the same line because `token` was too generic

May not fix every single instance, but will be a general improvement.