### PR TITLE
Export Utils to Allow Better Lint Extension of Common Ember Patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "./recommended": {
       "import": "./lib/recommended.mjs"
     },
-    "./configs/*": "./lib/config/*.js"
+    "./configs/*": "./lib/config/*.js",
+    "./utils/*": "./lib/utils/*.js"
   },
   "main": "./lib/index.js",
   "directories": {


### PR DESCRIPTION
When working on custom patterns for teams, it is pretty common to need to do things like deprecate a service method/property or some other Ember pattern specific feature.

The `utils` in this project are really useful, but currently are not exported in anyway so teams have to recreate them on their own.

> [!NOTE]
> An alternative to exporting these utilities would be to make this project a monorepo/workspace and publish a helpers/utils package explicitly. IMO this is actually a better experience so that users could use things like `getImportIdentifier` without tying directly to Ember.