### PR TITLE
Fix no-deprecated-router-transition-methods and no-implicit-injections when route is using mixins.

### DIFF
--- a/lib/rules/no-deprecated-router-transition-methods.js
+++ b/lib/rules/no-deprecated-router-transition-methods.js
@@ -25,10 +25,11 @@ function getBaseFixSteps(fixer, context, currentClass) {
   }
 
   if (!routerServicePropertyName) {
+    const targetIndex = currentClass.node.arguments?.findIndex(arg => arg?.properties?.[0]) ?? 0
     fixSteps.push(
       currentClass.node.type === 'CallExpression'
         ? fixer.insertTextBefore(
-            currentClass.node.arguments[0].properties[0],
+            currentClass.node.arguments[targetIndex].properties[0],
             `router: ${serviceInjectImportName}('router'),\n`
           )
         : fixer.insertTextBefore(

--- a/lib/rules/no-implicit-injections.js
+++ b/lib/rules/no-implicit-injections.js
@@ -28,9 +28,10 @@ const MODULE_TYPES = [
 function fixService(fixer, currentClass, serviceInjectImportName, failedConfig) {
   const serviceInjectPath = failedConfig.service;
 
+  const targetIndex = currentClass.node.arguments?.findIndex(arg => arg?.properties?.[0]) ?? 0
   return currentClass.node.type === 'CallExpression'
     ? fixer.insertTextBefore(
-        currentClass.node.arguments[0].properties[0],
+        currentClass.node.arguments[targetIndex].properties[0],
         `${failedConfig.propertyName}: ${serviceInjectImportName}('${serviceInjectPath}'),\n`
       )
     : fixer.insertTextBefore(


### PR DESCRIPTION
* Get first index which has properties to make sure the lint rule works even if route is using mixins