### PR TITLE
Allow imports from `ember-data/store`

### DIFF
--- a/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/lib/rules/use-ember-data-rfc-395-imports.js
@@ -96,6 +96,11 @@ module.exports = {
        * into `import { attr } from "@ember-data/attr"`
        */
       ImportDeclaration(node) {
+        // 'ember-data/store' is a valid import again: https://deprecations.emberjs.com/id/ember-data-deprecate-legacy-imports/
+        if (node.source.value === 'ember-data/store') {
+          return;
+        }
+
         if (node.source.value in OLD_DATA_IMPORTS) {
           const fix = buildFix(node, OLD_DATA_IMPORTS);
           context.report({ node, message, fix });

--- a/tests/lib/rules/use-ember-data-rfc-395-imports.js
+++ b/tests/lib/rules/use-ember-data-rfc-395-imports.js
@@ -44,6 +44,7 @@ ruleTester.run('use-ember-data-rfc-395-imports', rule, {
     "import ModelRegistry from 'ember-data/types/registries/model';",
     "import SerializerRegistry from 'ember-data/types/registries/serializer';",
     "import TransformRegistry from 'ember-data/types/registries/transform';",
+    "import Store from 'ember-data/store';",
   ],
 
   invalid: [


### PR DESCRIPTION
This adjusts the `use-ember-data-rfc-395` rule so imports from `ember-data/store` are allowed.

It is a valid import according to the deprecation guides: https://deprecations.emberjs.com/id/ember-data-deprecate-legacy-imports/

Closes https://github.com/ember-cli/eslint-plugin-ember/issues/2156