### PR TITLE
Drop support for ESLint 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,3 @@ jobs:
     - run: yarn update && git diff --exit-code
 
     - run: yarn test:coverage --runInBand
-
-    - run: yarn add --dev eslint@7 && yarn test --runInBand

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## ❗️Requirements
 
-- [ESLint](https://eslint.org/) `>= 7`
+- [ESLint](https://eslint.org/) `>= 8`
 - [Node.js](https://nodejs.org/) `18.* || 20.* || >= 21`
 
 ## 🚀 Usage

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "eslint": ">= 7"
+    "eslint": ">= 8"
   },
   "engines": {
     "node": "18.* || 20.* || >= 21"


### PR DESCRIPTION
ESLint v8 has been [out](https://eslint.org/blog/2021/10/eslint-v8.0.0-released/) for two years (since Oct 2021).

The ember-cli blueprint has also been using ESLint v8 since earlier this year:
* https://github.com/ember-cli/ember-cli/pull/10142
* https://github.com/ember-cli/ember-cli/releases/tag/v4.12.0