### PR TITLE
Determine Property Types in Native Classes

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -31,7 +31,10 @@ module.exports = {
   isEmberHelper,
   isEmberProxy,
 
+  isActionMethod,
+  isSingleLineAccessor,
   isSingleLineFn,
+  isMultiLineAccessor,
   isMultiLineFn,
   isFunctionExpression,
 
@@ -478,10 +481,12 @@ function isObjectProp(node) {
   return types.isObjectExpression(node.value);
 }
 
-function isCustomProp(property) {
-  const value = property.value;
+function isCustomProp(property, isNativeClass = false) {
+  const { value } = property;
   if (!value) {
-    return false;
+    // Native classes allow for empty values
+    // e.g. class Example { foo; }
+    return isNativeClass;
   }
   const isCustomObjectProp = types.isObjectExpression(value) && property.key.name !== 'actions';
 
@@ -507,6 +512,13 @@ function isActionsProp(property) {
     property.key.name === 'actions' &&
     types.isObjectExpression(property.value)
   );
+}
+
+function isActionMethod(property) {
+  if (property?.type === 'MethodDefinition') {
+    return decoratorUtils.hasDecorator(property, 'action');
+  }
+  return false;
 }
 
 function isComponentLifecycleHookName(name) {
@@ -635,6 +647,13 @@ function getEmberImportAliasName(importDeclaration) {
   return importDeclaration.specifiers[0].local.name;
 }
 
+function isSingleLineAccessor(property) {
+  return (
+    (types.isPropAccessor(property) || decoratorUtils.hasDecorator(property, 'computed')) &&
+    utils.getSize(property) === 1
+  );
+}
+
 function isSingleLineFn(property, importedEmberName, importedObserverName) {
   return (
     (types.isMethodDefinition(property) && utils.getSize(property) === 1) ||
@@ -644,6 +663,13 @@ function isSingleLineFn(property, importedEmberName, importedObserverName) {
       !isObserverProp(property, importedEmberName, importedObserverName) &&
       (isComputedProp(property.value, importedEmberName, 'computed', { includeSuffix: true }) ||
         !types.isCallWithFunctionExpression(property.value)))
+  );
+}
+
+function isMultiLineAccessor(property) {
+  return (
+    (types.isPropAccessor(property) || decoratorUtils.hasDecorator(property, 'computed')) &&
+    utils.getSize(property) > 1
   );
 }
 
@@ -663,7 +689,8 @@ function isFunctionExpression(property) {
   return (
     types.isFunctionExpression(property) ||
     types.isArrowFunctionExpression(property) ||
-    types.isCallWithFunctionExpression(property)
+    types.isCallWithFunctionExpression(property) ||
+    types.isCallWithArrowFunctionExpression(property)
   );
 }
 

--- a/lib/utils/property-order.js
+++ b/lib/utils/property-order.js
@@ -7,6 +7,7 @@ const decoratorUtils = require('../utils/decorators');
 
 module.exports = {
   determinePropertyType,
+  determinePropertyTypeInNativeClass,
   reportUnorderedProperties,
   addBackwardsPosition,
 };
@@ -143,6 +144,95 @@ function determinePropertyType(
   // Handle both babel-eslint and @babel/eslint-parser
   if (node.type === 'ExperimentalSpreadProperty' || node.type === 'SpreadElement') {
     return 'spread';
+  }
+
+  return 'unknown';
+}
+
+function determinePropertyTypeInNativeClass(
+  node,
+  parentType,
+  ORDER,
+  importedEmberName,
+  importedInjectName,
+  importedObserverName,
+  importedControllerName
+) {
+  if (node === undefined) {
+    return 'unknown';
+  }
+
+  if (ember.isInjectedServiceProp(node, importedEmberName, importedInjectName)) {
+    return 'service';
+  }
+
+  if (ember.isInjectedControllerProp(node, importedEmberName, importedControllerName)) {
+    return 'controller';
+  }
+
+  if (node.type === 'MethodDefinition' && node.key.name === 'constructor') {
+    return 'constructor';
+  }
+
+  if (parentType === 'component') {
+    if (node.type === 'MethodDefinition' && ember.isComponentLifecycleHook(node)) {
+      return node.key.name;
+    }
+  } else if (parentType === 'controller') {
+    if (
+      node.key !== undefined &&
+      node.key.type === 'Identifier' &&
+      node.key.name === 'queryParams'
+    ) {
+      return 'query-params';
+    } else if (ember.isControllerDefaultProp(node)) {
+      return 'inherited-property';
+    }
+  } else if (parentType === 'model') {
+    if (decoratorUtils.isClassPropertyOrPropertyDefinitionWithDecorator(node, 'attr')) {
+      return 'attribute';
+    } else if (ember.isRelation(node)) {
+      return 'relationship';
+    }
+  } else if (parentType === 'route') {
+    if (ember.isRouteDefaultProp(node)) {
+      return 'inherited-property';
+    } else if (ember.isRouteLifecycleHook(node)) {
+      return node.key.name;
+    }
+  }
+
+  if (parentType !== 'model' && ember.isActionMethod(node)) {
+    return 'action';
+  }
+
+  if (ember.isSingleLineAccessor(node)) {
+    return 'single-line-accessor';
+  }
+
+  if (ember.isMultiLineAccessor(node)) {
+    return 'multi-line-accessor';
+  }
+
+  const propName = getNodeKeyName(node);
+  const possibleOrderName = `custom:${propName}`;
+  if (ORDER.includes(possibleOrderName)) {
+    return possibleOrderName;
+  }
+
+  if (
+    (node.type === 'ClassProperty' || node.type === 'PropertyDefinition') &&
+    ember.isCustomProp(node, true)
+  ) {
+    return 'property';
+  }
+
+  if (node.value && ember.isFunctionExpression(node.value)) {
+    if (utils.isEmptyMethod(node)) {
+      return 'empty-method';
+    }
+
+    return 'method';
   }
 
   return 'unknown';

--- a/lib/utils/types.js
+++ b/lib/utils/types.js
@@ -14,6 +14,7 @@ module.exports = {
   isAssignmentExpression,
   isBinaryExpression,
   isCallExpression,
+  isCallWithArrowFunctionExpression,
   isCallWithFunctionExpression,
   isClassDeclaration,
   isClassPropertyOrPropertyDefinition,
@@ -36,6 +37,7 @@ module.exports = {
   isObjectPattern,
   isOptionalCallExpression,
   isOptionalMemberExpression,
+  isPropAccessor,
   isProperty,
   isReturnStatement,
   isSpreadElement,
@@ -111,6 +113,36 @@ function isBinaryExpression(node) {
  */
 function isCallExpression(node) {
   return node !== undefined && node.type === 'CallExpression';
+}
+
+/**
+ * Check whether or not a node is a CallExpression that has a
+ * ArrowExpression as the first argument
+ *
+ * @example
+ * ```js
+ * // Native class
+ * tSomeAction = mysteriousFnc(() => {})
+ *
+ * // Classic Ember object
+ * tSomeAction: mysteriousFnc(() => {})
+ * ```
+ *
+ * @param  {Object} node The node to check
+ * @return {boolean} Whether or not the node is a call with a arrow function expression as the first argument
+ */
+function isCallWithArrowFunctionExpression(node) {
+  if (!node?.type === 'CallExpression') {
+    return false;
+  }
+  const callObj = node.callee?.type === 'MemberExpression' ? node.callee.object : node;
+  const firstArg = callObj.arguments ? callObj.arguments[0] : null;
+  return (
+    callObj !== undefined &&
+    callObj?.type === 'CallExpression' &&
+    firstArg &&
+    firstArg?.type === 'ArrowFunctionExpression'
+  );
 }
 
 /**
@@ -356,6 +388,16 @@ function isOptionalCallExpression(node) {
  */
 function isOptionalMemberExpression(node) {
   return node.type === 'OptionalMemberExpression';
+}
+
+/**
+ * Check whether a node is a property accessor (get/set).
+ *
+ * @param {Node} node the node to check
+ * @returns {boolean} whether the node is an accessor
+ */
+function isPropAccessor(node) {
+  return node?.type === 'MethodDefinition' && ['get', 'set'].includes(node?.kind);
 }
 
 /**

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -5,7 +5,13 @@ const emberUtils = require('../../../lib/utils/ember');
 const { FauxContext } = require('../../helpers/faux-context');
 
 function parse(code) {
-  return babelESLintParse(code).body[0].expression;
+  const { body } = babelESLintParse(code);
+  const [firstBodyNode] = body;
+  if (firstBodyNode.type === 'ClassDeclaration') {
+    // return first node within ClassBody
+    return firstBodyNode.body.body[0];
+  }
+  return firstBodyNode.expression;
 }
 
 function getProperty(code) {
@@ -320,7 +326,7 @@ describe('isEmberComponent', () => {
   });
 });
 
-describe('isGlimerComponent', () => {
+describe('isGlimmerComponent', () => {
   describe("should check if it's a Glimmer Component", () => {
     it('should detect Component when using native classes', () => {
       const context = new FauxContext(`
@@ -1475,6 +1481,18 @@ describe('isActionsProp', () => {
   });
 });
 
+describe('isActionMethod', () => {
+  const node = parse(
+    `class Test {
+    @action foo() {}
+  }`
+  );
+
+  it('should be actions method', () => {
+    expect(emberUtils.isActionMethod(node)).toBeTruthy();
+  });
+});
+
 describe('getModuleProperties', () => {
   it("returns module's properties", () => {
     const code = `
@@ -1535,6 +1553,18 @@ describe('getModuleProperties', () => {
   });
 });
 
+describe('isSingleLineAccessor', () => {
+  const node = parse(
+    `class Test {
+    get foo() { return 'bar'; }
+  }`
+  );
+
+  it('should be single line accessor', () => {
+    expect(emberUtils.isSingleLineAccessor(node)).toBeTruthy();
+  });
+});
+
 describe('isSingleLineFn', () => {
   const property = getProperty(`test = {
     test: computed.or('asd', 'qwe')
@@ -1560,6 +1590,20 @@ describe('isSingleLineFn', () => {
     `);
     node = context.ast.body[0].body.body[0];
     expect(emberUtils.isSingleLineFn(node)).toBeFalsy();
+  });
+});
+
+describe('isMultiLineAccessor', () => {
+  const node = parse(
+    `class Test {
+    get foo() { 
+      return 'bar';
+    }
+  }`
+  );
+
+  it('should be multi line accessor', () => {
+    expect(emberUtils.isMultiLineAccessor(node)).toBeTruthy();
   });
 });
 
@@ -1614,6 +1658,11 @@ describe('isFunctionExpression', () => {
 
     property = getProperty(`test = {
       test: () => {}
+    }`);
+    expect(emberUtils.isFunctionExpression(property.value)).toBeTruthy();
+
+    property = getProperty(`test = {
+      test: someFn(() => {})
     }`);
     expect(emberUtils.isFunctionExpression(property.value)).toBeTruthy();
   });

--- a/tests/lib/utils/types-test.js
+++ b/tests/lib/utils/types-test.js
@@ -1,12 +1,14 @@
 const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const types = require('../../../lib/utils/types');
 
-function parse(code, isClassDeclaration = false) {
-  if (isClassDeclaration) {
-    // return ClassBody
-    return babelESLintParse(code).body[0].body;
+function parse(code) {
+  const { body } = babelESLintParse(code);
+  const [firstBodyNode] = body;
+  if (firstBodyNode.type === 'ClassDeclaration') {
+    // return first node within ClassBody
+    return firstBodyNode.body.body[0];
   }
-  return babelESLintParse(code).body[0].expression;
+  return firstBodyNode.expression;
 }
 
 describe('function sort order', function () {
@@ -131,9 +133,8 @@ describe('isPropAccessor', () => {
     const node = parse(
       `class Test {
       get fooProp() {}
-    }`,
-      true
-    ).body[0];
+    }`
+    );
     expect(types.isPropAccessor(node)).toBeTruthy();
   });
 
@@ -141,9 +142,8 @@ describe('isPropAccessor', () => {
     const node = parse(
       `class Test {
       set fooProp(bar) {}
-    }`,
-      true
-    ).body[0];
+    }`
+    );
     expect(types.isPropAccessor(node)).toBeTruthy();
   });
 
@@ -151,9 +151,8 @@ describe('isPropAccessor', () => {
     const node = parse(
       `class Test {
       fooProp() {}
-    }`,
-      true
-    ).body[0];
+    }`
+    );
     expect(types.isPropAccessor(node)).toBeFalsy();
   });
 });

--- a/tests/lib/utils/types-test.js
+++ b/tests/lib/utils/types-test.js
@@ -1,7 +1,11 @@
 const { parse: babelESLintParse } = require('../../helpers/babel-eslint-parser');
 const types = require('../../../lib/utils/types');
 
-function parse(code) {
+function parse(code, isClassDeclaration = false) {
+  if (isClassDeclaration) {
+    // return ClassBody
+    return babelESLintParse(code).body[0].body;
+  }
   return babelESLintParse(code).body[0].expression;
 }
 
@@ -42,6 +46,14 @@ describe('isCallWithFunctionExpression', () => {
 
   it('should check if node is call with function expression', () => {
     expect(types.isCallWithFunctionExpression(node)).toBeTruthy();
+  });
+});
+
+describe('isCallWithArrowFunctionExpression', () => {
+  const node = parse('mysteriousFnc(() => {})');
+
+  it('should check if node is call with function expression', () => {
+    expect(types.isCallWithArrowFunctionExpression(node)).toBeTruthy();
   });
 });
 
@@ -111,6 +123,38 @@ describe('isObjectExpression', () => {
 
   it('should check if node is identifier', () => {
     expect(types.isObjectExpression(node)).toBeTruthy();
+  });
+});
+
+describe('isPropAccessor', () => {
+  it('should check if node is a getter', () => {
+    const node = parse(
+      `class Test {
+      get fooProp() {}
+    }`,
+      true
+    ).body[0];
+    expect(types.isPropAccessor(node)).toBeTruthy();
+  });
+
+  it('should check if node is a setter', () => {
+    const node = parse(
+      `class Test {
+      set fooProp(bar) {}
+    }`,
+      true
+    ).body[0];
+    expect(types.isPropAccessor(node)).toBeTruthy();
+  });
+
+  it('should check if node is a not a getter/setter', () => {
+    const node = parse(
+      `class Test {
+      fooProp() {}
+    }`,
+      true
+    ).body[0];
+    expect(types.isPropAccessor(node)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
### PR Category
- New feature (code which adds functionality)

### Requirement/Problem
Add ability to distinguish property/method types in Native JS classes, for later consumption of `reportUnorderedProperties`
Relates to https://github.com/ember-cli/eslint-plugin-ember/issues/417

### Solution
- Create separate helper to separate logic for Ember Classic Objects vs. Ember Octane (Glimmer) Native Classes
  - Create separate naming conventions for new properties since getters/setters ≠ `'single-line-functions'`
  - For consumption of order-in-* rule, users should specify them to be treated equally
  e.g. `['single-line-function', 'single-line-accessor']`
  e.g. `['actions', 'action']`

### ToDo
- In separate PR
  - Consume new helper in `reportUnorderedProperties` and wire-up to order-in-* rules
  - Update docs and default values for order-in-* rules