### PR TITLE
Allow generic type in TypeScript class in `no-empty-glimmer-component-classes` rule

### DIFF
--- a/docs/rules/no-empty-glimmer-component-classes.md
+++ b/docs/rules/no-empty-glimmer-component-classes.md
@@ -8,7 +8,7 @@ This rule will catch and prevent the use of empty backing classes for Glimmer co
 
 ## Rule Details
 
-This rule aims to disallow the use of empty backing classes for Glimmer components when possible including only using ember template tags in your Glimmer component. Template-only Glimmer components where there is no backing class are much faster and lighter-weight than Glimmer components with backing classes, which are much lighter-weight than Ember components. Therefore, you should only have a backing class for a Glimmer component when absolutely necessary.
+This rule aims to disallow the use of empty backing classes for Glimmer components when possible including only using ember template tags in your Glimmer component. Template-only Glimmer components where there is no backing class are much faster and lighter-weight than Glimmer components with backing classes, which are much lighter-weight than Ember components. Therefore, you should only have a backing class for a Glimmer component when absolutely necessary. An exception to this case is if you need the component to be generic over part of its type signature.
 
 To fix violations of this rule:
 
@@ -32,6 +32,14 @@ import Component from '@glimmer/component';
 export default class MyComponent extends Component {
   <template>Hello World!</template>
 }
+```
+
+```ts
+import Component from '@glimmer/component';
+
+export interface TypeSig {}
+
+export default class MyComponent extends Component<TypeSig> {}
 ```
 
 Examples of **correct** code for this rule:
@@ -72,6 +80,15 @@ export default class MyComponent extends Component {
 
   <template>Hello World!</template>
 }
+```
+
+```ts
+import Component from '@glimmer/component';
+
+export interface SomeSig {}
+export interface SomeOtherSig {}
+
+export default class MyComponent<SomeSig> extends Component<SomeOtherSig> {}
 ```
 
 ## References

--- a/lib/rules/no-empty-glimmer-component-classes.js
+++ b/lib/rules/no-empty-glimmer-component-classes.js
@@ -31,14 +31,18 @@ module.exports = {
   create(context) {
     return {
       ClassDeclaration(node) {
-        const nodeIsGlimmerComponent = isGlimmerComponent(context, node);
-        if (nodeIsGlimmerComponent && !node.decorators && node.body.body.length === 0) {
+        if (!isGlimmerComponent(context, node)) {
+          return;
+        }
+
+        const subClassHasTypeDefinition = node.typeParameters?.params?.length > 0;
+        if (!node.decorators && node.body.body.length === 0 && !subClassHasTypeDefinition) {
           context.report({ node, message: ERROR_MESSAGE });
         } else if (
-          nodeIsGlimmerComponent &&
           node.body.body.length === 1 &&
           isClassPropertyOrPropertyDefinition(node.body.body[0]) &&
-          node.body.body[0].key?.callee?.name === '__GLIMMER_TEMPLATE'
+          node.body.body[0].key?.callee?.name === '__GLIMMER_TEMPLATE' &&
+          !subClassHasTypeDefinition
         ) {
           context.report({ node, message: ERROR_MESSAGE_TEMPLATE_TAG });
         }

--- a/tests/lib/rules/no-empty-glimmer-component-classes.js
+++ b/tests/lib/rules/no-empty-glimmer-component-classes.js
@@ -34,6 +34,34 @@ ruleTester.run('no-empty-glimmer-component-classes', rule, {
 
     @MyDecorator
     class MyComponent extends Component {}`,
+    {
+      code: `
+      import Component from '@glimmer/component';
+
+      interface ListSignature<T> {
+        Args: {
+          items: Array<T>;
+        };
+        Blocks: {
+          default: [item: T]
+        };
+      }
+
+      export default class List<T> extends Component<ListSignature<T>> {}
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
+    {
+      code: `
+        import Component from '@glimmer/component';
+
+        export interface SomeSig {}
+        export interface SomeOtherSig {}
+
+        export default class MyComponent<SomeSig> extends Component<SomeOtherSig> {}
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   invalid: [
     {
@@ -48,6 +76,18 @@ ruleTester.run('no-empty-glimmer-component-classes', rule, {
 
       class MyComponent extends Component { /* foo */ }`,
       output: null,
+      errors: [{ message: ERROR_MESSAGE, type: 'ClassDeclaration' }],
+    },
+    {
+      code: `
+      import Component from '@glimmer/component';
+
+      export interface TypeSig {}
+
+      export default class MyComponent extends Component<TypeSig> {}
+      `,
+      output: null,
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{ message: ERROR_MESSAGE, type: 'ClassDeclaration' }],
     },
   ],


### PR DESCRIPTION
- This fixes the issue brought up here https://github.com/ember-cli/eslint-plugin-ember/pull/1866#issuecomment-1558014631
- Made updates to `initESLint` within `tests/lib/rules-preprocessor/gjs-gts-processor-test.js` to allow for a custom parser so that it can handle `.gts` files too
- Note if you are only adding a type to the component class not the subclass then you must use `templateOnlyComponent` from `@ember/component/template-only` see https://typed-ember.gitbook.io/glint/environments/ember/template-only-components