### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
+++ b/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js
@@ -137,6 +137,7 @@ module.exports = {
                             minimum: 1,
                           },
                         },
+                        additionalProperties: false,
                       },
                       objects: {
                         type: 'object',

--- a/lib/rules/no-side-effects.js
+++ b/lib/rules/no-side-effects.js
@@ -164,6 +164,7 @@ module.exports = {
               'Whether the rule should check plain (non-computed) getters in native classes for side effects.',
           },
         },
+        additionalProperties: false,
       },
     ],
   },


### PR DESCRIPTION
Some rules, for example [no-assignment-of-untracked-properties-used-in-tracking-contexts](https://github.com/ember-cli/eslint-plugin-ember/blob/5a8810c6635f7458cb10390d724c1658c6ef9b93/lib/rules/no-assignment-of-untracked-properties-used-in-tracking-contexts.js#L124) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.