### PR TITLE
Avoid crash with `inject` decorator in `no-restricted-service-injections` rule

### DIFF
--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -101,7 +101,9 @@ module.exports = {
       }
 
       // Find the service decorator.
-      const serviceDecorator = decoratorUtils.findDecorator(node, 'service');
+      const serviceDecorator =
+        decoratorUtils.findDecorator(node, 'service') ||
+        decoratorUtils.findDecorator(node, 'inject');
 
       // Get the service name either from the string argument or from the property name.
       const serviceName =


### PR DESCRIPTION
Crash detected by:
* https://github.com/ember-cli/eslint-plugin-ember/pull/1741

```
Rule: "ember/no-restricted-service-injections"
Path: emberjs/data/tests/main/app/routes/application.ts
Link: https://github.com/emberjs/data/blob/HEAD/tests/main/app/routes/application.ts#L7

   5 |
   6 | export default class ApplicationRoute extends Route {
>  7 |   @inject declare store: Store;
   8 |
   9 |   model() {
  10 |     // adding a model to the store to enable manually testing the debug-adapter

Error:
TypeError: Cannot read property 'expression' of undefined
Occurred while linting /home/runner/work/eslint-plugin-ember/eslint-plugin-ember/node_modules/eslint-remote-tester/.cache-eslint-remote-tester/emberjs/data/tests/main/app/routes/application.ts:7
```

Related:
* https://github.com/ember-cli/eslint-plugin-ember/pull/1731