### PR TITLE
Fix a bug in autofixer and autofix additional cases with `firstObject and `lastObject` in `no-get` rule

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -49,7 +49,13 @@ function fixGet({
   isInLeftSideOfAssignmentExpression,
   objectText,
 }) {
-  if (path.includes('.') && !useOptionalChaining && !isInLeftSideOfAssignmentExpression) {
+  const getResultIsChained = node.parent.type === 'MemberExpression' && node.parent.object === node;
+
+  // If the result of get is chained, we can safely autofix nests paths without using optional chaining.
+  // In the left side of an assignment, we can safely autofix nested paths without using optional chaining.
+  const shouldIgnoreOptionalChaining = getResultIsChained || isInLeftSideOfAssignmentExpression;
+
+  if (path.includes('.') && !useOptionalChaining && !shouldIgnoreOptionalChaining) {
     // Not safe to autofix nested properties because some properties in the path might be null or undefined.
     return null;
   }
@@ -59,18 +65,37 @@ function fixGet({
     return null;
   }
 
-  const getResultIsChained = node.parent.type === 'MemberExpression' && node.parent.object === node;
+  if (path.match(/lastObject/g)?.length > 1) {
+    // Do not autofix when multiple `lastObject` are chained.
+    return null;
+  }
 
-  // If the result of get is chained, we can safely autofix nests paths without using optional chaining.
-  // In the left side of an assignment, we can safely autofix nested paths without using optional chaining.
-  let replacementPath =
-    getResultIsChained || isInLeftSideOfAssignmentExpression ? path : path.replace(/\./g, '?.');
+  let replacementPath = shouldIgnoreOptionalChaining ? path : path.replace(/\./g, '?.');
 
   // Replace any array element access (foo.1 => foo[1] or foo?.[1]).
   replacementPath = replacementPath
-    .replace(/\.(\d+)/g, isInLeftSideOfAssignmentExpression ? '[$1]' : '.[$1]') // Usages in middle of path.
-    .replace(/^(\d+)\??\./, isInLeftSideOfAssignmentExpression ? '[$1].' : '[$1]?.') // Usage at beginning of path.
+    .replace(/\.(\d+)/g, shouldIgnoreOptionalChaining ? '[$1]' : '.[$1]') // Usages in middle of path.
+    .replace(/^(\d+)\??\./, shouldIgnoreOptionalChaining ? '[$1].' : '[$1]?.') // Usage at beginning of path.
     .replace(/^(\d+)$/, '[$1]'); // Usage as entire string.
+
+  // Replace any array element access using `firstObject` and `lastObject` (foo.firstObject => foo[0] or foo?.[0]).
+  replacementPath = replacementPath
+    .replace(/\.firstObject/g, shouldIgnoreOptionalChaining ? '[0]' : '.[0]') // When `firstObject` is used in the middle of the path. e.g. foo.firstObject
+    .replace(/^firstObject\??\./, shouldIgnoreOptionalChaining ? '[0].' : '[0]?.') // When `firstObject` is used at the beginning of the path. e.g. firstObject.bar
+    .replace(/^firstObject$/, '[0]') // When `firstObject` is used as the entire path.
+    .replace(
+      /\??\.lastObject/, // When `lastObject` is used in the middle of the path. e.g. foo.lastObject
+      (_, offset) =>
+        `${shouldIgnoreOptionalChaining ? '' : '?.'}[${objectText}.${replacementPath.slice(
+          0,
+          offset
+        )}.length - 1]`
+    )
+    .replace(
+      /^lastObject\??\./, // When `lastObject` is used at the beginning of the path. e.g. lastObject.bar
+      `[${objectText}.length - 1]${shouldIgnoreOptionalChaining ? '.' : '?.'}`
+    )
+    .replace(/^lastObject$/, `[${objectText}.length - 1]`); // When `lastObject` is used as the entire path.
 
   // Add parenthesis around the object text in case of something like this: get(foo || {}, 'bar')
   const objectTextSafe = isValidJSPath(objectText) ? objectText : `(${objectText})`;


### PR DESCRIPTION
This PR fixes 2 bugs on no-get rule:
* Fix this use case. When `useOptionalChaining: true`, `this.get('foo.0.bar')[123]` used to be autfixed to `this.foo.[0].bar[123]`.
* Fix #1835. `firstObject` and `lastObject` are autofixed now.