### PR TITLE
[no-empty-glimmer-component-classes] Import the template tag value instead of hardcode

### DIFF
--- a/lib/rules/no-empty-glimmer-component-classes.js
+++ b/lib/rules/no-empty-glimmer-component-classes.js
@@ -2,6 +2,7 @@
 
 const { isGlimmerComponent } = require('../utils/ember');
 const { isClassPropertyOrPropertyDefinition } = require('../utils/types');
+const { TEMPLATE_TAG_PLACEHOLDER } = require('ember-template-imports/src/util');
 
 const ERROR_MESSAGE = 'Do not create empty backing classes for Glimmer components.';
 const ERROR_MESSAGE_TEMPLATE_TAG =
@@ -41,7 +42,7 @@ module.exports = {
         } else if (
           node.body.body.length === 1 &&
           isClassPropertyOrPropertyDefinition(node.body.body[0]) &&
-          node.body.body[0].key?.callee?.name === '__GLIMMER_TEMPLATE' &&
+          node.body.body[0].key?.callee?.name === TEMPLATE_TAG_PLACEHOLDER &&
           !subClassHasTypeDefinition
         ) {
           context.report({ node, message: ERROR_MESSAGE_TEMPLATE_TAG });


### PR DESCRIPTION
Noticed I hardcoded the value instead of importing it