### PR TITLE
linter reports incorrect line number when line contains <template> tag

### DIFF
--- a/lib/preprocessors/glimmer.js
+++ b/lib/preprocessors/glimmer.js
@@ -115,7 +115,12 @@ function mapRange(messages, filename) {
     }
 
     const line = lines[message.line - 1];
-    const token = line.slice(message.column - 1, message.endColumn - 1);
+    let token = line.slice(message.column - 1, message.endColumn - 1);
+
+    // since the originalLines source uses `<template>`, we need to modify our search token
+    if (token.includes(util.TEMPLATE_TAG_PLACEHOLDER)) {
+      token = util.TEMPLATE_TAG_NAME;
+    }
 
     // Now that we have the token, we need to find the location
     // in the original text

--- a/tests/lib/rules-preprocessor/gjs-gts-processor-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-processor-test.js
@@ -280,6 +280,6 @@ describe('lint errors on the exact line as the <template> tag', () => {
     const resultErrors = results.flatMap((result) => result.messages);
     expect(resultErrors).toHaveLength(1);
     expect(resultErrors[0].message).toBe('Expected blank line between class members.');
-    expect(resultErrors[0].line).toBe(9);
+    expect(resultErrors[0].line).toBe(10);
   });
 });

--- a/tests/lib/rules-preprocessor/gjs-gts-processor-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-processor-test.js
@@ -280,5 +280,6 @@ describe('lint errors on the exact line as the <template> tag', () => {
     const resultErrors = results.flatMap((result) => result.messages);
     expect(resultErrors).toHaveLength(1);
     expect(resultErrors[0].message).toBe('Expected blank line between class members.');
+    expect(resultErrors[0].line).toBe(9);
   });
 });


### PR DESCRIPTION
a continuation of the PRs from yesterday to make more improvements to GJS/GTS linting. This test demonstrates that when a lint error falls on the line containing the `<template>` tag, the post-process script incorrectly reports the line number / column number as `0:0`.

will be pushing a fix shortly