### PR TITLE
docs: recommended-gts/gjs instead of gts/gjs-recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = {
       plugins: ['ember'],
       extends: [
         'eslint:recommended',
-        'plugin:ember/gts-recommended', // or other configuration
+        'plugin:ember/recommended-gts', // or other configuration
       ],
     },
     {
@@ -79,7 +79,7 @@ module.exports = {
       plugins: ['ember'],
       extends: [
         'eslint:recommended',
-        'plugin:ember/gjs-recommended', // or other configuration
+        'plugin:ember/recommended-gjs', // or other configuration
       ],
     },
     {


### PR DESCRIPTION
currently the readme says to extend `gts-recommended` and `gjs-recommended`, this is reversed and should be `recommended-gts` `recommended-gjs`