### PR TITLE
Ignore `findBy` calls from `ember-cli-mirage` in `no-array-prototype-extensions`

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -90,6 +90,15 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
 ]);
 
 /**
+ * Ignore these function calls using RegExps.
+ */
+const KNOWN_NON_ARRAY_FUNCTION_CALLS_REGEXP = new Set([
+  // ember-cli-mirage
+  /(window|undefined)\.server\.schema\.(.*)\.findBy\(\)/,
+]);
+
+
+/**
  * Ignore objects of these names.
  */
 const KNOWN_NON_ARRAY_OBJECTS = new Set([
@@ -690,6 +699,13 @@ module.exports = {
         ) {
           // Ignore any known non-array objects/function calls to reduce false positives.
           return;
+        }
+
+        for (const expression of KNOWN_NON_ARRAY_FUNCTION_CALLS_REGEXP) {
+          // Ignore any known non-array function calls matching a regular expression to reduce false positives.
+          if (expression.test(name)) {
+            return;
+          }
         }
 
         for (const functionName of FN_NAMES_TO_KNOWN_NON_ARRAY_WORDS.keys()) {

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -97,7 +97,6 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS_REGEXP = new Set([
   /(window|undefined)\.server\.schema\.(.*)\.findBy\(\)/,
 ]);
 
-
 /**
  * Ignore objects of these names.
  */

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -94,7 +94,7 @@ const KNOWN_NON_ARRAY_FUNCTION_CALLS = new Set([
  */
 const KNOWN_NON_ARRAY_FUNCTION_CALLS_REGEXP = new Set([
   // ember-cli-mirage
-  /(window|undefined)\.server\.schema\.(.*)\.findBy\(\)/,
+  /\.server\.schema\.(.*)\.findBy\(\)/,
 ]);
 
 /**

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -247,6 +247,12 @@ ruleTester.run('no-array-prototype-extensions', rule, {
 
     // TODO: handle non-Identifier property names:
     'foo["clear"]();',
+
+    // Common ember-cli-mirage calls
+    'this.server.schema.users.findBy()',
+    'this.server.schema.devices.findBy()',
+    'this.server.schema.users.findBy({ foo: "bar" })',
+    'this.server.schema.devices.findBy({ foo: "bar" })',
   ],
   invalid: [
     {


### PR DESCRIPTION
We're trying to fix array prototype extensions usages in our project, and are running into a lot of false positives in our tests when using `findBy` from `ember-cli-mirage`:

```js
this.server.schema.courses.findBy({ slug: 'dummy' });
this.server.schema.users.findBy({ username: 'test' });
```

This adds an exception to `lib/rules/no-array-prototype-extensions.js` and adjusts the tests.