### PR TITLE
Automatically generate README configs list with eslint-doc-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,16 @@ module.exports = {
 
 ## 🧰 Configurations
 
-|    | Name | Description |
-|:---|:-----|:------------|
-| ✅ | [recommended](./lib/recommended-rules.js) | enables the `recommended` rules |
+<!-- begin auto-generated configs list -->
+
+|    | Name          |
+| :- | :------------ |
+| ✅  | `recommended` |
+
+<!-- end auto-generated configs list -->
 
 ## 🍟 Rules
+
 <!-- begin auto-generated rules list -->
 
 💼 [Configurations](https://github.com/ember-cli/eslint-plugin-ember#-configurations) enabled in.\

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@typescript-eslint/parser": "^5.31.0",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^1.0.0",
+    "eslint-doc-generator": "^1.5.2",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^5.0.1",
     "eslint-plugin-filenames": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,10 +3002,10 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
   integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
 
-eslint-doc-generator@^1.0.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-1.4.3.tgz#78fbb59fc0182501cb562a185832319062903020"
-  integrity sha512-cn9KXE7xuKlxKi/9VbirR3cbz7W1geRObwWzZjJAnpTeNBoqA8Rj+lD8/HHHJ7PnOdaTrRyhhoYdCtxqq3U7Bw==
+eslint-doc-generator@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-1.5.2.tgz#4ea1c8124404ecf1ea1c10a8482ee19870468ad0"
+  integrity sha512-j+eTFcOlaKZE7h/xoQeshjzBZCW7hwKzLsS1vKsop0jfOVXIqd9uXaHXe9lCQYH4v8vGSQqaKxxrou7t22rrIg==
   dependencies:
     "@typescript-eslint/utils" "^5.38.1"
     ajv "^8.11.2"


### PR DESCRIPTION
Useful especially in case there are additional configs in the future. We can optionally export a `description` property from a config resulting in a "Description" column getting added to this list.