### PR TITLE
Consider `_test.{js|ts|gjs|gts}` as test file.

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -176,9 +176,12 @@ function isModuleByFilePath(filePath, module) {
 }
 
 const validFileExtensions = ['js', 'ts', 'gjs', 'gts'];
+const validTestFilePatterns = ['-test', '_test'];
 
 function isTestFile(fileName) {
-  return validFileExtensions.some((ext) => fileName.endsWith(`-test.${ext}`));
+  return validFileExtensions.some((ext) =>
+    validTestFilePatterns.some((testFilePattern) => fileName.endsWith(`${testFilePattern}.${ext}`))
+  );
 }
 
 function isMirageDirectory(fileName) {

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -136,11 +136,18 @@ describe('isMirageConfig', () => {
 });
 
 describe('isTestFile', () => {
-  it('detects test files', () => {
+  it('detects test files ending with -test', () => {
     expect(emberUtils.isTestFile('some-test.js')).toBeTruthy();
     expect(emberUtils.isTestFile('some-test.ts')).toBeTruthy();
     expect(emberUtils.isTestFile('some-test.gjs')).toBeTruthy();
     expect(emberUtils.isTestFile('some-test.gts')).toBeTruthy();
+  });
+
+  it('detects test files ending with _test', () => {
+    expect(emberUtils.isTestFile('some_test.js')).toBeTruthy();
+    expect(emberUtils.isTestFile('some_test.ts')).toBeTruthy();
+    expect(emberUtils.isTestFile('some_test.gjs')).toBeTruthy();
+    expect(emberUtils.isTestFile('some_test.gts')).toBeTruthy();
   });
 
   it('does not detect other files', () => {


### PR DESCRIPTION
`isTestFile` used by 13 rules only consider files ending with `-test.{js|ts|gjs|gts}`.

Some codebase uses test files named as `c`, but doing so some eslint rules are basically ignored.

Thus, with this PR, we allow files named as `_test.{js|ts|gjs|gts}` to be considered as what they are: test files.

Note that this could be a setting providing by each app but we kept it simple at first.