### PR TITLE
Set config `ecmaVersion` to `2022`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'script',
     babelOptions: {
       configFile: require.resolve('./.babelrc'),
@@ -24,7 +24,7 @@ module.exports = {
     'prettier',
   ],
   env: {
-    es2020: true,
+    es2022: true,
     node: true,
     jest: true,
   },

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -2,13 +2,13 @@ module.exports = {
   root: true,
 
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 
   env: {
     browser: true,
-    es2020: true,
+    es2022: true,
   },
 
   plugins: ['ember'],

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -30,7 +30,7 @@ function initESLint(parser = gjsGtsParser) {
         browser: true,
       },
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
       },
       parser,

--- a/tests/lib/rules/alias-model-in-controller.js
+++ b/tests/lib/rules/alias-model-in-controller.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('alias-model-in-controller', rule, {

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
   valid: [

--- a/tests/lib/rules/avoid-using-needs-in-controllers.js
+++ b/tests/lib/rules/avoid-using-needs-in-controllers.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/classic-decorator-hooks.js
+++ b/tests/lib/rules/classic-decorator-hooks.js
@@ -11,7 +11,7 @@ const {
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('classic-decorator-hooks', rule, {

--- a/tests/lib/rules/classic-decorator-no-classic-methods.js
+++ b/tests/lib/rules/classic-decorator-no-classic-methods.js
@@ -7,7 +7,7 @@ const { disallowedMethodErrorMessage } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('classic-decorator-no-classic-methods', rule, {

--- a/tests/lib/rules/closure-actions.js
+++ b/tests/lib/rules/closure-actions.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('closure-actions', rule, {

--- a/tests/lib/rules/computed-property-getters.js
+++ b/tests/lib/rules/computed-property-getters.js
@@ -14,7 +14,7 @@ const { addComputedImport } = require('../../helpers/test-case');
 
 const { PREVENT_GETTER_MESSAGE, ALWAYS_GETTER_MESSAGE, ALWAYS_WITH_SETTER_MESSAGE } = rule;
 const ruleTester = new RuleTester();
-const parserOptions = { ecmaVersion: 2020, sourceType: 'module' };
+const parserOptions = { ecmaVersion: 2022, sourceType: 'module' };
 const output = null;
 
 const alwaysWithSetterOptionErrors = [

--- a/tests/lib/rules/jquery-ember-run.js
+++ b/tests/lib/rules/jquery-ember-run.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('jquery-ember-run', rule, {

--- a/tests/lib/rules/named-functions-in-promises.js
+++ b/tests/lib/rules/named-functions-in-promises.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020 },
+  parserOptions: { ecmaVersion: 2022 },
 });
 
 eslintTester.run('named-functions-in-promises', rule, {

--- a/tests/lib/rules/new-module-imports.js
+++ b/tests/lib/rules/new-module-imports.js
@@ -19,7 +19,7 @@ eslintTester.run('new-module-imports', rule, {
 
         const { Handlebars: { Utils: { escapeExpression } } } = Ember
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     'Ember.Handlebars.Utils.escapeExpression("foo");',
     'Ember.onerror = function() {};',
@@ -31,7 +31,7 @@ eslintTester.run('new-module-imports', rule, {
 
         export default Component.extend({});
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: `
@@ -43,22 +43,22 @@ eslintTester.run('new-module-imports', rule, {
           ...foo
         });
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: `import LOL from 'who-knows-but-definitely-not-ember';
 
         const { Controller } = LOL;
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: 'export const Ember = 1;',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: 'for (let i = 0; i < 10; i++) { }',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     'SomethingRandom.Ember.Service;',
   ],
@@ -71,7 +71,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -86,7 +86,7 @@ eslintTester.run('new-module-imports', rule, {
         const { Controller } = LOL;
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -103,7 +103,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Controller.extend({});
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message: "Use `import $ from 'jquery';` instead of using Ember destructuring",
@@ -125,7 +125,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -149,7 +149,7 @@ eslintTester.run('new-module-imports', rule, {
         });
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -178,7 +178,7 @@ eslintTester.run('new-module-imports', rule, {
         export default Component.extend({});
       `,
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -195,7 +195,7 @@ eslintTester.run('new-module-imports', rule, {
     {
       code: 'export default Ember.Service;',
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message: "Use `import Service from '@ember/service';` instead of using Ember.Service",
@@ -206,7 +206,7 @@ eslintTester.run('new-module-imports', rule, {
     {
       code: 'export default Ember.Service.extend({});',
       output: null,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message: "Use `import Service from '@ember/service';` instead of using Ember.Service",

--- a/tests/lib/rules/no-actions-hash.js
+++ b/tests/lib/rules/no-actions-hash.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 ruleTester.run('no-actions-hash', rule, {
   valid: [

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -9,7 +9,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-array-prototype-extensions', rule, {

--- a/tests/lib/rules/no-arrow-function-computed-properties.js
+++ b/tests/lib/rules/no-arrow-function-computed-properties.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/tests/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     babelOptions: {
       configFile: require.resolve('../../../.babelrc'),

--- a/tests/lib/rules/no-at-ember-render-modifiers.js
+++ b/tests/lib/rules/no-at-ember-render-modifiers.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-attrs-in-components.js
+++ b/tests/lib/rules/no-attrs-in-components.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 

--- a/tests/lib/rules/no-attrs-snapshot.js
+++ b/tests/lib/rules/no-attrs-snapshot.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 

--- a/tests/lib/rules/no-capital-letters-in-routes.js
+++ b/tests/lib/rules/no-capital-letters-in-routes.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 //------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 eslintTester.run('no-capital-letters-in-routes', rule, {
   valid: [

--- a/tests/lib/rules/no-classic-classes.js
+++ b/tests/lib/rules/no-classic-classes.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE_NO_CLASSIC_CLASSES: ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-classic-classes', rule, {

--- a/tests/lib/rules/no-classic-components.js
+++ b/tests/lib/rules/no-classic-components.js
@@ -13,7 +13,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const parserOptions = {
-  ecmaVersion: 2020,
+  ecmaVersion: 2022,
   sourceType: 'module',
 };
 const ruleTester = new RuleTester({ parserOptions });

--- a/tests/lib/rules/no-component-lifecycle-hooks.js
+++ b/tests/lib/rules/no-component-lifecycle-hooks.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE_NO_COMPONENT_LIFECYCLE_HOOKS: ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-component-lifecycle-hooks', rule, {

--- a/tests/lib/rules/no-computed-properties-in-native-classes.js
+++ b/tests/lib/rules/no-computed-properties-in-native-classes.js
@@ -8,7 +8,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-controller-access-in-routes.js
+++ b/tests/lib/rules/no-controller-access-in-routes.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-controllers.js
+++ b/tests/lib/rules/no-controllers.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 ruleTester.run('no-controllers', rule, {
   valid: [

--- a/tests/lib/rules/no-current-route-name.js
+++ b/tests/lib/rules/no-current-route-name.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-current-route-name', rule, {

--- a/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
+++ b/tests/lib/rules/no-deeply-nested-dependent-keys-with-each.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-deprecated-router-transition-methods.js
+++ b/tests/lib/rules/no-deprecated-router-transition-methods.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     babelOptions: {
       configFile: require.resolve('../../../.babelrc'),

--- a/tests/lib/rules/no-duplicate-dependent-keys.js
+++ b/tests/lib/rules/no-duplicate-dependent-keys.js
@@ -16,7 +16,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-ember-super-in-es-classes.js
+++ b/tests/lib/rules/no-ember-super-in-es-classes.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020 },
+  parserOptions: { ecmaVersion: 2022 },
 });
 
 eslintTester.run('no-ember-super-in-es-classes', rule, {

--- a/tests/lib/rules/no-ember-testing-in-module-scope.js
+++ b/tests/lib/rules/no-ember-testing-in-module-scope.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGES } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-empty-attrs.js
+++ b/tests/lib/rules/no-empty-attrs.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 const message = 'Supply proper attribute type';
@@ -24,7 +24,7 @@ eslintTester.run('no-empty-attrs', rule, {
       code: `someArrayOfStrings.filter(function(attr) {
         return attr.underscore();
       });`,
-      parserOptions: { ecmaVersion: 2020 },
+      parserOptions: { ecmaVersion: 2022 },
     },
     `export default Model.extend({
         someArray: someArrayOfStrings.filter(function(attr) {

--- a/tests/lib/rules/no-empty-glimmer-component-classes.js
+++ b/tests/lib/rules/no-empty-glimmer-component-classes.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-function-prototype-extensions.js
+++ b/tests/lib/rules/no-function-prototype-extensions.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('no-function-prototype-extensions', rule, {

--- a/tests/lib/rules/no-get-with-default.js
+++ b/tests/lib/rules/no-get-with-default.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-get.js
+++ b/tests/lib/rules/no-get.js
@@ -7,7 +7,7 @@ const { ERROR_MESSAGE_GET, ERROR_MESSAGE_GET_PROPERTIES } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });
@@ -31,11 +31,11 @@ ruleTester.run('no-get', rule, {
     // Template literals.
     {
       code: 'this.get(`foo`);',
-      parserOptions: { ecmaVersion: 2020 },
+      parserOptions: { ecmaVersion: 2022 },
     },
     {
       code: "import { get } from '@ember/object'; get(this, `foo`);",
-      parserOptions: { ecmaVersion: 2020 },
+      parserOptions: { ecmaVersion: 2022 },
     },
 
     // Not `this`.

--- a/tests/lib/rules/no-global-jquery.js
+++ b/tests/lib/rules/no-global-jquery.js
@@ -13,7 +13,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester();
 const parserOptions = {
-  ecmaVersion: 2020,
+  ecmaVersion: 2022,
   sourceType: 'module',
 };
 const globals = { $: true, jQuery: true };

--- a/tests/lib/rules/no-html-safe.js
+++ b/tests/lib/rules/no-html-safe.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-implicit-injections.js
+++ b/tests/lib/rules/no-implicit-injections.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     babelOptions: {
       configFile: require.resolve('../../../.babelrc'),

--- a/tests/lib/rules/no-implicit-service-injection-argument.js
+++ b/tests/lib/rules/no-implicit-service-injection-argument.js
@@ -18,7 +18,7 @@ const NEW_SERVICE_IMPORT = "import {service} from '@ember/service';";
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
+++ b/tests/lib/rules/no-incorrect-calls-with-inline-anonymous-functions.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-incorrect-computed-macros.js
+++ b/tests/lib/rules/no-incorrect-computed-macros.js
@@ -15,7 +15,7 @@ const { ERROR_MESSAGE_AND_OR } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-invalid-debug-function-arguments.js
+++ b/tests/lib/rules/no-invalid-debug-function-arguments.js
@@ -115,7 +115,7 @@ const INVALID_USAGES = DEBUG_FUNCTIONS.flatMap((debugFunction) => [
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-invalid-dependent-keys.js
+++ b/tests/lib/rules/no-invalid-dependent-keys.js
@@ -18,7 +18,7 @@ const {
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/no-invalid-test-waiters.js
+++ b/tests/lib/rules/no-invalid-test-waiters.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-jquery.js
+++ b/tests/lib/rules/no-jquery.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('no-jquery', rule, {

--- a/tests/lib/rules/no-legacy-test-waiters.js
+++ b/tests/lib/rules/no-legacy-test-waiters.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-mixins.js
+++ b/tests/lib/rules/no-mixins.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 eslintTester.run('no-mixins', rule, {
   valid: [

--- a/tests/lib/rules/no-new-mixins.js
+++ b/tests/lib/rules/no-new-mixins.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 eslintTester.run('no-new-mixins', rule, {
   valid: [

--- a/tests/lib/rules/no-noop-setup-on-error-in-before.js
+++ b/tests/lib/rules/no-noop-setup-on-error-in-before.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-observers.js
+++ b/tests/lib/rules/no-observers.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,

--- a/tests/lib/rules/no-old-shims.js
+++ b/tests/lib/rules/no-old-shims.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('no-old-shims', rule, {

--- a/tests/lib/rules/no-on-calls-in-components.js
+++ b/tests/lib/rules/no-on-calls-in-components.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 const message = "Don't use .on() for component lifecycle events.";
@@ -40,7 +40,7 @@ eslintTester.run('no-on-calls-in-components', rule, {
         ...foo,
       });
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
   ],
   invalid: [

--- a/tests/lib/rules/no-pause-test.js
+++ b/tests/lib/rules/no-pause-test.js
@@ -17,7 +17,7 @@ const TEST_FILE_NAME = 'some-test.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-private-routing-service.js
+++ b/tests/lib/rules/no-private-routing-service.js
@@ -22,7 +22,7 @@ const NEW_SERVICE_IMPORT = "import {service} from '@ember/service';";
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-proxies.js
+++ b/tests/lib/rules/no-proxies.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-restricted-property-modifications.js
+++ b/tests/lib/rules/no-restricted-property-modifications.js
@@ -5,7 +5,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-restricted-resolver-tests.js
+++ b/tests/lib/rules/no-restricted-resolver-tests.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGES } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 ruleTester.run('no-restricted-resolver-tests', rule, {
   valid: [

--- a/tests/lib/rules/no-restricted-service-injections.js
+++ b/tests/lib/rules/no-restricted-service-injections.js
@@ -11,7 +11,7 @@ const NEW_SERVICE_IMPORT = "import {service} from '@ember/service';";
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-runloop.js
+++ b/tests/lib/rules/no-runloop.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('no-runloop', rule, {

--- a/tests/lib/rules/no-settled-after-test-helper.js
+++ b/tests/lib/rules/no-settled-after-test-helper.js
@@ -6,7 +6,7 @@ const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-shadow-route-definition.js
+++ b/tests/lib/rules/no-shadow-route-definition.js
@@ -14,7 +14,7 @@ const { buildErrorMessage } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-side-effects.js
+++ b/tests/lib/rules/no-side-effects.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE } = rule;
 
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('no-side-effects', rule, {
@@ -50,7 +50,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -64,7 +64,7 @@ eslintTester.run('no-side-effects', rule, {
       `,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -210,7 +210,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -227,7 +227,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -244,7 +244,7 @@ eslintTester.run('no-side-effects', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'CallExpression' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/no-string-prototype-extensions.js
+++ b/tests/lib/rules/no-string-prototype-extensions.js
@@ -7,7 +7,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 ruleTester.run('no-string-prototype-extensions', rule, {

--- a/tests/lib/rules/no-test-and-then.js
+++ b/tests/lib/rules/no-test-and-then.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-import-export.js
+++ b/tests/lib/rules/no-test-import-export.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-module-for.js
+++ b/tests/lib/rules/no-test-module-for.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-support-import.js
+++ b/tests/lib/rules/no-test-support-import.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-test-this-render.js
+++ b/tests/lib/rules/no-test-this-render.js
@@ -17,7 +17,7 @@ const TEST_FILE_NAME = 'some-test.js';
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-tracked-properties-from-args.js
+++ b/tests/lib/rules/no-tracked-properties-from-args.js
@@ -12,7 +12,7 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });
@@ -39,7 +39,7 @@ ruleTester.run('no-tracked-properties-from-args', rule, {
       }`,
     `
       import { tracked } from '@glimmer/tracking'
-      
+
       class Test {
         test = 7
       }`,
@@ -116,7 +116,7 @@ ruleTester.run('no-tracked-properties-from-args', rule, {
     {
       code: `
       import { tracked as fooTracked } from '@glimmer/tracking';
-      
+
       class Test {
         @fooTracked test = this.args.test
       }

--- a/tests/lib/rules/no-try-invoke.js
+++ b/tests/lib/rules/no-try-invoke.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/no-unnecessary-service-injection-argument.js
+++ b/tests/lib/rules/no-unnecessary-service-injection-argument.js
@@ -18,7 +18,7 @@ const NEW_SERVICE_IMPORT = "import {service} from '@ember/service';";
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),
@@ -35,7 +35,7 @@ ruleTester.run('no-unnecessary-service-injection-argument', rule, {
       code: `${RENAMED_SERVICE_IMPORT} class Test { @service serviceName }`,
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/no-unused-services.js
+++ b/tests/lib/rules/no-unused-services.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),

--- a/tests/lib/rules/no-volatile-computed-properties.js
+++ b/tests/lib/rules/no-volatile-computed-properties.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020, sourceType: 'module' } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2022, sourceType: 'module' } });
 ruleTester.run('no-volatile-computed-properties', rule, {
   valid: [
     'computed()',
@@ -27,7 +27,7 @@ ruleTester.run('no-volatile-computed-properties', rule, {
       code: "class Test { @computed('prop') get someProp() {} }",
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },
@@ -61,7 +61,7 @@ ruleTester.run('no-volatile-computed-properties', rule, {
       errors: [{ message: ERROR_MESSAGE, type: 'Identifier' }],
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -347,7 +347,7 @@ eslintTester.run('order-in-components', rule, {
           ],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: `export default Component.extend({
@@ -362,7 +362,7 @@ eslintTester.run('order-in-components', rule, {
           order: ['property', 'actions', 'custom:customProp', 'method'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
   ],
   invalid: [
@@ -971,7 +971,7 @@ eslintTester.run('order-in-components', rule, {
         bar() { const foo = 'bar'},
         onBar: () => {}
       });`,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -1026,7 +1026,7 @@ eslintTester.run('order-in-components', rule, {
           order: ['property', 'custom:customProp', 'actions', 'method'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message: 'The "customProp" custom property should be above the actions hash on line 3',
@@ -1052,7 +1052,7 @@ eslintTester.run('order-in-components', rule, {
           order: ['method', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:

--- a/tests/lib/rules/order-in-controllers.js
+++ b/tests/lib/rules/order-in-controllers.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -144,7 +144,7 @@ eslintTester.run('order-in-controllers', rule, {
           order: ['property', 'actions', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
   ],
   invalid: [
@@ -443,7 +443,7 @@ eslintTester.run('order-in-controllers', rule, {
           },
 });
       `,
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:
@@ -515,7 +515,7 @@ eslintTester.run('order-in-controllers', rule, {
           order: ['method', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:

--- a/tests/lib/rules/order-in-models.js
+++ b/tests/lib/rules/order-in-models.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -88,7 +88,7 @@ eslintTester.run('order-in-models', rule, {
           order: ['attribute', 'method', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: `import {inject as service} from '@ember/service';
@@ -100,7 +100,7 @@ eslintTester.run('order-in-models', rule, {
           customProp: { a: 1 }
         });`,
       options: [{ order: ['service', 'attribute', 'method'] }],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
   ],
   invalid: [
@@ -297,7 +297,7 @@ eslintTester.run('order-in-models', rule, {
           order: ['method', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:

--- a/tests/lib/rules/order-in-routes.js
+++ b/tests/lib/rules/order-in-routes.js
@@ -10,7 +10,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -160,7 +160,7 @@ eslintTester.run('order-in-routes', rule, {
           order: ['property', 'actions', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
   ],
   invalid: [
@@ -776,7 +776,7 @@ eslintTester.run('order-in-routes', rule, {
           order: ['method', 'custom:customProp'],
         },
       ],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [
         {
           message:

--- a/tests/lib/rules/prefer-ember-test-helpers.js
+++ b/tests/lib/rules/prefer-ember-test-helpers.js
@@ -9,7 +9,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/require-computed-macros.js
+++ b/tests/lib/rules/require-computed-macros.js
@@ -27,7 +27,7 @@ const {
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/require-computed-property-dependencies.js
+++ b/tests/lib/rules/require-computed-property-dependencies.js
@@ -8,7 +8,7 @@ const { ERROR_MESSAGE_NON_STRING_VALUE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/require-fetch-import.js
+++ b/tests/lib/rules/require-fetch-import.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester;
 const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   env: { browser: true },
 });
 

--- a/tests/lib/rules/require-return-from-computed.js
+++ b/tests/lib/rules/require-return-from-computed.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 eslintTester.run('require-return-from-computed', rule, {
@@ -30,7 +30,7 @@ eslintTester.run('require-return-from-computed', rule, {
       code: 'class Test { @computed() get someProp() {} set someProp(val) {} }',
       parser: require.resolve('@babel/eslint-parser'),
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: 'module',
         ecmaFeatures: { legacyDecorators: true },
       },

--- a/tests/lib/rules/require-super-in-lifecycle-hooks.js
+++ b/tests/lib/rules/require-super-in-lifecycle-hooks.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE: message } = rule;
 // ------------------------------------------------------------------------------
 
 const eslintTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   parser: require.resolve('@babel/eslint-parser'),
 });
 
@@ -88,7 +88,7 @@ eslintTester.run('require-super-in-lifecycle-hooks', rule, {
     'export default Service.extend();',
     {
       code: 'export default Service.extend({ ...spread })',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     `export default Component({
         init() {

--- a/tests/lib/rules/require-tagless-components.js
+++ b/tests/lib/rules/require-tagless-components.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE_REQUIRE_TAGLESS_COMPONENTS: ERROR_MESSAGE } = rule;
 const ruleTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: {
       legacyDecorators: true,

--- a/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
+++ b/tests/lib/rules/require-valid-css-selector-in-test-helpers.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
 });

--- a/tests/lib/rules/route-path-style.js
+++ b/tests/lib/rules/route-path-style.js
@@ -13,7 +13,7 @@ const { ERROR_MESSAGE } = rule;
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
   },
   parser: require.resolve('@babel/eslint-parser'),

--- a/tests/lib/rules/template-indent.js
+++ b/tests/lib/rules/template-indent.js
@@ -11,12 +11,12 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('../../../lib/parsers/gjs-gts-parser.js'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 
 const ruleTesterWithBaseIntent = new RuleTester({
   parser: require.resolve('../../../lib/parsers/gjs-gts-parser.js'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
   rules: {
     indent: 'warn',
   },

--- a/tests/lib/rules/template-no-let-reference.js
+++ b/tests/lib/rules/template-no-let-reference.js
@@ -11,7 +11,7 @@ const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
   parser: require.resolve('../../../lib/parsers/gjs-gts-parser.js'),
-  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
 });
 ruleTester.run('template-no-let-reference', rule, {
   valid: [

--- a/tests/lib/rules/use-brace-expansion.js
+++ b/tests/lib/rules/use-brace-expansion.js
@@ -15,7 +15,7 @@ const { ERROR_MESSAGE } = rule;
 const eslintTester = new RuleTester({
   parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: { legacyDecorators: true },
   },

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -7,7 +7,7 @@
 const rule = require('../../../lib/rules/use-ember-data-rfc-395-imports');
 const RuleTester = require('eslint').RuleTester;
 
-const parserOptions = { ecmaVersion: 2020, sourceType: 'module' };
+const parserOptions = { ecmaVersion: 2022, sourceType: 'module' };
 
 const { ERROR_MESSAGE: message } = rule;
 

--- a/tests/lib/rules/use-ember-get-and-set.js
+++ b/tests/lib/rules/use-ember-get-and-set.js
@@ -38,32 +38,32 @@ eslintTester.run('use-ember-get-and-set', rule, {
     },
     {
       code: 'import Ember from "ember"; Ember.get(this, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: 'import Ember from "ember"; Ember.set(this, "test", someValue)',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: 'import EmberAlias from "ember"; EmberAlias.get(this, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
 
     // ignoreNonThisExpressions
     {
       code: "let a = new Map(); a.set('name', 'Tomster');",
       options: [{ ignoreNonThisExpressions: true }],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: "let a = new Map(); a.get('myKey')",
       options: [{ ignoreNonThisExpressions: true }],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
     {
       code: 'this.test("ok")',
       options: [{ ignoreNonThisExpressions: true }],
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
     },
 
     // ignoreThisExpressions
@@ -171,99 +171,99 @@ eslintTester.run('use-ember-get-and-set', rule, {
     {
       code: 'import Ember from "ember"; const { get } = Ember; this.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(this, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; controller.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(controller, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; model.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(model, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { get } = Ember; this.foo.get("test")',
       output: 'import Ember from "ember"; const { get } = Ember; get(this.foo, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; this.getWithDefault("test", "default")',
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(this, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; controller.getWithDefault("test", "default")',
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(controller, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; this.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(this, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; controller.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(controller, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { set } = Ember; model.set("test", "value")',
       output: 'import Ember from "ember"; const { set } = Ember; set(model, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; this.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(this, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; controller.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(controller, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { getProperties } = Ember; model.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(model, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; this.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(this, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; controller.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(controller, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; const { setProperties } = Ember; model.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(model, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
@@ -271,7 +271,7 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import Ember from "ember"; const { getProperties } = Ember; controller.getProperties("test", "test2")',
       output:
         'import Ember from "ember"; const { getProperties } = Ember; getProperties(controller, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
@@ -279,7 +279,7 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import Ember from "ember"; const { setProperties } = Ember; controller.setProperties({test: "value"})',
       output:
         'import Ember from "ember"; const { setProperties } = Ember; setProperties(controller, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
@@ -287,119 +287,119 @@ eslintTester.run('use-ember-get-and-set', rule, {
       code: 'import Ember from "ember"; const { getWithDefault } = Ember; controller.getWithDefault("test", "default")',
       output:
         'import Ember from "ember"; const { getWithDefault } = Ember; getWithDefault(controller, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     // Fixable errors using method on Ember
     {
       code: 'import Ember from "ember"; this.get("test")',
       output: 'import Ember from "ember"; Ember.get(this, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; controller.get("test")',
       output: 'import Ember from "ember"; Ember.get(controller, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; model.get("test")',
       output: 'import Ember from "ember"; Ember.get(model, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; this.foo.get("test")',
       output: 'import Ember from "ember"; Ember.get(this.foo, "test")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; this.getWithDefault("test", "default")',
       output: 'import Ember from "ember"; Ember.getWithDefault(this, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; controller.getWithDefault("test", "default")',
       output: 'import Ember from "ember"; Ember.getWithDefault(controller, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; this.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(this, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; controller.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(controller, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; model.set("test", "value")',
       output: 'import Ember from "ember"; Ember.set(model, "test", "value")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; this.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(this, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; controller.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(controller, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; model.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(model, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; this.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(this, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; controller.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(controller, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       code: 'import Ember from "ember"; model.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(model, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       filename: 'app/tests/unit/controllers/controller-test.js',
       code: 'import Ember from "ember"; controller.getProperties("test", "test2")',
       output: 'import Ember from "ember"; Ember.getProperties(controller, "test", "test2")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       filename: 'app/tests/unit/controllers/controller-test.js',
       code: 'import Ember from "ember"; controller.setProperties({test: "value"})',
       output: 'import Ember from "ember"; Ember.setProperties(controller, {test: "value"})',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
     {
       filename: 'app/tests/unit/controllers/controller-test.js',
       code: 'import Ember from "ember"; controller.getWithDefault("test", "default")',
       output: 'import Ember from "ember"; Ember.getWithDefault(controller, "test", "default")',
-      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
       errors: [{ message: 'Use get/set' }],
     },
 


### PR DESCRIPTION
2022 is the highest version we can use while still supporting all versions of ESLint v8.

Follow-up to:
* https://github.com/ember-cli/eslint-plugin-ember/pull/1516