### PR TITLE
Allow ember-data type registry imports in `use-ember-data-rfc-395-imports` rule

### DIFF
--- a/docs/rules/use-ember-data-rfc-395-imports.md
+++ b/docs/rules/use-ember-data-rfc-395-imports.md
@@ -14,6 +14,8 @@ The goal of this rule is to ease the migration to the new @ember-data packages.
 
 ember-data has been split in multiple packages. For instance, its store is now released in "@ember-data/store" package. These packages have been released starting from ember-data version 3.11.
 
+For TypeScript users, imports from `ember-data/types/registries/*` are still allowed since there is currently no equivalent in the new packages.
+
 ## Examples
 
 Examples of **incorrect** code for this rule:

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -102,7 +102,7 @@ module.exports = {
           return;
         }
 
-        if (node.source.value === 'ember-data' || node.source.value.startsWith('ember-data/')) {
+        if (node.source.value === 'ember-data' || (node.source.value.startsWith('ember-data/') && !node.source.value.startsWith('ember-data/types/registries/'))) {
           context.report({ node, message });
         }
       },

--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -102,7 +102,11 @@ module.exports = {
           return;
         }
 
-        if (node.source.value === 'ember-data' || (node.source.value.startsWith('ember-data/') && !node.source.value.startsWith('ember-data/types/registries/'))) {
+        if (
+          node.source.value === 'ember-data' ||
+          (node.source.value.startsWith('ember-data/') &&
+            !node.source.value.startsWith('ember-data/types/registries/'))
+        ) {
           context.report({ node, message });
         }
       },

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -40,6 +40,10 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
        name: SomethingRandom.DS('string')
      });
     `,
+    "import AdapterRegistry from 'ember-data/types/registries/adapter';",
+    "import ModelRegistry from 'ember-data/types/registries/model';",
+    "import SerializerRegistry from 'ember-data/types/registries/serializer';",
+    "import TransformRegistry from 'ember-data/types/registries/transform';"
   ],
 
   invalid: [

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -43,7 +43,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
     "import AdapterRegistry from 'ember-data/types/registries/adapter';",
     "import ModelRegistry from 'ember-data/types/registries/model';",
     "import SerializerRegistry from 'ember-data/types/registries/serializer';",
-    "import TransformRegistry from 'ember-data/types/registries/transform';"
+    "import TransformRegistry from 'ember-data/types/registries/transform';",
   ],
 
   invalid: [


### PR DESCRIPTION
Addresses the issue raised by #1833, though we require the import to be directly from the registry module.