### PR TITLE
Fix API deprecations blocking eslint v9 compatibility

### DIFF
--- a/lib/rules/jquery-ember-run.js
+++ b/lib/rules/jquery-ember-run.js
@@ -119,8 +119,10 @@ module.exports = {
         }
       },
 
-      'Program:exit'() {
-        const scope = context.getScope();
+      'Program:exit'(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
         const tracker = new ReferenceTracker(scope);
 
         /**

--- a/lib/rules/no-ember-testing-in-module-scope.js
+++ b/lib/rules/no-ember-testing-in-module-scope.js
@@ -45,7 +45,10 @@ module.exports = {
           node.parent.type === 'MemberExpression' &&
           node.parent.object.name === emberImportAliasName
         ) {
-          if (context.getScope().variableScope.type === 'module') {
+          const sourceCode = context.sourceCode ?? context.getSourceCode();
+          const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
+          if (scope.variableScope.type === 'module') {
             context.report({ node: node.parent, message: ERROR_MESSAGES[0] });
           }
           const nodeGrandParent = utils.getPropertyValue(node, 'parent.parent.type');

--- a/lib/rules/no-global-jquery.js
+++ b/lib/rules/no-global-jquery.js
@@ -27,8 +27,11 @@ module.exports = {
 
   create(context) {
     return {
-      Program() {
-        const tracker = new ReferenceTracker(context.getScope());
+      Program(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
+        const tracker = new ReferenceTracker(scope);
 
         for (const { node } of tracker.iterateGlobalReferences(globalMap)) {
           context.report({ node, message: ERROR_MESSAGE });

--- a/lib/rules/no-jquery.js
+++ b/lib/rules/no-jquery.js
@@ -48,8 +48,10 @@ module.exports = {
       /**
        * Report references of jQuery
        */
-      Program() {
-        const scope = context.getScope();
+      Program(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
         const tracker = new ReferenceTracker(scope);
 
         /**

--- a/lib/rules/prefer-ember-test-helpers.js
+++ b/lib/rules/prefer-ember-test-helpers.js
@@ -34,8 +34,11 @@ module.exports = {
     };
 
     return {
-      Program() {
-        const tracker = new ReferenceTracker(context.getScope());
+      Program(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
+        const tracker = new ReferenceTracker(scope);
         const traceMap = {
           blur: { [ReferenceTracker.CALL]: true },
           find: { [ReferenceTracker.CALL]: true },

--- a/lib/rules/require-fetch-import.js
+++ b/lib/rules/require-fetch-import.js
@@ -22,8 +22,11 @@ module.exports = {
 
   create(context) {
     return {
-      'Program:exit'() {
-        const tracker = new ReferenceTracker(context.getScope());
+      'Program:exit'(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+
+        const tracker = new ReferenceTracker(scope);
 
         const traceMap = {
           fetch: { [ReferenceTracker.CALL]: true },

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -68,15 +68,18 @@ module.exports = {
       },
 
       onCodePathStart(codePath, node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const ancestors = sourceCode.getAncestors
+          ? sourceCode.getAncestors(node)
+          : context.getAncestors();
+
         funcInfo = {
           upper: funcInfo,
           codePath,
           shouldCheck:
-            context.sourceCode
-              .getAncestors(node)
-              .findIndex((node) =>
-                ember.isComputedProp(node, importedEmberName, importedComputedName)
-              ) > -1,
+            ancestors.findIndex((node) =>
+              ember.isComputedProp(node, importedEmberName, importedComputedName)
+            ) > -1,
           node,
           currentSegments: new Set(),
         };

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -43,7 +43,6 @@ module.exports = {
     let funcInfo = {
       upper: null,
       codePath: null,
-      hasReturn: false,
       shouldCheck: false,
       node: null,
       currentSegments: [],
@@ -72,7 +71,6 @@ module.exports = {
         funcInfo = {
           upper: funcInfo,
           codePath,
-          hasReturn: false,
           shouldCheck:
             context.sourceCode
               .getAncestors(node)

--- a/lib/rules/require-return-from-computed.js
+++ b/lib/rules/require-return-from-computed.js
@@ -7,8 +7,14 @@ const { getImportIdentifier } = require('../utils/import');
 // General rule - Always return a value from computed properties
 //------------------------------------------------------------------------------
 
-function isReachable(segment) {
-  return segment.reachable;
+function isAnySegmentReachable(segments) {
+  for (const segment of segments) {
+    if (segment.reachable) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 const ERROR_MESSAGE = 'Always return a value from computed properties';
@@ -37,19 +43,20 @@ module.exports = {
     let funcInfo = {
       upper: null,
       codePath: null,
+      hasReturn: false,
       shouldCheck: false,
       node: null,
+      currentSegments: [],
     };
 
     function checkLastSegment(node) {
-      if (funcInfo.shouldCheck && funcInfo.codePath.currentSegments.some(isReachable)) {
+      if (funcInfo.shouldCheck && isAnySegmentReachable(funcInfo.currentSegments)) {
         report(node);
       }
     }
 
     let importedEmberName;
     let importedComputedName;
-
     return {
       ImportDeclaration(node) {
         if (node.source.value === 'ember') {
@@ -61,21 +68,40 @@ module.exports = {
         }
       },
 
-      onCodePathStart(codePath) {
+      onCodePathStart(codePath, node) {
         funcInfo = {
           upper: funcInfo,
           codePath,
+          hasReturn: false,
           shouldCheck:
-            context
-              .getAncestors()
+            context.sourceCode
+              .getAncestors(node)
               .findIndex((node) =>
                 ember.isComputedProp(node, importedEmberName, importedComputedName)
               ) > -1,
+          node,
+          currentSegments: new Set(),
         };
       },
 
+      // Pops this function's information.
       onCodePathEnd() {
         funcInfo = funcInfo.upper;
+      },
+      onUnreachableCodePathSegmentStart(segment) {
+        funcInfo.currentSegments.add(segment);
+      },
+
+      onUnreachableCodePathSegmentEnd(segment) {
+        funcInfo.currentSegments.delete(segment);
+      },
+
+      onCodePathSegmentStart(segment) {
+        funcInfo.currentSegments.add(segment);
+      },
+
+      onCodePathSegmentEnd(segment) {
+        funcInfo.currentSegments.delete(segment);
       },
 
       'FunctionExpression:exit'(node) {

--- a/lib/rules/use-ember-get-and-set.js
+++ b/lib/rules/use-ember-get-and-set.js
@@ -98,7 +98,9 @@ module.exports = {
 
       VariableDeclarator(node) {
         const isEmberImported = Boolean(emberImportAliasName);
-        const isModuleScope = context.getScope().type === 'module';
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+        const isModuleScope = scope.type === 'module';
         if (isEmberImported && isModuleScope) {
           // Populate localModulesPresent as a mapping of (avoided method -> local module alias)
           for (const methodName of avoidedMethods) {


### PR DESCRIPTION
There are a couple deprecations in eslint that are preventing this plugin from working under v9. As this addon already supports the flat config format, I believe these should be the only changes needed to work under v9. 

`currentSegments` deprecation: https://github.com/eslint/eslint/issues/17457
'context.getAncestors` deprecation: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getancestors()

This was my reference for how to fix this rule: https://github.com/eslint/eslint/blob/main/lib/rules/getter-return.js