### PR TITLE
Add `getProperties` autofixer to `no-get` rule

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -80,6 +80,74 @@ function fixGet({
   return fixer.replaceText(node, `${objectTextSafe}${objectPathSeparator}${replacementPath}`);
 }
 
+function reportGetProperties({ context, node, objectText, properties }) {
+  let _properties = properties;
+  if (properties[0].type === 'ArrayExpression') {
+    // When properties are in an array(e.g. getProperties(this.obj, [bar, foo]) ), actual properties are under Array.elements.
+    _properties = properties[0].elements;
+  }
+  const propertyNames = _properties.map((arg) => arg.value);
+
+  context.report({
+    node,
+    message: ERROR_MESSAGE_GET_PROPERTIES,
+    fix(fixer) {
+      return fixGetProperties({
+        fixer,
+        node,
+        objectText,
+        propertyNames,
+      });
+    },
+  });
+}
+
+function fixGetProperties({ fixer, node, objectText, propertyNames }) {
+  if (!propertyNames.every((name) => isValidJSVariableName(name) || isValidJSArrayIndex(name))) {
+    // Do not autofix if any property is invalid.
+    return null;
+  }
+
+  if (node.parent.type === 'VariableDeclarator' && node.parent.id.type === 'ObjectPattern') {
+    // When destructuring assignment is in the left side of "=".
+    // Example: const { foo, bar } = getProperties(this.obj, "foo", "bar");
+    // Expectation:
+    // const foo = this.obj.foo;
+    // const bar = this.obj.bar;
+
+    if (node.parent.parent.type !== 'VariableDeclaration' && !node.parent.parent.kind) {
+      // It has to start with a declaration text. e.g. "const", "let"
+      return null;
+    }
+    const declarationText = node.parent.parent.kind;
+
+    const destructuredPropertiesWithAliases = node.parent.id.properties.reduce((acc, property) => {
+      if (property?.key?.name) {
+        acc[property.key.name] = property.value.name; // eslint-disable-line no-param-reassign
+      }
+      return acc;
+    }, {});
+
+    if (Object.keys(destructuredPropertiesWithAliases).length !== propertyNames.length) {
+      // When a spread operator in the left side of an assignment. e.g. const { a, b, ...rest } = obj.getProperties(a, b, c, d)
+      return null;
+    }
+
+    const leadingIndent = ' '.repeat(node.parent.parent.loc.start.column);
+    const newDeclarations = Object.keys(destructuredPropertiesWithAliases)
+      .map(
+        (name) =>
+          `${declarationText} ${destructuredPropertiesWithAliases[name]} = ${objectText}.${name}`
+      )
+      .join(`;\n${leadingIndent}`);
+
+    return fixer.replaceTextRange([node.parent.parent.range[0], node.range[1]], newDeclarations);
+  }
+
+  const newProperties = propertyNames.map((name) => `${name}: ${objectText}.${name}`).join(', ');
+  return fixer.replaceText(node, `{ ${newProperties} }`);
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   ERROR_MESSAGE_GET,
@@ -269,7 +337,9 @@ module.exports = {
           validateGetPropertiesArguments(node.arguments, ignoreNestedPaths)
         ) {
           // Example: this.getProperties('foo', 'bar');
-          context.report({ node, message: ERROR_MESSAGE_GET_PROPERTIES });
+          const objectText = context.getSourceCode().getText(node.callee.object);
+          const properties = node.arguments;
+          reportGetProperties({ context, node, objectText, properties });
         }
 
         if (
@@ -279,7 +349,14 @@ module.exports = {
           validateGetPropertiesArguments(node.arguments.slice(1), ignoreNestedPaths)
         ) {
           // Example: getProperties(this, 'foo', 'bar');
-          context.report({ node, message: ERROR_MESSAGE_GET_PROPERTIES });
+          const objectText = context.getSourceCode().getText(node.arguments[0]);
+          const properties = node.arguments.slice(1);
+          reportGetProperties({
+            context,
+            node,
+            objectText,
+            properties,
+          });
         }
       },
     };

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -103,7 +103,7 @@ function reportGetProperties({ context, node, objectText, properties }) {
 }
 
 function fixGetProperties({ fixer, node, objectText, propertyNames }) {
-  if (!propertyNames.every((name) => isValidJSVariableName(name) || isValidJSArrayIndex(name))) {
+  if (!propertyNames.every((name) => isValidJSVariableName(name))) {
     // Do not autofix if any property is invalid.
     return null;
   }
@@ -112,36 +112,9 @@ function fixGetProperties({ fixer, node, objectText, propertyNames }) {
     // When destructuring assignment is in the left side of "=".
     // Example: const { foo, bar } = getProperties(this.obj, "foo", "bar");
     // Expectation:
-    // const foo = this.obj.foo;
-    // const bar = this.obj.bar;
+    // const const { foo, bar } = this.obj;
 
-    if (node.parent.parent.type !== 'VariableDeclaration' && !node.parent.parent.kind) {
-      // It has to start with a declaration text. e.g. "const", "let"
-      return null;
-    }
-    const declarationText = node.parent.parent.kind;
-
-    const destructuredPropertiesWithAliases = node.parent.id.properties.reduce((acc, property) => {
-      if (property?.key?.name) {
-        acc[property.key.name] = property.value.name; // eslint-disable-line no-param-reassign
-      }
-      return acc;
-    }, {});
-
-    if (Object.keys(destructuredPropertiesWithAliases).length !== propertyNames.length) {
-      // When a spread operator in the left side of an assignment. e.g. const { a, b, ...rest } = obj.getProperties(a, b, c, d)
-      return null;
-    }
-
-    const leadingIndent = ' '.repeat(node.parent.parent.loc.start.column);
-    const newDeclarations = Object.keys(destructuredPropertiesWithAliases)
-      .map(
-        (name) =>
-          `${declarationText} ${destructuredPropertiesWithAliases[name]} = ${objectText}.${name}`
-      )
-      .join(`;\n${leadingIndent}`);
-
-    return fixer.replaceTextRange([node.parent.parent.range[0], node.range[1]], newDeclarations);
+    return fixer.replaceText(node, `${objectText}`);
   }
 
   const newProperties = propertyNames.map((name) => `${name}: ${objectText}.${name}`).join(', ');

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -347,6 +347,11 @@ ruleTester.run('no-get', rule, {
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
     {
+      code: "const obj = this.getProperties('obj.foo');", // With invalid JS variable name.
+      output: null,
+      errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
+    },
+    {
       code: `
       import { getProperties } from '@ember/object';
       import { somethingElse } from '@ember/object';

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -337,6 +337,16 @@ ruleTester.run('no-get', rule, {
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
     {
+      code: "const obj = this.getProperties('1');", // With invalid JS variable name.
+      output: null,
+      errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
+    },
+    {
+      code: "const obj = this.getProperties('a*');", // With invalid JS variable name.
+      output: null,
+      errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
+    },
+    {
       code: `
       import { getProperties } from '@ember/object';
       import { somethingElse } from '@ember/object';
@@ -401,8 +411,7 @@ ruleTester.run('no-get', rule, {
       `,
       output: `
       import { getProperties } from '@ember/object';
-      const foo = this.obj.foo;
-      const bar = this.obj.bar;
+      const { foo, bar } = this.obj;
       `,
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
@@ -417,8 +426,7 @@ ruleTester.run('no-get', rule, {
       `,
       output: `
       import { getProperties } from '@ember/object';
-      const qux = this.obj.foo;
-      const bar = this.obj.bar;
+      const { foo: qux, bar } = this.obj;
       `,
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
@@ -433,7 +441,28 @@ ruleTester.run('no-get', rule, {
         "frex"
       );
       `,
-      output: null,
+      output: `
+      import { getProperties } from '@ember/object';
+      const { foo, bar, ...qux } = this.obj;
+      `,
+      errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
+    },
+    {
+      code: `
+      import { getProperties } from '@ember/object';
+
+      const { foo, bar, baz } = getProperties(
+        get(obj, 't.s'),
+        'foo',
+        'bar',
+        'baz',
+      );
+      `,
+      output: `
+      import { getProperties } from '@ember/object';
+
+      const { foo, bar, baz } = get(obj, 't.s');
+      `,
       errors: [{ message: ERROR_MESSAGE_GET_PROPERTIES, type: 'CallExpression' }],
     },
 


### PR DESCRIPTION
Fixes #1821
Add support for auto-fixing `getProperties` in no-get rule. 
Tests are added.