### PR TITLE
Change `useAt` option default to `true` at in `no-get` rule

### DIFF
--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -95,7 +95,7 @@ This rule takes an optional object containing:
 
 - `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
 - `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`) (default `false`)
-- `boolean` -- `useAt` -- whether the rule should use `at(-1)` [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) to replace `lastObject` (default `false`) (TODO: enable by default once we require Node 16.6)
+- `boolean` -- `useAt` -- whether the rule should use `at(-1)` [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) to replace `lastObject` (default `true`)
 - `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `true`)
 - `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `get(foo, 'bar')` (default `true`)
 - `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -190,7 +190,7 @@ module.exports = {
           },
           useAt: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -788,6 +788,20 @@ ruleTester.run('no-get', rule, {
       ],
     },
     {
+      // useAt default value
+      // `lastObject` used at the beginning of a path.
+      // And the result of get() is chained (getResultIsChained=true).
+      code: "this.get('lastObject.bar')[123];",
+      output: 'this.at(-1).bar[123];',
+      options: [{ useOptionalChaining: true }],
+      errors: [
+        {
+          message: ERROR_MESSAGE_GET,
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
       // `lastObject` used at the beginning of a path.
       // And the result of get() is chained (getResultIsChained=true).
       code: "this.get('lastObject.bar')[123];",


### PR DESCRIPTION
Option was originally added here: https://github.com/ember-cli/eslint-plugin-ember/pull/1847

`at` is now supported by all our Node versions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at