### PR TITLE
fix: no-runloop: catch namespace imports

### DIFF
--- a/lib/rules/no-runloop.js
+++ b/lib/rules/no-runloop.js
@@ -76,6 +76,11 @@ module.exports = {
     const allowList = context.options[0]?.allowList ?? [];
     // Maps local names to imported names of imports
     const localToImportedNameMap = new Map();
+    let namespaceImportName;
+
+    const isDisallowed = function (fn) {
+      return EMBER_RUNLOOP_FUNCTIONS.includes(fn) && !allowList.includes(fn);
+    };
 
     /**
      * Reports a node with usage of a disallowed runloop function
@@ -109,38 +114,50 @@ module.exports = {
               if (EMBER_RUNLOOP_FUNCTIONS.includes(importedName)) {
                 localToImportedNameMap.set(spec.local.name, importedName);
               }
+            } else if (spec.type === 'ImportNamespaceSpecifier') {
+              namespaceImportName = spec.local.name;
             }
           }
         }
       },
 
       CallExpression(node) {
+        const callee = node.callee;
+
         // Examples: run(...), later(...)
-        if (node.callee.type === 'Identifier') {
-          const name = node.callee.name;
-          const runloopFn = localToImportedNameMap.get(name);
-          const isNotAllowed = runloopFn && !allowList.includes(runloopFn);
-          if (isNotAllowed) {
-            report(node, runloopFn, name);
+        if (callee.type === 'Identifier') {
+          const localName = callee.name;
+          const runloopFn = localToImportedNameMap.get(localName);
+
+          if (runloopFn && isDisallowed(runloopFn)) {
+            report(node, runloopFn, localName);
           }
+
+          return;
         }
 
-        // runloop functions (aside from run itself) can chain onto `run`, so we need to check for this
-        // Examples: run.later(...), run.schedule(...)
-        if (node.callee.type === 'MemberExpression' && node.callee.object?.type === 'Identifier') {
-          const objectName = node.callee.object.name;
-          const objectRunloopFn = localToImportedNameMap.get(objectName);
+        if (
+          callee.type === 'MemberExpression' &&
+          callee.object.type === 'Identifier' &&
+          callee.property.type === 'Identifier'
+        ) {
+          const objectName = callee.object.name;
+          const methodName = callee.property.name;
 
-          if (objectRunloopFn === 'run' && node.callee.property?.type === 'Identifier') {
-            const runloopFn = node.callee.property.name;
+          // runloop functions (aside from run itself) can chain onto `run`, so we need to check for this
+          // Examples: run.later(...), run.schedule(...)
+          if (
+            localToImportedNameMap.get(objectName) === 'run' &&
+            isDisallowed(methodName) &&
+            methodName !== 'run'
+          ) {
+            report(node, methodName, `${objectName}.${methodName}`);
+            return;
+          }
 
-            if (
-              EMBER_RUNLOOP_FUNCTIONS.includes(runloopFn) &&
-              runloopFn !== 'run' &&
-              !allowList.includes(runloopFn)
-            ) {
-              report(node, runloopFn, `${objectName}.${runloopFn}`);
-            }
+          // Example: `import * as runloop from '@ember/runloop'` -> `runloop.later(...)`
+          if (objectName === namespaceImportName && isDisallowed(methodName)) {
+            report(node, methodName, `${objectName}.${methodName}`);
           }
         }
       },

--- a/tests/lib/rules/no-runloop.js
+++ b/tests/lib/rules/no-runloop.js
@@ -222,5 +222,18 @@ eslintTester.run('no-runloop', rule, {
         },
       ],
     },
+    {
+      code: `
+        import * as run from '@ember/runloop';
+        run.later();
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'lifelineReplacement',
+          type: 'CallExpression',
+        },
+      ],
+    }
   ],
 });

--- a/tests/lib/rules/no-runloop.js
+++ b/tests/lib/rules/no-runloop.js
@@ -234,6 +234,6 @@ eslintTester.run('no-runloop', rule, {
           type: 'CallExpression',
         },
       ],
-    }
+    },
   ],
 });


### PR DESCRIPTION
Let's update the `no-runloop` rule to flag usages of `@ember/runloop` methods when imported via namespace import (e.g. `import * as runloop from '@ember/runloop'`) and used via member expressions (e.g. `runloop.later(), runloop.schedule(), etc.).

This fixes: #2263.