### PR TITLE
include recommended ts-eslint rules for gts

### DIFF
--- a/lib/config/recommended-gts.js
+++ b/lib/config/recommended-gts.js
@@ -1,17 +1,29 @@
 const base = require('./base');
 const gtsRules = require('../recommended-rules-gts');
 
-let typescriptRecommendedRules = {};
-try {
-  // typescript recommended rules turn off eslint rules that do not work for ts/gts
-  // but they only to that for known extensions, therefore we need to reapply them in our
-  // recommended config
-  // see issue https://github.com/typescript-eslint/typescript-eslint/issues/8607
-  const recommended = // eslint-disable-next-line n/no-extraneous-require
-    require('@typescript-eslint/eslint-plugin').configs['eslint-recommended'];
-  typescriptRecommendedRules = recommended.overrides[0].rules;
-} catch {
-  // not available
-}
+// see https://github.com/typescript-eslint/typescript-eslint/issues/8607
+// https://github.com/typescript-eslint/typescript-eslint/blob/v7.4.0/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+const tsRecommended = {
+  'constructor-super': 'off', // ts(2335) & ts(2377)
+  'getter-return': 'off', // ts(2378)
+  'no-const-assign': 'off', // ts(2588)
+  'no-dupe-args': 'off', // ts(2300)
+  'no-dupe-class-members': 'off', // ts(2393) & ts(2300)
+  'no-dupe-keys': 'off', // ts(1117)
+  'no-func-assign': 'off', // ts(2630)
+  'no-import-assign': 'off', // ts(2632) & ts(2540)
+  'no-new-symbol': 'off', // ts(7009)
+  'no-obj-calls': 'off', // ts(2349)
+  'no-redeclare': 'off', // ts(2451)
+  'no-setter-return': 'off', // ts(2408)
+  'no-this-before-super': 'off', // ts(2376) & ts(17009)
+  'no-undef': 'off', // ts(2304) & ts(2552)
+  'no-unreachable': 'off', // ts(7027)
+  'no-unsafe-negation': 'off', // ts(2365) & ts(2322) & ts(2358)
+  'no-var': 'error', // ts transpiles let/const to var, so no need for vars any more
+  'prefer-const': 'error', // ts provides better types with const
+  'prefer-rest-params': 'error', // ts provides better types with rest args over arguments
+  'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
+};
 
-module.exports = [...base, { rules: { ...gtsRules, ...typescriptRecommendedRules } }];
+module.exports = [...base, { rules: { ...gtsRules, ...tsRecommended } }];

--- a/lib/config/recommended-gts.js
+++ b/lib/config/recommended-gts.js
@@ -1,4 +1,17 @@
 const base = require('./base');
 const gtsRules = require('../recommended-rules-gts');
 
-module.exports = [...base, { rules: gtsRules }];
+let typescriptRecommendedRules = {};
+try {
+  // typescript recommended rules turn off eslint rules that do not work for ts/gts
+  // but they only to that for known extensions, therefore we need to reapply them in our
+  // recommended config
+  // see issue https://github.com/typescript-eslint/typescript-eslint/issues/8607
+  const recommended = // eslint-disable-next-line n/no-extraneous-require
+    require('@typescript-eslint/eslint-plugin').configs['eslint-recommended'];
+  typescriptRecommendedRules = recommended.overrides[0].rules;
+} catch {
+  // not available
+}
+
+module.exports = [...base, { rules: { ...gtsRules, ...typescriptRecommendedRules } }];


### PR DESCRIPTION
typescript recommended rules turn off eslint rules that do not work for ts/gts

but they only to that for known extensions, therefore we need to reapply them in our recommended config
see issue https://github.com/typescript-eslint/typescript-eslint/issues/8607

fixes #2106