### PR TITLE
#1784: Ensure super() called with args in init hook

### DIFF
--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -8,7 +8,7 @@
 
 Call super in lifecycle hooks.
 
-When overriding lifecycle hooks inside Ember Components, Controllers, Routes, Mixins, or Services, it is necessary to include a call to super.
+When overriding lifecycle hooks inside Ember Components, Controllers, Routes, Mixins, or Services, it is necessary to include a call to super. It is necessary to call the super.int() hook with arguments.
 
 ## Examples
 
@@ -20,7 +20,7 @@ import Component from '@ember/component';
 export default Component.extend({
   init() {
     this.set('items', []);
-  }
+  },
 });
 ```
 
@@ -30,7 +30,7 @@ import Component from '@ember/component';
 export default Component.extend({
   didInsertElement() {
     // ...
-  }
+  },
 });
 ```
 
@@ -53,7 +53,7 @@ export default Component.extend({
   init(...args) {
     this._super(...args);
     this.set('items', []);
-  }
+  },
 });
 ```
 
@@ -64,7 +64,7 @@ export default Component.extend({
   didInsertElement(...args) {
     this._super(...args);
     // ...
-  }
+  },
 });
 ```
 

--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -44,7 +44,8 @@ function isNativeSuper(node, hook) {
     types.isMemberExpression(node.callee) &&
     node.callee.object.type === 'Super' &&
     types.isIdentifier(node.callee.property) &&
-    node.callee.property.name === hook
+    node.callee.property.name === hook &&
+    (hook !== 'init' || node.arguments.length > 0)
   );
 }
 


### PR DESCRIPTION
Updated `require-super-in-lifecycle-hooks` rule to error when `init.super()` is called without `...arguments`.