### PR TITLE
Fix nested classes case in `no-ember-super-in-es-classes`

### DIFF
--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -1,5 +1,23 @@
 'use strict';
 
+function isDirectlyInClass(node) {
+  let nestedFunctionsCount = 0;
+
+  while (node.parent) {
+    if (node.type === 'MethodDefinition') {
+      return true;
+    } else if (node.type === 'FunctionExpression') {
+      nestedFunctionsCount++;
+    }
+
+    if (nestedFunctionsCount > 1) {
+      return false;
+    }
+
+    node = node.parent;
+  }
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -19,6 +37,10 @@ module.exports = {
       'MethodDefinition MemberExpression[object.type="ThisExpression"][property.name="_super"]'(
         node
       ) {
+        if (!isDirectlyInClass(node)) {
+          return;
+        }
+
         context.report({
           node,
           message: "Don't use `this._super` in ES classes; instead, you should use `super`",

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -4,7 +4,7 @@ function isDirectlyInClass(node) {
   let currentNode = node.parent;
   let inFunctionAlready = false;
 
-  while (currentNode.parent) {
+  while (currentNode) {
     if (currentNode.type === 'MethodDefinition') {
       return true;
     } else if (currentNode.type === 'FunctionExpression') {

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -1,17 +1,17 @@
 'use strict';
 
 function isDirectlyInClass(node) {
-  let nestedFunctionsCount = 0;
+  let inFunctionAlready = false;
 
   while (node.parent) {
     if (node.type === 'MethodDefinition') {
       return true;
     } else if (node.type === 'FunctionExpression') {
-      nestedFunctionsCount++;
-    }
-
-    if (nestedFunctionsCount > 1) {
-      return false;
+      if (inFunctionAlready) {
+        return false;
+      } else {
+        inFunctionAlready = true;
+      }
     }
 
     node = node.parent;

--- a/lib/rules/no-ember-super-in-es-classes.js
+++ b/lib/rules/no-ember-super-in-es-classes.js
@@ -1,12 +1,13 @@
 'use strict';
 
 function isDirectlyInClass(node) {
+  let currentNode = node.parent;
   let inFunctionAlready = false;
 
-  while (node.parent) {
-    if (node.type === 'MethodDefinition') {
+  while (currentNode.parent) {
+    if (currentNode.type === 'MethodDefinition') {
       return true;
-    } else if (node.type === 'FunctionExpression') {
+    } else if (currentNode.type === 'FunctionExpression') {
       if (inFunctionAlready) {
         return false;
       } else {
@@ -14,8 +15,10 @@ function isDirectlyInClass(node) {
       }
     }
 
-    node = node.parent;
+    currentNode = currentNode.parent;
   }
+
+  return false;
 }
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/tests/lib/rules/no-ember-super-in-es-classes.js
+++ b/tests/lib/rules/no-ember-super-in-es-classes.js
@@ -18,6 +18,7 @@ eslintTester.run('no-ember-super-in-es-classes', rule, {
     'EmberObject.extend({ init() { this._super(); } })',
     'EmberObject.extend({ init(a, b) { this._super(a, b); } })',
     'EmberObject.extend({ init() { this._super(...arguments); } })',
+    'class Foo { bar() { Baz.reopen({ quux() { this._super(); } }); } }',
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-ember-super-in-es-classes.js
+++ b/tests/lib/rules/no-ember-super-in-es-classes.js
@@ -19,6 +19,8 @@ eslintTester.run('no-ember-super-in-es-classes', rule, {
     'EmberObject.extend({ init(a, b) { this._super(a, b); } })',
     'EmberObject.extend({ init() { this._super(...arguments); } })',
     'class Foo { bar() { Baz.reopen({ quux() { this._super(); } }); } }',
+    'class Foo { bar() { return function() { this._super(); }; } }',
+    'class Foo { bar() { return { baz() { this._super() } }; } }',
   ],
   invalid: [
     {
@@ -67,6 +69,20 @@ eslintTester.run('no-ember-super-in-es-classes', rule, {
     {
       code: 'class Foo { [Symbol.iterator]() { this._super(); } }',
       output: 'class Foo { [Symbol.iterator]() { super[Symbol.iterator](); } }',
+      errors: [
+        { message: "Don't use `this._super` in ES classes; instead, you should use `super`" },
+      ],
+    },
+    {
+      code: 'class Foo { init() { return { a: this._super() }; } }',
+      output: 'class Foo { init() { return { a: super.init() }; } }',
+      errors: [
+        { message: "Don't use `this._super` in ES classes; instead, you should use `super`" },
+      ],
+    },
+    {
+      code: 'class Foo { init() { return () => { this._super(); }; } }',
+      output: 'class Foo { init() { return () => { super.init(); }; } }',
       errors: [
         { message: "Don't use `this._super` in ES classes; instead, you should use `super`" },
       ],


### PR DESCRIPTION
This rule was incorrectly failing on the following code:

```js
class Foo {
  bar() {
    Baz.reopen({
      quux() {
        this._super();
      },
    });
  }
}
```