### PR TITLE
Upgrade ember-eslint-parser to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": ">= 0.3.4",
+    "ember-eslint-parser": "^0.3.4",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": "^0.3.4",
+    "ember-eslint-parser": "^0.3.5",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": "^0.3.4",
+    "ember-eslint-parser": ">= 0.3.4",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": "^0.3.5",
+    "ember-eslint-parser": "^0.3.6",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": "^0.2.5",
+    "ember-eslint-parser": "^0.3.4",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -90,9 +90,9 @@ const valid = [
 
       const noop = () => {};
 
-      <template>
+      export const Two = <template>
         <div {{on 'click' noop}} />
-      </template>
+      </template>;
 
       <template>
         <div {{on 'click' noop}} />
@@ -268,8 +268,8 @@ const invalid = [
       {
         column: 27,
         endColumn: 34,
-        endLine: 3,
-        line: 3,
+        endLine: 2,
+        line: 2,
         message: "'notUsed' is defined but never used.",
         messageId: 'unusedVar',
         nodeType: 'BlockParam',
@@ -279,8 +279,8 @@ const invalid = [
       {
         column: 10,
         endColumn: 15,
-        endLine: 6,
-        line: 6,
+        endLine: 5,
+        line: 5,
         message: "'undef' is not defined.",
         messageId: 'undef',
         nodeType: 'GlimmerElementNodePart',
@@ -290,8 +290,8 @@ const invalid = [
       {
         column: 10,
         endColumn: 26,
-        endLine: 7,
-        line: 7,
+        endLine: 6,
+        line: 6,
         message: "'non-std-html-tag' is not defined.",
         messageId: 'undef',
         nodeType: 'GlimmerElementNodePart',
@@ -313,15 +313,15 @@ const invalid = [
     errors: [
       {
         message: "'Foo' is not defined.",
-        line: 3,
-        endLine: 3,
+        line: 2,
+        endLine: 2,
         column: 10,
         endColumn: 13,
       },
       {
         message: "'Bar' is not defined.",
-        line: 4,
-        endLine: 4,
+        line: 3,
+        endLine: 3,
         column: 10,
         endColumn: 13,
       },
@@ -337,7 +337,7 @@ const invalid = [
     errors: [
       {
         message: "'F_0_O' is not defined.",
-        line: 3,
+        line: 2,
         column: 10,
         endColumn: 15,
       },
@@ -715,7 +715,10 @@ describe('multiple tokens in same file', () => {
     const resultErrors = results.flatMap((result) => result.messages);
     expect(resultErrors).toHaveLength(2);
 
-    expect(resultErrors[0]).toStrictEqual({
+    const noUndef = resultErrors.find((error) => error.ruleId === 'no-undef');
+    const noUnusedVars = resultErrors.find((error) => error.ruleId === 'no-unused-vars');
+
+    expect(noUnusedVars).toStrictEqual({
       column: 13,
       endColumn: 17,
       endLine: 4,
@@ -727,11 +730,11 @@ describe('multiple tokens in same file', () => {
       severity: 2,
     });
 
-    expect(resultErrors[1]).toStrictEqual({
-      column: 31,
-      endColumn: 34,
-      endLine: 4,
-      line: 4,
+    expect(noUndef).toStrictEqual({
+      column: 12,
+      endColumn: 15,
+      endLine: 1,
+      line: 1,
       message: "'Bad' is not defined.",
       messageId: 'undef',
       nodeType: 'GlimmerElementNodePart',

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -90,9 +90,9 @@ const valid = [
 
       const noop = () => {};
 
-      export const Two = <template>
+      <template>
         <div {{on 'click' noop}} />
-      </template>;
+      </template>
 
       <template>
         <div {{on 'click' noop}} />
@@ -268,8 +268,8 @@ const invalid = [
       {
         column: 27,
         endColumn: 34,
-        endLine: 2,
-        line: 2,
+        endLine: 3,
+        line: 3,
         message: "'notUsed' is defined but never used.",
         messageId: 'unusedVar',
         nodeType: 'BlockParam',
@@ -279,8 +279,8 @@ const invalid = [
       {
         column: 10,
         endColumn: 15,
-        endLine: 5,
-        line: 5,
+        endLine: 6,
+        line: 6,
         message: "'undef' is not defined.",
         messageId: 'undef',
         nodeType: 'GlimmerElementNodePart',
@@ -290,8 +290,8 @@ const invalid = [
       {
         column: 10,
         endColumn: 26,
-        endLine: 6,
-        line: 6,
+        endLine: 7,
+        line: 7,
         message: "'non-std-html-tag' is not defined.",
         messageId: 'undef',
         nodeType: 'GlimmerElementNodePart',
@@ -313,15 +313,15 @@ const invalid = [
     errors: [
       {
         message: "'Foo' is not defined.",
-        line: 2,
-        endLine: 2,
+        line: 3,
+        endLine: 3,
         column: 10,
         endColumn: 13,
       },
       {
         message: "'Bar' is not defined.",
-        line: 3,
-        endLine: 3,
+        line: 4,
+        endLine: 4,
         column: 10,
         endColumn: 13,
       },
@@ -337,7 +337,7 @@ const invalid = [
     errors: [
       {
         message: "'F_0_O' is not defined.",
-        line: 2,
+        line: 3,
         column: 10,
         endColumn: 15,
       },
@@ -715,10 +715,7 @@ describe('multiple tokens in same file', () => {
     const resultErrors = results.flatMap((result) => result.messages);
     expect(resultErrors).toHaveLength(2);
 
-    const noUndef = resultErrors.find((error) => error.ruleId === 'no-undef');
-    const noUnusedVars = resultErrors.find((error) => error.ruleId === 'no-unused-vars');
-
-    expect(noUnusedVars).toStrictEqual({
+    expect(resultErrors[0]).toStrictEqual({
       column: 13,
       endColumn: 17,
       endLine: 4,
@@ -730,11 +727,11 @@ describe('multiple tokens in same file', () => {
       severity: 2,
     });
 
-    expect(noUndef).toStrictEqual({
-      column: 12,
-      endColumn: 15,
-      endLine: 1,
-      line: 1,
+    expect(resultErrors[1]).toStrictEqual({
+      column: 31,
+      endColumn: 34,
+      endLine: 4,
+      line: 4,
       message: "'Bad' is not defined.",
       messageId: 'undef',
       nodeType: 'GlimmerElementNodePart',

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -90,9 +90,9 @@ const valid = [
 
       const noop = () => {};
 
-      <template>
+      export const Foo = <template>
         <div {{on 'click' noop}} />
-      </template>
+      </template>;
 
       <template>
         <div {{on 'click' noop}} />

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -90,22 +90,6 @@ const valid = [
 
       const noop = () => {};
 
-      export const Foo = <template>
-        <div {{on 'click' noop}} />
-      </template>;
-
-      <template>
-        <div {{on 'click' noop}} />
-      </template>
-    `,
-  },
-  {
-    filename: 'my-component.gjs',
-    code: `
-      import { on } from '@ember/modifier';
-
-      const noop = () => {};
-
       export default <template>
         <div {{on 'click' noop}} />
       </template>
@@ -200,6 +184,27 @@ const invalid = [
     errors: [
       {
         message: 'Parsing error: Parse Error at <anon>:2:29: 2:40',
+      },
+    ],
+  },
+  {
+    filename: 'my-component.gjs',
+    code: `
+      import { on } from '@ember/modifier';
+
+      const noop = () => {};
+
+      <template>
+        <div {{on 'click' noop}} />
+      </template>
+
+      <template>
+        <div {{on 'click' noop}} />
+      </template>
+    `,
+    errors: [
+      {
+        message: 'Missing semicolon.',
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,10 +2483,10 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-ember-eslint-parser@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.4.tgz#faec69bd25853120cf312cbe8c581672f87f119b"
-  integrity sha512-yb531OZbv3x52oh8QjKDhmuNc+7qWYKxnHSzvUyIBGPm9SOhDupxtqKnZnUXc7bGtt6Z1MWEkxMV34SPbwnhBg==
+ember-eslint-parser@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.5.tgz#19072b82fe95b7893ad1c1e1a84e7426db8df176"
+  integrity sha512-59Qadm1jKWawnWsQrVeDKvlVwn8wBczRlOOP2i4QKeJCSjZIswgEFQUNKH3wkGxXMxbZVPgtLoSeUM3UiHADhQ==
   dependencies:
     "@babel/eslint-parser" "7.23.10"
     "@glimmer/syntax" "^0.88.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,10 +2483,10 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-ember-eslint-parser@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.5.tgz#19072b82fe95b7893ad1c1e1a84e7426db8df176"
-  integrity sha512-59Qadm1jKWawnWsQrVeDKvlVwn8wBczRlOOP2i4QKeJCSjZIswgEFQUNKH3wkGxXMxbZVPgtLoSeUM3UiHADhQ==
+ember-eslint-parser@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.6.tgz#3a778b8eeba418b799c37591d98d674baf553734"
+  integrity sha512-3GQerv+/7gXUBaG9IgxQ6PZ7KVz0nbBKAheFMfGKTUXP54SruT1IgsuDRCAzkE3tWWPnIl2WkrfnwHGKRigevQ==
   dependencies:
     "@babel/eslint-parser" "7.23.10"
     "@glimmer/syntax" "^0.88.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,7 +58,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@^7.22.15", "@babel/eslint-parser@^7.23.3":
+"@babel/eslint-parser@7.23.10", "@babel/eslint-parser@^7.22.15":
   version "7.23.10"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz#2d4164842d6db798873b40e0c4238827084667a2"
   integrity sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==
@@ -458,39 +458,39 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==
 
-"@glimmer/interfaces@^0.85.13":
-  version "0.85.13"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.85.13.tgz#02ec31a29977cf06af5d1bb9f685f0ad453ae613"
-  integrity sha512-qOEdvFgCQX1g+Gfi/nA2zbKYPmEkEbhFgzZ5esgmlQNOSQx4j8nyGiBvnG/vepHrh4wUzTvIynrCQpfr3SiKXg==
+"@glimmer/interfaces@^0.88.1":
+  version "0.88.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.88.1.tgz#e5ce6b5aea2a9fbc15d5f7f684e4b6d2695e7e8f"
+  integrity sha512-BOcN8xFNX/eppGxwS9Rm1+PlQaFX+tK91cuQLHj2sRwB+qVbL/WeutIa3AUQYr0VVEzMm2S6bYCLvG6p0a8v9A==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/syntax@^0.85.13":
-  version "0.85.13"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.85.13.tgz#841e6da0a555252f087145f83f92cf0d9cf76cb5"
-  integrity sha512-zMGkJh6JcHdCTx1emmBbhBrGO04gqD6CS5khmDwSJCIpVHnGH0Ejxp9rpnSMc5IW71/hFoQY6RlMgVYF2hrHhA==
+"@glimmer/syntax@^0.88.0":
+  version "0.88.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.88.1.tgz#04c1827a43847867156a2d7d792b6bb5ebf57b80"
+  integrity sha512-tucexG0j5SSbk3d4ayCOnvjg5FldvWyrZbzxukZOBhDgAYhGWUnGFAqdoXjpr3w6FkD4xIVliVD9GFrH4lI8DA==
   dependencies:
-    "@glimmer/interfaces" "^0.85.13"
-    "@glimmer/util" "^0.85.13"
-    "@glimmer/wire-format" "^0.85.13"
+    "@glimmer/interfaces" "^0.88.1"
+    "@glimmer/util" "^0.88.1"
+    "@glimmer/wire-format" "^0.88.1"
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/util@^0.85.13":
-  version "0.85.13"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.85.13.tgz#a17824e5fd91e4e3f3847f38f600ecd3c1508dad"
-  integrity sha512-ogj65iukNKEPPqQ2bOD6CLsqxsFwmiGvTQbAsg1eh1MoPjxhNZMpLsT5CdQ10XE7yUALHGJ71SwxBSpAOGDmxg==
+"@glimmer/util@^0.88.1":
+  version "0.88.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.88.1.tgz#a9e8cf0be78c5dc0d433294c71101ba1af8433e5"
+  integrity sha512-PV/24+vBmsReR78UQXJlEHDblU6QBAeIJa8MwKhQoxSD6WgvQHP4KmX23rvlCz11GxApTwyPm/2qyp/SwVvX2A==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.85.13"
+    "@glimmer/interfaces" "^0.88.1"
 
-"@glimmer/wire-format@^0.85.13":
-  version "0.85.13"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.85.13.tgz#a8df8c44646b8f0d09dda187ac64f45c33904b63"
-  integrity sha512-q6bHPfjSYE9jH27L75lUzyhSpBA+iONzsJVXewdwO4GdYYCC4s+pfUaJg7ZYNFDcHDuVKUcLhBb/NICDzMA5Uw==
+"@glimmer/wire-format@^0.88.1":
+  version "0.88.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.88.1.tgz#75411def71a30ad4a3afaeb5a95d7cb9f8e22d9a"
+  integrity sha512-DPM2UiYRNzcWdOUrSa8/IFbWKovH+c2JPnbvtk04DpfQapU7+hteBj34coEN/pW3FJiP3WMvx/EuPfWROkeDsg==
   dependencies:
-    "@glimmer/interfaces" "^0.85.13"
-    "@glimmer/util" "^0.85.13"
+    "@glimmer/interfaces" "^0.88.1"
+    "@glimmer/util" "^0.88.1"
 
 "@handlebars/parser@~2.0.0":
   version "2.0.0"
@@ -1217,7 +1217,7 @@
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/scope-manager@6.21.0", "@typescript-eslint/scope-manager@^6.15.0":
+"@typescript-eslint/scope-manager@6.21.0", "@typescript-eslint/scope-manager@^6.21.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
   integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
@@ -2483,14 +2483,14 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-ember-eslint-parser@^0.2.5:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.2.6.tgz#81da7ba03630a7f7f9d2369587f2d654f32daa40"
-  integrity sha512-dwW9hPVqv147zyBbqFsF72cDmJk4X8AUYhiL8eGQAG4QOUR2uOuTA6I4tt8m5kG5LZiZbnk9Lymaju+NUyoJBQ==
+ember-eslint-parser@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.4.tgz#faec69bd25853120cf312cbe8c581672f87f119b"
+  integrity sha512-yb531OZbv3x52oh8QjKDhmuNc+7qWYKxnHSzvUyIBGPm9SOhDupxtqKnZnUXc7bGtt6Z1MWEkxMV34SPbwnhBg==
   dependencies:
-    "@babel/eslint-parser" "^7.23.3"
-    "@glimmer/syntax" "^0.85.13"
-    "@typescript-eslint/scope-manager" "^6.15.0"
+    "@babel/eslint-parser" "7.23.10"
+    "@glimmer/syntax" "^0.88.0"
+    "@typescript-eslint/scope-manager" "^6.21.0"
     content-tag "^1.2.2"
     eslint-scope "^7.2.2"
     html-tags "^3.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,7 +2483,7 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-"ember-eslint-parser@>= 0.3.4":
+ember-eslint-parser@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.4.tgz#faec69bd25853120cf312cbe8c581672f87f119b"
   integrity sha512-yb531OZbv3x52oh8QjKDhmuNc+7qWYKxnHSzvUyIBGPm9SOhDupxtqKnZnUXc7bGtt6Z1MWEkxMV34SPbwnhBg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,7 +2483,7 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-ember-eslint-parser@^0.3.4:
+"ember-eslint-parser@>= 0.3.4":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.3.4.tgz#faec69bd25853120cf312cbe8c581672f87f119b"
   integrity sha512-yb531OZbv3x52oh8QjKDhmuNc+7qWYKxnHSzvUyIBGPm9SOhDupxtqKnZnUXc7bGtt6Z1MWEkxMV34SPbwnhBg==


### PR DESCRIPTION
Folks are still installing an old parser, see: https://github.com/ember-cli/eslint-plugin-ember/issues/2062


We don't actually want to support older than what's specified here.