### PR TITLE
Fixed #2078: Allow let to be used in the test flies.

### DIFF
--- a/lib/rules/template-no-let-reference.js
+++ b/lib/rules/template-no-let-reference.js
@@ -18,8 +18,13 @@ module.exports = {
 
   create: (context) => {
     const sourceCode = context.sourceCode;
+    const pathname = context.physicalFilename;
 
     function checkIfWritableReferences(node, scope) {
+      // Return if the pathname starts with '/start/'
+      if (pathname.startsWith('/tests/')) {
+        return;
+      }
       const ref = scope.references.find((v) => v.identifier === node);
       if (!ref) {
         return;


### PR DESCRIPTION
This allows referencing let variables in the files in the tests directory without causing linting errors.

 Fixed issue #2078 