### PR TITLE
Avoid further decorator detection crashes in `no-restricted-service-injections` rule

### DIFF
--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -103,7 +103,13 @@ module.exports = {
       // Find the service decorator.
       const serviceDecorator =
         decoratorUtils.findDecorator(node, 'service') ||
-        decoratorUtils.findDecorator(node, 'inject');
+        decoratorUtils.findDecorator(node, 'inject') ||
+        decoratorUtils.findDecorator(node, 'Ember.inject.service');
+
+      if (!serviceDecorator) {
+        // TODO: emberUtils.isInjectedServiceProp() must have detected an injection that findDecorator() didn't.
+        return;
+      }
 
       // Get the service name either from the string argument or from the property name.
       const serviceName =

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -84,6 +84,13 @@ ruleTester.run('no-restricted-service-injections', rule, {
       code: `${SERVICE_IMPORT} Component.extend({ myService: service(SOME_VARIABLE) })`,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
     },
+    {
+      // TODO: This should be invalid. With `inject.service` decorator.
+      filename: 'app/components/path.js',
+      code: `${INJECT_IMPORT} class MyComponent extends Component { @inject.service('myService') randomName }`,
+      output: null,
+      options: [{ paths: ['app/components'], services: ['my-service'] }],
+    },
   ],
   invalid: [
     {
@@ -156,7 +163,7 @@ ruleTester.run('no-restricted-service-injections', rule, {
       ],
     },
     {
-      // With decorator with camelized service name argument:
+      // With decorator with camelized service name argument (inject):
       filename: 'app/components/path.js',
       code: `${INJECT_IMPORT} class MyComponent extends Component { @inject('myService') randomName }`,
       output: null,
@@ -211,6 +218,19 @@ ruleTester.run('no-restricted-service-injections', rule, {
       // With decorator without service name argument (with parentheses) (with property name as string literal):
       filename: 'app/components/path.js',
       code: `${SERVICE_IMPORT} class MyComponent extends Component { @service() 'myService' }`,
+      output: null,
+      options: [{ paths: ['app/components'], services: ['my-service'] }],
+      errors: [
+        {
+          message: DEFAULT_ERROR_MESSAGE,
+          // type could be ClassProperty (ESLint v7) or PropertyDefinition (ESLint v8)
+        },
+      ],
+    },
+    {
+      // With chained decorator
+      filename: 'app/components/path.js',
+      code: `${EMBER_IMPORT} class MyComponent extends Component { @Ember.inject.service('myService') randomName }`,
       output: null,
       options: [{ paths: ['app/components'], services: ['my-service'] }],
       errors: [


### PR DESCRIPTION

Follow-up to:
* #1869