### PR TITLE
Remove `routes-segments-snake-case` as a recommended rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ module.exports = {
 | [no-unnecessary-index-route](docs/rules/no-unnecessary-index-route.md)             | disallow unnecessary `index` route definition                                            |    |    |    |
 | [no-unnecessary-route-path-option](docs/rules/no-unnecessary-route-path-option.md) | disallow unnecessary usage of the route `path` option                                    | ✅  | 🔧 |    |
 | [route-path-style](docs/rules/route-path-style.md)                                 | enforce usage of kebab-case (instead of snake_case or camelCase) in route paths          |    |    | 💡 |
-| [routes-segments-snake-case](docs/rules/routes-segments-snake-case.md)             | enforce usage of snake_cased dynamic segments in routes                                  | ✅  |    |    |
+| [routes-segments-snake-case](docs/rules/routes-segments-snake-case.md)             | enforce usage of snake_cased dynamic segments in routes                                  |    |    |    |
 
 ### Services
 

--- a/docs/rules/routes-segments-snake-case.md
+++ b/docs/rules/routes-segments-snake-case.md
@@ -1,7 +1,5 @@
 # ember/routes-segments-snake-case
 
-💼 This rule is enabled in the ✅ `recommended` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
-
 <!-- end auto-generated rule header -->
 
 Dynamic segments in routes should use _snake case_, so Ember doesn't have to do extra serialization in order to resolve promises.

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -67,7 +67,6 @@ module.exports = {
   "ember/require-super-in-lifecycle-hooks": "error",
   "ember/require-tagless-components": "error",
   "ember/require-valid-css-selector-in-test-helpers": "error",
-  "ember/routes-segments-snake-case": "error",
   "ember/use-brace-expansion": "error",
   "ember/use-ember-data-rfc-395-imports": "error"
 }

--- a/lib/rules/routes-segments-snake-case.js
+++ b/lib/rules/routes-segments-snake-case.js
@@ -20,7 +20,7 @@ module.exports = {
     docs: {
       description: 'enforce usage of snake_cased dynamic segments in routes',
       category: 'Routes',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/routes-segments-snake-case.md',
     },
     fixable: null,

--- a/tests/__snapshots__/recommended.js.snap
+++ b/tests/__snapshots__/recommended.js.snap
@@ -64,7 +64,6 @@ exports[`recommended rules has the right list 1`] = `
   "require-super-in-lifecycle-hooks",
   "require-tagless-components",
   "require-valid-css-selector-in-test-helpers",
-  "routes-segments-snake-case",
   "use-brace-expansion",
   "use-ember-data-rfc-395-imports",
 ]


### PR DESCRIPTION
Using implicit `model` hooks is deprecated as of Ember v5.3:
https://deprecations.emberjs.com/v5.x#toc_deprecate-implicit-route-model

This means we can remove the `routes-segments-snake-case` rule from the recommended set.
Users will have to manually define the `model` hook themselves to resolve the deprecation, so enforcing snake_case should not be necessary anymore.