### PR TITLE
Clarify error message for `no-pause-test` rule

### DIFF
--- a/lib/rules/no-pause-test.js
+++ b/lib/rules/no-pause-test.js
@@ -4,7 +4,7 @@ const emberUtils = require('../utils/ember');
 const types = require('../utils/types');
 const { getImportIdentifier } = require('../utils/import');
 
-const ERROR_MESSAGE = 'Do not use `pauseTest()`';
+const ERROR_MESSAGE = 'Do not commit `pauseTest()`';
 
 //------------------------------------------------------------------------------
 // Rule Definition


### PR DESCRIPTION
The current message `Do not use pauseTest()` implies that  `pauseTest` should not be used - it is still (as far as I'm aware) a supported debugging tool. Could we make the messaging clearer?