### PR TITLE
Add automatic rule option lists with eslint-doc-generator

### DIFF
--- a/docs/rules/_TEMPLATE_.md
+++ b/docs/rules/_TEMPLATE_.md
@@ -41,11 +41,10 @@ TODO: suggest any fast/automated techniques for fixing violations in a large cod
 
 ## Configuration
 
-TODO: exclude this section if the rule has no extra configuration
-
-- object -- containing the following properties:
-  - string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  - boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+<!-- begin auto-generated rule options list -->
+TODO: exclude this section if the rule has no extra configuration.
+TODO: ensure `meta.schema` contains descriptions, constraints, defaults, etc for all options.
+<!-- end auto-generated rule options list -->
 
 ## Related Rules
 

--- a/docs/rules/named-functions-in-promises.md
+++ b/docs/rules/named-functions-in-promises.md
@@ -67,6 +67,10 @@ test('it reloads user in promise handler', function (assert) {
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `allowSimpleArrowFunction` -- (default false) setting to `true` allows arrow function expressions that do not have block bodies. These simple arrow functions must also only contain a single function call. For example: `.then(user => this._reloadUser(user))`.
+| Name                       | Description                                                                                                                                                                                                 | Type    | Default |
+| :------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `allowSimpleArrowFunction` | Enabling allows arrow function expressions that do not have block bodies. These simple arrow functions must also only contain a single function call. For example: `.then(user => this._reloadUser(user))`. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->

--- a/docs/rules/no-arrow-function-computed-properties.md
+++ b/docs/rules/no-arrow-function-computed-properties.md
@@ -38,9 +38,13 @@ const Person = EmberObject.extend({
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `onlyThisContexts` -- whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference (default: `false`)
+| Name               | Description                                                                                                                      | Type    | Default |
+| :----------------- | :------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `onlyThisContexts` | Whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/no-classic-classes.md
+++ b/docs/rules/no-classic-classes.md
@@ -49,9 +49,13 @@ export default class MyComponent extends Component.extend(Evented) {}
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `string[]` -- `additionalClassImports` -- Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`.
+| Name                     | Description                                                                                                                                                                                                        | Type     |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| `additionalClassImports` | Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`. | String[] |
+
+<!-- end auto-generated rule options list -->
 
 ## When Not To Use It
 

--- a/docs/rules/no-computed-properties-in-native-classes.md
+++ b/docs/rules/no-computed-properties-in-native-classes.md
@@ -68,9 +68,13 @@ export default class MyComponent extends Component {}
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `ignoreClassic` -- whether the rule should ignore usage inside of native classes labeled with `@classic` (default `true`)
+| Name            | Description                                                                            | Type    | Default |
+| :-------------- | :------------------------------------------------------------------------------------- | :------ | :------ |
+| `ignoreClassic` | Whether the rule should ignore usage inside of native classes labeled with `@classic`. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/no-controller-access-in-routes.md
+++ b/docs/rules/no-controller-access-in-routes.md
@@ -66,5 +66,10 @@ export default class MyRoute extends Route {
 
 ## Configuration
 
-- object -- containing the following properties:
-  - boolean -- `allowControllerFor` -- whether the rule should allow or disallow routes from accessing the controller outside of `setupController`/`resetController` via `controllerFor` (default: `false`)
+<!-- begin auto-generated rule options list -->
+
+| Name                 | Description                                                                                                                                        | Type    | Default |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `allowControllerFor` | Whether the rule should allow or disallow routes from accessing the controller outside of `setupController`/`resetController` via `controllerFor`. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->

--- a/docs/rules/no-get-with-default.md
+++ b/docs/rules/no-get-with-default.md
@@ -44,10 +44,14 @@ const test = this.key || [];
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `getWithDefault(person, 'name', '')` (default `true`)
-- `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `person.getWithDefault('name', '')` even though we don't know for sure if `person` is an Ember object (default `true`)
+| Name                 | Description                                                                                                                                                 | Type    | Default |
+| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `catchSafeObjects`   | Whether the rule should catch non-`this` imported usages like `getWithDefault(person, 'name', '')`.                                                         | Boolean | `true`  |
+| `catchUnsafeObjects` | Whether the rule should catch non-`this` usages like `person.getWithDefault('name', '')` even though we don't know for sure if `person` is an Ember object. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/no-get.md
+++ b/docs/rules/no-get.md
@@ -91,14 +91,18 @@ export default EmberObject.extend({
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `ignoreGetProperties` -- whether the rule should ignore `getProperties` (default `false`)
-- `boolean` -- `ignoreNestedPaths` -- whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`) (default `false`)
-- `boolean` -- `useAt` -- whether the rule should use `at(-1)` [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) to replace `lastObject` (default `true`)
-- `boolean` -- `useOptionalChaining` -- whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all) (default `true`)
-- `boolean` -- `catchSafeObjects` -- whether the rule should catch non-`this` imported usages like `get(foo, 'bar')` (default `true`)
-- `boolean` -- `catchUnsafeObjects` -- whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object (default `false`)
+| Name                  | Description                                                                                                                                                                                                                                                                                                                                   | Type    | Default |
+| :-------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `catchSafeObjects`    | Whether the rule should catch non-`this` imported usages like `get(foo, 'bar')`.                                                                                                                                                                                                                                                              | Boolean | `true`  |
+| `catchUnsafeObjects`  | Whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object.                                                                                                                                                                                                         | Boolean | `false` |
+| `ignoreGetProperties` | Whether the rule should ignore `getProperties`.                                                                                                                                                                                                                                                                                               | Boolean | `false` |
+| `ignoreNestedPaths`   | Whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`).                                                                                                                                                                                                               | Boolean | `false` |
+| `useAt`               | Whether the rule should use `at(-1)` [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) to replace `lastObject`.                                                                                                                                                               | Boolean | `true`  |
+| `useOptionalChaining` | Whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all). | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## Related Rules
 

--- a/docs/rules/no-private-routing-service.md
+++ b/docs/rules/no-private-routing-service.md
@@ -83,10 +83,14 @@ export default class MyComponent extends Component {
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `catchRouterMicrolib` -- whether the rule should catch usages of the private property `_routerMicrolib` (default `true`)
-- `boolean` -- `catchRouterMain` -- whether the rule should catch usages of the private property `router:main` (default `true`)
+| Name                  | Description                                                                     | Type    | Default |
+| :-------------------- | :------------------------------------------------------------------------------ | :------ | :------ |
+| `catchRouterMain`     | Whether the rule should catch usages of the private property `router:main`.     | Boolean | `true`  |
+| `catchRouterMicrolib` | Whether the rule should catch usages of the private property `_routerMicrolib`. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/no-restricted-property-modifications.md
+++ b/docs/rules/no-restricted-property-modifications.md
@@ -56,7 +56,12 @@ export default class MyComponent extends Component {
 
 ## Configuration
 
-- object -- containing the following properties:
-  - `String[]` -- `properties` -- array of names of properties that should not be modified (modifying child/nested/sub-properties of these is also not allowed)
+<!-- begin auto-generated rule options list -->
+
+| Name         | Description                                                                                                                    | Type     | Required |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------- | :------- | :------- |
+| `properties` | Array of names of properties that should not be modified (modifying child/nested/sub-properties of these is also not allowed). | String[] | Yes      |
+
+<!-- end auto-generated rule options list -->
 
 Not yet implemented: There is currently no way to configure whether sub-properties are restricted from modification. To make this configurable, the `properties` array option could be updated to also accept objects of the form `{ name: 'myPropertyName', includeSubProperties: false }` where `includeSubProperties` defaults to `true`.

--- a/docs/rules/no-restricted-service-injections.md
+++ b/docs/rules/no-restricted-service-injections.md
@@ -45,10 +45,17 @@ class MyComponent extends Component {
 
 ## Configuration
 
-- object[] -- containing the following properties:
-  - string[] -- `services` -- list of (kebab-case) service names that should be disallowed from being injected under the specified paths
-  - string[] -- `paths` -- optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path) (for glob patterns, use [ESLint `overrides`](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead)
-  - string -- `message` -- optional custom error message to display for violations
+Accepts an array of the objects with the following options:
+
+<!-- begin auto-generated rule options list -->
+
+| Name       | Description                                                                                                                                                                                                                                                                                                    | Type     | Required |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- |
+| `message`  | Optional custom error message to display for violations.                                                                                                                                                                                                                                                       | String   |          |
+| `paths`    | Optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path) (for glob patterns, use [ESLint `overrides`](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead). | String[] |          |
+| `services` | List of (kebab-case) service names that should be disallowed from being injected under the specified paths.                                                                                                                                                                                                    | String[] | Yes      |
+
+<!-- end auto-generated rule options list -->
 
 ## Related Rules
 

--- a/docs/rules/no-runloop.md
+++ b/docs/rules/no-runloop.md
@@ -58,7 +58,13 @@ export default class MyComponent extends Component {
 
 ## Configuration
 
-If you have `@ember/runloop` functions that you wish to allow, you can configure this rule to allow specific methods. The configuration takes an object with the `allowList` property, which is an array of strings where the strings must be names of runloop functions.
+<!-- begin auto-generated rule options list -->
+
+| Name        | Description                                                                                                                                                                                                                                                               | Type     |
+| :---------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- |
+| `allowList` | If you have `@ember/runloop` functions that you wish to allow, you can configure this rule to allow specific methods. The configuration takes an object with the `allowList` property, which is an array of strings where the strings must be names of runloop functions. | String[] |
+
+<!-- end auto-generated rule options list -->
 
 ```js
 module.exports = {

--- a/docs/rules/no-side-effects.md
+++ b/docs/rules/no-side-effects.md
@@ -46,7 +46,11 @@ export default Component.extend({
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `true`)
-- `boolean` -- `checkPlainGetters` -- whether the rule should check plain (non-computed) getters in native classes for side effects (default `true`)
+| Name                | Description                                                                                    | Type    | Default |
+| :------------------ | :--------------------------------------------------------------------------------------------- | :------ | :------ |
+| `catchEvents`       | Whether the rule should catch function calls that send actions or events.                      | Boolean | `true`  |
+| `checkPlainGetters` | Whether the rule should check plain (non-computed) getters in native classes for side effects. | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -8,6 +8,14 @@ Note: this rule will not be added to the `recommended` configuration because it 
 
 ## Configuration
 
+<!-- begin auto-generated rule options list -->
+
+| Name    | Type  |
+| :------ | :---- |
+| `order` | Array |
+
+<!-- end auto-generated rule options list -->
+
 ```js
 const rules = {
   'ember/order-in-components': [

--- a/docs/rules/order-in-controllers.md
+++ b/docs/rules/order-in-controllers.md
@@ -8,6 +8,14 @@ Note: this rule will not be added to the `recommended` configuration because it 
 
 ## Configuration
 
+<!-- begin auto-generated rule options list -->
+
+| Name    | Type  |
+| :------ | :---- |
+| `order` | Array |
+
+<!-- end auto-generated rule options list -->
+
 ```js
 const rules = {
   'ember/order-in-controllers': [

--- a/docs/rules/order-in-models.md
+++ b/docs/rules/order-in-models.md
@@ -8,6 +8,14 @@ Note: this rule will not be added to the `recommended` configuration because it 
 
 ## Configuration
 
+<!-- begin auto-generated rule options list -->
+
+| Name    | Type  |
+| :------ | :---- |
+| `order` | Array |
+
+<!-- end auto-generated rule options list -->
+
 ```js
 const rules = {
   'ember/order-in-models': [

--- a/docs/rules/order-in-routes.md
+++ b/docs/rules/order-in-routes.md
@@ -8,6 +8,14 @@ Note: this rule will not be added to the `recommended` configuration because it 
 
 ## Configuration
 
+<!-- begin auto-generated rule options list -->
+
+| Name    | Type  |
+| :------ | :---- |
+| `order` | Array |
+
+<!-- end auto-generated rule options list -->
+
 ```js
 const rules = {
   'ember/order-in-routes': [

--- a/docs/rules/require-computed-macros.md
+++ b/docs/rules/require-computed-macros.md
@@ -119,9 +119,13 @@ export default Component.extend({
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `includeNativeGetters` -- whether the rule should check and autofix computed properties with native getters (i.e. `@computed() get someProp() {}`) to use computed property macros (default `false`). This is off by default because in the Ember Octane world, the better improvement would be to keep the native getter and use tracked properties instead of computed properties.
+| Name                   | Description                                                                                                                                                                                                                                                                                                                              | Type    | Default |
+| :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `includeNativeGetters` | Whether the rule should check and autofix computed properties with native getters (i.e. `@computed() get someProp() {}`) to use computed property macros. This is off by default because in the Ember Octane world, the better improvement would be to keep the native getter and use tracked properties instead of computed properties. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/require-computed-property-dependencies.md
+++ b/docs/rules/require-computed-property-dependencies.md
@@ -47,10 +47,14 @@ export default EmberObject.extend({
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `allowDynamicKeys` -- whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties (default `true`)
-- `boolean` -- `requireServiceNames` -- whether the rule should require injected service names to be listed as dependency keys in computed properties (default `false`)
+| Name                  | Description                                                                                                       | Type    | Default |
+| :-------------------- | :---------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `allowDynamicKeys`    | Whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties. | Boolean | `true`  |
+| `requireServiceNames` | Whether the rule should require injected service names to be listed as dependency keys in computed properties.    | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->
 
 ## References
 

--- a/docs/rules/require-super-in-lifecycle-hooks.md
+++ b/docs/rules/require-super-in-lifecycle-hooks.md
@@ -92,7 +92,11 @@ class Foo extends Component {
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `false`)
-- `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `true`)
+| Name                 | Description                                                                                       | Type    | Default |
+| :------------------- | :------------------------------------------------------------------------------------------------ | :------ | :------ |
+| `checkInitOnly`      | Whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks.       | Boolean | `false` |
+| `checkNativeClasses` | Whether the rule should check lifecycle hooks in native classes (in addition to classic classes). | Boolean | `true`  |
+
+<!-- end auto-generated rule options list -->

--- a/docs/rules/use-ember-get-and-set.md
+++ b/docs/rules/use-ember-get-and-set.md
@@ -43,7 +43,11 @@ setProperties(object, { foo: 'bar', baz: 'qux' });
 
 ## Configuration
 
-This rule takes an optional object containing:
+<!-- begin auto-generated rule options list -->
 
-- `boolean` -- `ignoreThisExpressions` -- setting to `true` allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`.
-- `boolean` -- `ignoreNonThisExpressions` -- setting to  `true` allows use of non-Ember objects like `server.get()` and `map.set()`.
+| Name                       | Description                                                                                                        | Type    | Default |
+| :------------------------- | :----------------------------------------------------------------------------------------------------------------- | :------ | :------ |
+| `ignoreNonThisExpressions` | Enabling allows use of non-Ember objects like `server.get()` and `map.set()`.                                      | Boolean | `false` |
+| `ignoreThisExpressions`    | Enabling allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`. | Boolean | `false` |
+
+<!-- end auto-generated rule options list -->

--- a/lib/rules/named-functions-in-promises.js
+++ b/lib/rules/named-functions-in-promises.js
@@ -24,6 +24,8 @@ module.exports = {
           allowSimpleArrowFunction: {
             type: 'boolean',
             default: false,
+            description:
+              'Enabling allows arrow function expressions that do not have block bodies. These simple arrow functions must also only contain a single function call. For example: `.then(user => this._reloadUser(user))`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-arrow-function-computed-properties.js
+++ b/lib/rules/no-arrow-function-computed-properties.js
@@ -25,6 +25,8 @@ module.exports = {
           onlyThisContexts: {
             type: 'boolean',
             default: false,
+            description:
+              'Whether the rule should allow or disallow computed properties where the arrow function body does not contain a `this` reference.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-classic-classes.js
+++ b/lib/rules/no-classic-classes.js
@@ -59,6 +59,8 @@ module.exports = {
             items: {
               type: 'string',
             },
+            description:
+              'Allows you to specify additional imports that should be flagged to disallow calling `extend` on. This allows you to handle the case where your app or addon is importing from a module that performs the `extend`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-computed-properties-in-native-classes.js
+++ b/lib/rules/no-computed-properties-in-native-classes.js
@@ -44,6 +44,8 @@ module.exports = {
           ignoreClassic: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should ignore usage inside of native classes labeled with `@classic`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-controller-access-in-routes.js
+++ b/lib/rules/no-controller-access-in-routes.js
@@ -30,6 +30,8 @@ module.exports = {
           allowControllerFor: {
             type: 'boolean',
             default: false,
+            description:
+              'Whether the rule should allow or disallow routes from accessing the controller outside of `setupController`/`resetController` via `controllerFor`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-get-with-default.js
+++ b/lib/rules/no-get-with-default.js
@@ -24,10 +24,14 @@ module.exports = {
           catchSafeObjects: {
             type: 'boolean',
             default: true,
+            description:
+              "Whether the rule should catch non-`this` imported usages like `getWithDefault(person, 'name', '')`.",
           },
           catchUnsafeObjects: {
             type: 'boolean',
             default: true,
+            description:
+              "Whether the rule should catch non-`this` usages like `person.getWithDefault('name', '')` even though we don't know for sure if `person` is an Ember object.",
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-get.js
+++ b/lib/rules/no-get.js
@@ -171,26 +171,37 @@ module.exports = {
           ignoreGetProperties: {
             type: 'boolean',
             default: false,
+            description: 'Whether the rule should ignore `getProperties`.',
           },
           ignoreNestedPaths: {
             type: 'boolean',
             default: false,
+            description:
+              "Whether the rule should ignore `this.get('some.nested.property')` (can't be enabled at the same time as `useOptionalChaining`).",
           },
           useOptionalChaining: {
             type: 'boolean',
             default: true,
+            description:
+              "Whether the rule should use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `?.` to autofix nested paths such as `this.get('some.nested.property')` to `this.some?.nested?.property` (when this option is off, these nested paths won't be autofixed at all).",
           },
           catchSafeObjects: {
             type: 'boolean',
             default: true,
+            description:
+              "Whether the rule should catch non-`this` imported usages like `get(foo, 'bar')`.",
           },
           catchUnsafeObjects: {
             type: 'boolean',
             default: false,
+            description:
+              "Whether the rule should catch non-`this` usages like `foo.get('bar')` even though we don't know for sure if `foo` is an Ember object.",
           },
           useAt: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should use `at(-1)` [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) to replace `lastObject`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-private-routing-service.js
+++ b/lib/rules/no-private-routing-service.js
@@ -36,10 +36,14 @@ module.exports = {
           catchRouterMicrolib: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should catch usages of the private property `_routerMicrolib`.',
           },
           catchRouterMain: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should catch usages of the private property `router:main`.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-restricted-property-modifications.js
+++ b/lib/rules/no-restricted-property-modifications.js
@@ -30,6 +30,8 @@ module.exports = {
               },
               minItems: 1,
               uniqueItems: true,
+              description:
+                'Array of names of properties that should not be modified (modifying child/nested/sub-properties of these is also not allowed).',
             },
           },
           required: ['properties'],

--- a/lib/rules/no-restricted-service-injections.js
+++ b/lib/rules/no-restricted-service-injections.js
@@ -32,6 +32,8 @@ module.exports = {
               items: {
                 type: 'string',
               },
+              description:
+                'Optional list of regexp file paths that injecting the specified services should be disallowed under (omit this field to match any path) (for glob patterns, use [ESLint `overrides`](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#configuration-based-on-glob-patterns) instead).',
             },
             services: {
               type: 'array',
@@ -40,9 +42,12 @@ module.exports = {
               items: {
                 type: 'string',
               },
+              description:
+                'List of (kebab-case) service names that should be disallowed from being injected under the specified paths.',
             },
             message: {
               type: 'string',
+              description: 'Optional custom error message to display for violations.',
             },
           },
           additionalProperties: false,

--- a/lib/rules/no-runloop.js
+++ b/lib/rules/no-runloop.js
@@ -58,6 +58,8 @@ module.exports = {
               enum: EMBER_RUNLOOP_FUNCTIONS,
               minItems: 1,
             },
+            description:
+              'If you have `@ember/runloop` functions that you wish to allow, you can configure this rule to allow specific methods. The configuration takes an object with the `allowList` property, which is an array of strings where the strings must be names of runloop functions.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -154,10 +154,14 @@ module.exports = {
           catchEvents: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should catch function calls that send actions or events.',
           },
           checkPlainGetters: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should check plain (non-computed) getters in native classes for side effects.',
           },
         },
       },

--- a/lib/rules/require-computed-macros.js
+++ b/lib/rules/require-computed-macros.js
@@ -140,6 +140,8 @@ module.exports = {
           includeNativeGetters: {
             type: 'boolean',
             default: false,
+            description:
+              'Whether the rule should check and autofix computed properties with native getters (i.e. `@computed() get someProp() {}`) to use computed property macros. This is off by default because in the Ember Octane world, the better improvement would be to keep the native getter and use tracked properties instead of computed properties.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/require-computed-property-dependencies.js
+++ b/lib/rules/require-computed-property-dependencies.js
@@ -260,10 +260,14 @@ module.exports = {
           allowDynamicKeys: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should allow or disallow dynamic (variable / non-string) dependency keys in computed properties.',
           },
           requireServiceNames: {
             type: 'boolean',
             default: false,
+            description:
+              'Whether the rule should require injected service names to be listed as dependency keys in computed properties.',
           },
         },
         additionalProperties: false,

--- a/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/lib/rules/require-super-in-lifecycle-hooks.js
@@ -74,10 +74,14 @@ module.exports = {
           checkInitOnly: {
             type: 'boolean',
             default: false,
+            description:
+              'Whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks.',
           },
           checkNativeClasses: {
             type: 'boolean',
             default: true,
+            description:
+              'Whether the rule should check lifecycle hooks in native classes (in addition to classic classes).',
           },
         },
         additionalProperties: false,

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -30,10 +30,14 @@ module.exports = {
           ignoreThisExpressions: {
             type: 'boolean',
             default: false,
+            description:
+              'Enabling allows use of `this.get()` and `this.set()` where you will generally know if `this` is an `Ember.Object`.',
           },
           ignoreNonThisExpressions: {
             type: 'boolean',
             default: false,
+            description:
+              'Enabling allows use of non-Ember objects like `server.get()` and `map.set()`.',
           },
         },
         additionalProperties: false,

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@typescript-eslint/parser": "^5.31.0",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-doc-generator": "^1.5.2",
+    "eslint-doc-generator": "^1.5.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^5.0.1",
     "eslint-plugin-filenames": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,10 +3056,10 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
   integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
 
-eslint-doc-generator@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-1.5.2.tgz#4ea1c8124404ecf1ea1c10a8482ee19870468ad0"
-  integrity sha512-j+eTFcOlaKZE7h/xoQeshjzBZCW7hwKzLsS1vKsop0jfOVXIqd9uXaHXe9lCQYH4v8vGSQqaKxxrou7t22rrIg==
+eslint-doc-generator@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/eslint-doc-generator/-/eslint-doc-generator-1.5.3.tgz#570e72420e9f6f413957fca90c7a42eacf8a9f25"
+  integrity sha512-QVHi3ljaKXHr86L640rYgh0tJY/CTYncy/NbsFpzHu7ENwb0Dc/2xTESfbYeOl6/ILXqJQMMjNfQ4euEi7Rcjw==
   dependencies:
     "@typescript-eslint/utils" "^5.38.1"
     ajv "^8.11.2"


### PR DESCRIPTION
More info:
* https://github.com/bmish/eslint-doc-generator/pull/481

Note that I have only added these automatic lists to rules with simple objects of options. Other types of rule options (e.g. rules that accept a string instead of an object) aren't supported yet.