### PR TITLE
add `plugin:@typescript-eslint/recommended` to readme for GTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module.exports = {
       plugins: ['ember'],
       extends: [
         'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
         'plugin:ember/recommended',
         'plugin:ember/recommended-gts',
       ],


### PR DESCRIPTION
GTS linting will not be correct without this plugin.

Should we also show the default node files override in the readme? So people don't blow those away when following the config recomendations.