### PR TITLE
chore: try actions/setup-node before pnpm/action-setup

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -52,10 +52,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: 'master'
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
         with:
           node-version: 18
-      - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
         with:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-      - uses: pnpm/action-setup@v4
       - run: pnpm install --frozen-lockfile
       - run: pnpm release-plan publish --provenance
         env:


### PR DESCRIPTION
I'm seeing a failure with .github/workflows/plan-release.yml:

```
Run actions/setup-node@v5
Found in cache @ /opt/hostedtoolcache/node/18.20.8/x64
(node:2235) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Environment details
Error: Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

Updating to match the order from: https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time

Might have been caused by: 
- https://github.com/ember-cli/eslint-plugin-ember/pull/2330
