### PR TITLE
[gjs-gts-parser] fix parsing when there are multiple default <template> blocks (not allowed)

### DIFF
--- a/lib/parsers/gjs-gts-parser.js
+++ b/lib/parsers/gjs-gts-parser.js
@@ -388,7 +388,7 @@ function convertAst(result, preprocessedResult, visitorKeys) {
     if (
       node.type === 'ExpressionStatement' ||
       node.type === 'StaticBlock' ||
-      node.type === 'TemplateLiteral' ||
+      node.type === 'TaggedTemplateExpression' ||
       node.type === 'ExportDefaultDeclaration'
     ) {
       let range = node.range;
@@ -397,7 +397,9 @@ function convertAst(result, preprocessedResult, visitorKeys) {
       }
 
       const template = templateInfos.find(
-        (t) => t.templateRange[0] === range[0] && t.templateRange[1] === range[1]
+        (t) =>
+          t.templateRange[0] === range[0] &&
+          (t.templateRange[1] === range[1] || t.templateRange[1] === range[1] + 1)
       );
       if (!template) {
         return null;
@@ -501,9 +503,9 @@ function transformForLint(code) {
       jsCode = replaceRange(jsCode, tplInfo.range.start, tplInfo.range.end, replacementCode);
     } else {
       const tplLength = tplInfo.range.end - tplInfo.range.start;
-      const spaces = tplLength - '`'.length - '`'.length - lineBreaks;
+      const spaces = tplLength - '""`'.length - '`'.length - lineBreaks;
       const total = ' '.repeat(spaces) + '\n'.repeat(lineBreaks);
-      const replacementCode = `\`${total}\``;
+      const replacementCode = `""\`${total}\``;
       jsCode = replaceRange(jsCode, tplInfo.range.start, tplInfo.range.end, replacementCode);
     }
   }

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -91,6 +91,10 @@ const valid = [
       <template>
         <div {{on 'click' noop}} />
       </template>
+
+      <template>
+        <div {{on 'click' noop}} />
+      </template>
     `,
   },
   {


### PR DESCRIPTION
I encountered this while working on implementing content-tag for prettier plugin, which has tests for multiple default templates.
It would fail to parse the file in that case.

Before i would have converted the template parts to template string literals.
```js
`
Tpl1
`
`
Tpl2
`
```
But that makes it one tagged template literal... Instead of 2 separates.
Now i make them tagged already.

```js
""
`
Tpl1
`
""
`
Tpl2
`
```
I use string as tag name, as otherwise eslint would complain about missing references to identifiers