### PR TITLE
[Docs] Use js syntax highlighting for no-empty-glimmer-component-classes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,5 @@ coverage/
 node_modules
 lib/recommended-rules.js
 
-// Contains <template> in js markdown
+# Contains <template> in js markdown
 docs/rules/no-empty-glimmer-component-classes.md

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,6 @@
 coverage/
 node_modules
 lib/recommended-rules.js
+
+// Contains <template> in js markdown
+docs/rules/no-empty-glimmer-component-classes.md

--- a/docs/rules/no-empty-glimmer-component-classes.md
+++ b/docs/rules/no-empty-glimmer-component-classes.md
@@ -26,8 +26,7 @@ import Component from '@glimmer/component';
 class MyComponent extends Component {}
 ```
 
-<!-- markdownlint-disable-next-line MD040 -->
-```
+```js
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
@@ -63,8 +62,7 @@ import MyDecorator from 'my-decorator';
 class MyComponent extends Component {}
 ```
 
-<!-- markdownlint-disable-next-line MD040 -->
-```
+```js
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {


### PR DESCRIPTION
- Fix the docs in `no-empty-glimmer-component-classes` to use `js` in the markdown code blocks for syntax highlighting 
- Ignore file from eslint since it cannot parse the `<template>` from `gjs` from [ember-template-imports](https://github.com/ember-template-imports/ember-template-imports)
