### PR TITLE
No-get  lastObject improvement

### DIFF
--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -49,7 +49,13 @@ function fixGet({
   isInLeftSideOfAssignmentExpression,
   objectText,
 }) {
-  if (path.includes('.') && !useOptionalChaining && !isInLeftSideOfAssignmentExpression) {
+  const getResultIsChained = node.parent.type === 'MemberExpression' && node.parent.object === node;
+
+  // If the result of get is chained, we can safely autofix nests paths without using optional chaining.
+  // In the left side of an assignment, we can safely autofix nested paths without using optional chaining.
+  const shouldIgnoreOptionalChaining = getResultIsChained || isInLeftSideOfAssignmentExpression;
+
+  if (path.includes('.') && !useOptionalChaining && !shouldIgnoreOptionalChaining) {
     // Not safe to autofix nested properties because some properties in the path might be null or undefined.
     return null;
   }
@@ -59,18 +65,37 @@ function fixGet({
     return null;
   }
 
-  const getResultIsChained = node.parent.type === 'MemberExpression' && node.parent.object === node;
+  if (path.match(/lastObject/g)?.length > 1) {
+    // Do not autofix when multiple `lastObject` are chained.
+    return null;
+  }
 
-  // If the result of get is chained, we can safely autofix nests paths without using optional chaining.
-  // In the left side of an assignment, we can safely autofix nested paths without using optional chaining.
-  let replacementPath =
-    getResultIsChained || isInLeftSideOfAssignmentExpression ? path : path.replace(/\./g, '?.');
+  let replacementPath = shouldIgnoreOptionalChaining ? path : path.replace(/\./g, '?.');
 
   // Replace any array element access (foo.1 => foo[1] or foo?.[1]).
   replacementPath = replacementPath
-    .replace(/\.(\d+)/g, isInLeftSideOfAssignmentExpression ? '[$1]' : '.[$1]') // Usages in middle of path.
-    .replace(/^(\d+)\??\./, isInLeftSideOfAssignmentExpression ? '[$1].' : '[$1]?.') // Usage at beginning of path.
+    .replace(/\.(\d+)/g, shouldIgnoreOptionalChaining ? '[$1]' : '.[$1]') // Usages in middle of path.
+    .replace(/^(\d+)\??\./, shouldIgnoreOptionalChaining ? '[$1].' : '[$1]?.') // Usage at beginning of path.
     .replace(/^(\d+)$/, '[$1]'); // Usage as entire string.
+
+  // Replace any array element access using `firstObject` and `lastObject` (foo.firstObject => foo[0] or foo?.[0]).
+  replacementPath = replacementPath
+    .replace(/\.firstObject/g, shouldIgnoreOptionalChaining ? '[0]' : '.[0]') // When `firstObject` is used in the middle of the path. e.g. foo.firstObject
+    .replace(/^firstObject\??\./, shouldIgnoreOptionalChaining ? '[0].' : '[0]?.') // When `firstObject` is used at the beginning of the path. e.g. firstObject.bar
+    .replace(/^firstObject$/, '[0]') // When `firstObject` is used as the entire path.
+    .replace(
+      /\??\.lastObject/, // When `lastObject` is used in the middle of the path. e.g. foo.lastObject
+      (_, offset) =>
+        `${shouldIgnoreOptionalChaining ? '' : '?.'}[${objectText}.${replacementPath.slice(
+          0,
+          offset
+        )}.length - 1]`
+    )
+    .replace(
+      /^lastObject\??\./, // When `lastObject` is used at the beginning of the path. e.g. lastObject.bar
+      `[${objectText}.length - 1]${shouldIgnoreOptionalChaining ? '.' : '?.'}`
+    )
+    .replace(/^lastObject$/, `[${objectText}.length - 1]`); // When `lastObject` is used as the entire path.
 
   // Add parenthesis around the object text in case of something like this: get(foo || {}, 'bar')
   const objectTextSafe = isValidJSPath(objectText) ? objectText : `(${objectText})`;

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -65,11 +65,6 @@ function fixGet({
     return null;
   }
 
-  if (path.match(/lastObject/g)?.length > 1) {
-    // Do not autofix when multiple `lastObject` are chained.
-    return null;
-  }
-
   let replacementPath = shouldIgnoreOptionalChaining ? path : path.replace(/\./g, '?.');
 
   // Replace any array element access (foo.1 => foo[1] or foo?.[1]).
@@ -83,19 +78,7 @@ function fixGet({
     .replace(/\.firstObject/g, shouldIgnoreOptionalChaining ? '[0]' : '.[0]') // When `firstObject` is used in the middle of the path. e.g. foo.firstObject
     .replace(/^firstObject\??\./, shouldIgnoreOptionalChaining ? '[0].' : '[0]?.') // When `firstObject` is used at the beginning of the path. e.g. firstObject.bar
     .replace(/^firstObject$/, '[0]') // When `firstObject` is used as the entire path.
-    .replace(
-      /\??\.lastObject/, // When `lastObject` is used in the middle of the path. e.g. foo.lastObject
-      (_, offset) =>
-        `${shouldIgnoreOptionalChaining ? '' : '?.'}[${objectText}.${replacementPath.slice(
-          0,
-          offset
-        )}.length - 1]`
-    )
-    .replace(
-      /^lastObject\??\./, // When `lastObject` is used at the beginning of the path. e.g. lastObject.bar
-      `[${objectText}.length - 1]${shouldIgnoreOptionalChaining ? '.' : '?.'}`
-    )
-    .replace(/^lastObject$/, `[${objectText}.length - 1]`); // When `lastObject` is used as the entire path.
+    .replace(/lastObject/g, 'at(-1)');
 
   // Add parenthesis around the object text in case of something like this: get(foo || {}, 'bar')
   const objectTextSafe = isValidJSPath(objectText) ? objectText : `(${objectText})`;

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -702,6 +702,19 @@ ruleTester.run('no-get', rule, {
       ],
     },
     {
+      // `firstObject` used in multiple places in a path.
+      // And the result of get() is chained (getResultIsChained=true).
+      code: "this.get('firstObject.foo.firstObject.bar')[123];",
+      output: 'this[0].foo[0].bar[123];',
+      options: [{ useOptionalChaining: true }],
+      errors: [
+        {
+          message: ERROR_MESSAGE_GET,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
       // `firstObject` used in the middle of a path.
       // And the resolved path of `get` is NOT chained (getResultIsChained=false).
       code: "this.get('foo.firstObject.bar');",
@@ -757,7 +770,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used in the middle of a path.
       // And the result of get() is chained (getResultIsChained=true).
       code: "this.get('foo.lastObject.bar')[123];",
-      output: 'this.foo[this.foo.length - 1].bar[123];',
+      output: 'this.foo.at(-1).bar[123];',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -770,7 +783,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used at the beginning of a path.
       // And the result of get() is chained (getResultIsChained=true).
       code: "this.get('lastObject.bar')[123];",
-      output: 'this[this.length - 1].bar[123];',
+      output: 'this.at(-1).bar[123];',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -783,7 +796,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used as the entire path.
       // And the result of get() is chained (getResultIsChained=true).
       code: "this.get('lastObject')[123];",
-      output: 'this[this.length - 1][123];',
+      output: 'this.at(-1)[123];',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -796,7 +809,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used in the middle of a path.
       // And the resolved path of `get` is NOT chained (getResultIsChained=false).
       code: "this.get('foo.lastObject.bar');",
-      output: 'this.foo?.[this.foo.length - 1]?.bar;',
+      output: 'this.foo?.at(-1)?.bar;',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -809,7 +822,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used at the beginning of a path.
       // And the resolved path of `get` is NOT chained (getResultIsChained=false).
       code: "this.get('lastObject.bar');",
-      output: 'this[this.length - 1]?.bar;',
+      output: 'this.at(-1)?.bar;',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -820,9 +833,8 @@ ruleTester.run('no-get', rule, {
     },
     {
       // `lastObject` used in the middle of a path.
-      // When multiple `lastObject` are chained, it won't auto-fix.
       code: "this.get('foo.lastObject.bar.lastObject')[123];",
-      output: null,
+      output: 'this.foo.at(-1).bar.at(-1)[123];',
       options: [{ useOptionalChaining: true }],
       errors: [
         {
@@ -835,7 +847,7 @@ ruleTester.run('no-get', rule, {
       // `lastObject` used at the beginning of a path.
       // And the result of get() is chained (getResultIsChained=true).
       code: "this.get('lastObject.bar.lastObject')[123];",
-      output: null,
+      output: 'this.at(-1).bar.at(-1)[123];',
       options: [{ useOptionalChaining: true }],
       errors: [
         {


### PR DESCRIPTION
`.lastObject` autofix rule can be simplified as `.lastObject` ==> `.at(-1)`. 
We can lift the limit of handling only one `.lastObject` in path as well.