### PR TITLE
Fix flat config for gts/gjs and `noop` parser name

### DIFF
--- a/lib/config-legacy/base.js
+++ b/lib/config-legacy/base.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       files: ['**/*.{gts,gjs}'],
       parser: 'ember-eslint-parser',
-      processor: 'ember/<noop>',
+      processor: 'ember/noop',
     },
   ],
 };

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -1,4 +1,5 @@
 const plugin = require('../index');
+const emberEslintParser = require('ember-eslint-parser');
 
 module.exports = [
   {
@@ -11,7 +12,9 @@ module.exports = [
    */
   {
     files: ['**/*.{gts,gjs}'],
-    parser: 'ember-eslint-parser',
-    processor: 'ember/<noop>',
+    languageOptions: {
+      parser: emberEslintParser,
+    },
+    processor: 'ember/noop',
   },
 ];

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,6 @@ module.exports = {
   },
   processors: {
     // https://eslint.org/docs/developer-guide/working-with-plugins#file-extension-named-processor
-    '<noop>': noop,
+    noop,
   },
 };


### PR DESCRIPTION
Fixes #2061.

Fixes two issues:
* `parser` needs to be inside `languagesOptions` in flat config: `A config object is using the "parser" key, which is not supported in flat config system. Flat config uses "languageOptions.parser" to override the default parser.` https://eslint.org/docs/latest/use/configure/configuration-files-new#configuring-a-custom-parser-and-its-options
* Processor name cannot have angle brackets: `TypeError: Expected string in the form "pluginName/objectName" but found "ember/<noop>".`

@Techn1x @patricklx @NullVoxPopuli 