### PR TITLE
A failing test for no-deprecated-router-transition-methods (multiple classes)

### DIFF
--- a/tests/lib/rules/no-deprecated-router-transition-methods.js
+++ b/tests/lib/rules/no-deprecated-router-transition-methods.js
@@ -873,5 +873,59 @@ import Controller from '@ember/controller';
         },
       ],
     },
+
+    // Multiple classes in a single file
+    {
+      filename: 'routes/index.js',
+      code: `
+      import Route from '@ember/routing/route';
+      import { action } from '@ember/object';
+
+      export class SettingsRoute extends Route {
+        @action
+        foo() {
+          this.transitionTo('login');
+        }
+      }
+
+      export class AnotherRoute extends Route {
+        @action
+        foo() {
+          this.transitionTo('login');
+        }
+      }`,
+      output: `
+      import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+      import { action } from '@ember/object';
+
+      export class SettingsRoute extends Route {
+        @service('router') router;
+@action
+        foo() {
+          this.router.transitionTo('login');
+        }
+      }
+
+      export class AnotherRoute extends Route {
+        @service('router') router;
+@action
+        foo() {
+          this.router.transitionTo('login');
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'main',
+          data: { methodUsed: 'transitionTo', desiredMethod: 'transitionTo', moduleType: 'Route' },
+          type: 'MemberExpression',
+        },
+        {
+          messageId: 'main',
+          data: { methodUsed: 'transitionTo', desiredMethod: 'transitionTo', moduleType: 'Route' },
+          type: 'MemberExpression',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
This rule incorrectly fails on the following code, where there is more than one Route class in a file:

```js
import Route from '@ember/routing/route';
import { action } from '@ember/object';

export class SettingsRoute extends Route {
  @action
  foo() {
    this.transitionTo('login');
  }
}

export class AnotherRoute extends Route {
  @action
  foo() {
    this.transitionTo('login');
  }
}
```