### PR TITLE
fix: `no-array-prototype-extensions` rule to lint against `setObjects()`

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -50,7 +50,7 @@ const EXTENSION_METHODS = new Set([
   'removeObject',
   'removeObjects',
   'reverseObjects',
-  'setObject',
+  'setObjects',
   'shiftObject',
   'unshiftObject',
   'unshiftObjects',

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -1290,7 +1290,7 @@ import { get as g } from '@custom/object';
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },
     {
-      code: 'something.setObject()',
+      code: 'something.setObjects()',
       output: null,
       errors: [{ messageId: 'main', type: 'CallExpression' }],
     },


### PR DESCRIPTION
The method `setObject()` (singular) has never existed, only the plural version has existed:

- https://api.emberjs.com/ember/3.0/classes/MutableArray/methods/setObjects?anchor=setObjects
- https://api.emberjs.com/ember/4.0/classes/MutableArray/methods/setObjects?anchor=setObjects
- https://api.emberjs.com/ember/5.12/classes/MutableArray/methods/setObjects?anchor=setObjects

---

cc @simonihmig , if we want to wait for this to be released or if we want to patch the library internally.