### PR TITLE
fix isTestFile

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -175,8 +175,10 @@ function isModuleByFilePath(filePath, module) {
   );
 }
 
+const validFileExtensions = ['js', 'ts', 'gjs', 'gts'];
+
 function isTestFile(fileName) {
-  return fileName.endsWith('-test.js') || fileName.endsWith('-test.ts');
+  return validFileExtensions.some((ext) => fileName.endsWith(`-test.${ext}`));
 }
 
 function isMirageDirectory(fileName) {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -139,6 +139,8 @@ describe('isTestFile', () => {
   it('detects test files', () => {
     expect(emberUtils.isTestFile('some-test.js')).toBeTruthy();
     expect(emberUtils.isTestFile('some-test.ts')).toBeTruthy();
+    expect(emberUtils.isTestFile('some-test.gjs')).toBeTruthy();
+    expect(emberUtils.isTestFile('some-test.gts')).toBeTruthy();
   });
 
   it('does not detect other files', () => {


### PR DESCRIPTION
We forgot to update this when we added gjs/gts support, so all the test-specific lints on gjs/gts files might be accidentally turned off right now (prior to this fix).

Fixes: https://github.com/ember-cli/eslint-plugin-ember/issues/2146