### PR TITLE
Fix crash with default computed property import in `no-unused-services` rule

### DIFF
--- a/lib/rules/no-unused-services.js
+++ b/lib/rules/no-unused-services.js
@@ -130,6 +130,9 @@ module.exports = {
         }
         if (node.source.value === '@ember/object/computed') {
           for (const spec of node.specifiers) {
+            if (spec.type === 'ImportDefaultSpecifier') {
+              continue;
+            }
             const name = spec.imported.name;
             if (macros.includes(name)) {
               const localName = spec.local.name;

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -187,6 +187,7 @@ ruleTester.run('no-unused-services', rule, {
     `${SERVICE_IMPORT} class MyClass {}`,
     `${SERVICE_IMPORT} Component.extend({});`,
     'const foo = service();',
+    "import ComputedProperty from '@ember/object/computed';",
   ],
   invalid: [
     {


### PR DESCRIPTION
Crash detected by:

* https://github.com/ember-cli/eslint-plugin-ember/pull/1741

```
Rule: "ember/no-unused-services"
Path: emberjs/data/@types/@ember/array/-private/enumerable.d.ts
Link: https://github.com/emberjs/data/blob/HEAD/@types/@ember/array/-private/enumerable.d.ts#L2

  1 | import type NativeArray from '@ember/array/-private/native-array';
> 2 | import type ComputedProperty from '@ember/object/computed';
  3 | import type Mixin from '@ember/object/mixin';
  4 | /**
  5 |  * This mixin defines the common interface implemented by enumerable objects

Error:
TypeError: Cannot read property 'name' of undefined
Occurred while linting /home/runner/work/eslint-plugin-ember/eslint-plugin-ember/node_modules/eslint-remote-tester/.cache-eslint-remote-tester/emberjs/data/@types/@ember/array/-private/enumerable.d.ts:2
Rule: "ember/no-unused-services"
    at ImportDeclaration (/home/runner/work/eslint-plugin-ember/eslint-plugin-ember/lib/rules/no-unused-services.js:133:40)
```