### PR TITLE
Bump parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ember-data/rfc395-data": "^0.0.4",
     "css-tree": "^2.3.1",
-    "ember-eslint-parser": "^0.4.1",
+    "ember-eslint-parser": "^0.4.3",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
+++ b/tests/lib/rules-preprocessor/gjs-gts-parser-test.js
@@ -261,7 +261,7 @@ const invalid = [
     filename: 'my-component.gjs',
     code: `
       <template>
-      {{#let 'x' as |noop notUsed usedEl|}}
+      {{#let 'x' as |noop usedEl notUsed|}}
         {{noop}}
         <usedEl />
         <undef.x />
@@ -271,8 +271,8 @@ const invalid = [
     `,
     errors: [
       {
-        column: 27,
-        endColumn: 34,
+        column: 34,
+        endColumn: 41,
         endLine: 3,
         line: 3,
         message: "'notUsed' is defined but never used.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,39 +449,39 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==
 
-"@glimmer/interfaces@^0.88.1":
-  version "0.88.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.88.1.tgz#e5ce6b5aea2a9fbc15d5f7f684e4b6d2695e7e8f"
-  integrity sha512-BOcN8xFNX/eppGxwS9Rm1+PlQaFX+tK91cuQLHj2sRwB+qVbL/WeutIa3AUQYr0VVEzMm2S6bYCLvG6p0a8v9A==
+"@glimmer/interfaces@^0.92.0":
+  version "0.92.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.92.0.tgz#2b4071b11245284b330cb1d221bccc31dbccfec7"
+  integrity sha512-SKZvIs+ZPN8F3EH8kEzs7rGIUa+wuV+/3oWYyEiBrqd+VrZlmAxIELM6qZ6oxXT2tx6q1rh2EmA5rWezi6bmYQ==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/syntax@^0.88.0":
-  version "0.88.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.88.1.tgz#04c1827a43847867156a2d7d792b6bb5ebf57b80"
-  integrity sha512-tucexG0j5SSbk3d4ayCOnvjg5FldvWyrZbzxukZOBhDgAYhGWUnGFAqdoXjpr3w6FkD4xIVliVD9GFrH4lI8DA==
+"@glimmer/syntax@^0.92.0":
+  version "0.92.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.92.0.tgz#f681367d2f84a18f7fdbb1e31093af59617ff790"
+  integrity sha512-h8pYBC2cCnEyjbZBip2Yw4qi8S8sjNCYAb57iHek3AIhyFKMM13aTN+/aajFOM4FUTMCVE2B/iAAmO41WRCX4A==
   dependencies:
-    "@glimmer/interfaces" "^0.88.1"
-    "@glimmer/util" "^0.88.1"
-    "@glimmer/wire-format" "^0.88.1"
+    "@glimmer/interfaces" "^0.92.0"
+    "@glimmer/util" "^0.92.0"
+    "@glimmer/wire-format" "^0.92.0"
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/util@^0.88.1":
-  version "0.88.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.88.1.tgz#a9e8cf0be78c5dc0d433294c71101ba1af8433e5"
-  integrity sha512-PV/24+vBmsReR78UQXJlEHDblU6QBAeIJa8MwKhQoxSD6WgvQHP4KmX23rvlCz11GxApTwyPm/2qyp/SwVvX2A==
+"@glimmer/util@^0.92.0":
+  version "0.92.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.92.0.tgz#cf97dca6bb926453bd194532410d2cdd8d71961b"
+  integrity sha512-Fap52smLp8RkCgvozrZG7RysNJ2T6mk1SPoknMzmukbabFVBAzxl5iyY4OXUbmR09j6t2pupjF6sPabnLtL4vw==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.88.1"
+    "@glimmer/interfaces" "^0.92.0"
 
-"@glimmer/wire-format@^0.88.1":
-  version "0.88.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.88.1.tgz#75411def71a30ad4a3afaeb5a95d7cb9f8e22d9a"
-  integrity sha512-DPM2UiYRNzcWdOUrSa8/IFbWKovH+c2JPnbvtk04DpfQapU7+hteBj34coEN/pW3FJiP3WMvx/EuPfWROkeDsg==
+"@glimmer/wire-format@^0.92.0":
+  version "0.92.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.92.0.tgz#b485c91b1a49e77c67c16e9c9392e8727727433c"
+  integrity sha512-yKhfU7b3PN86iqbfKksB+F9PB/RqbVkZlcRpZWRpEL3HnZ0bJUKC9bsOJynOg77PDXuYQXkbDMfL8ngTuxk+rg==
   dependencies:
-    "@glimmer/interfaces" "^0.88.1"
-    "@glimmer/util" "^0.88.1"
+    "@glimmer/interfaces" "^0.92.0"
+    "@glimmer/util" "^0.92.0"
 
 "@handlebars/parser@~2.0.0":
   version "2.0.0"
@@ -2432,13 +2432,13 @@ electron-to-chromium@^1.4.648:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
   integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
-ember-eslint-parser@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.4.1.tgz#9c064718d79942ce84e8b1ffec27d39c1861ae0c"
-  integrity sha512-MAQdBSOhsazHSxeZs3mZOPoVxMbfTaYNrGMEJewpEobCw9N0x9tpTUKY2AC2V6cQKPaeKikQL1Q6fwL3AtqEew==
+ember-eslint-parser@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/ember-eslint-parser/-/ember-eslint-parser-0.4.3.tgz#a7ca3c380872719610b94c7a06cc550ced745031"
+  integrity sha512-wMPoaaA+i/F/tPPxURRON9XXJH5MRUOZ5x/9CVJTSpL+0n4EWphyztb20gR+ZJeShnOACQpAdFy6YSS1/JSHKw==
   dependencies:
     "@babel/eslint-parser" "7.23.10"
-    "@glimmer/syntax" "^0.88.0"
+    "@glimmer/syntax" "^0.92.0"
     content-tag "^1.2.2"
     eslint-scope "^7.2.2"
     html-tags "^3.3.1"


### PR DESCRIPTION
Bumps the min-parser version so we get bugfixes / force bugfixes when folks upgrade eslint-plugin-ember.