### PR TITLE
fix: allow decorated template-tag-only classes

### DIFF
--- a/docs/rules/no-empty-glimmer-component-classes.md
+++ b/docs/rules/no-empty-glimmer-component-classes.md
@@ -72,6 +72,16 @@ class MyComponent extends Component {}
 
 ```js
 import Component from '@glimmer/component';
+import MyDecorator from 'my-decorator';
+
+@MyDecorator
+class MyComponent extends Component {
+  <template>foo</template>
+}
+```
+
+```js
+import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
   foo() {

--- a/lib/rules/no-empty-glimmer-component-classes.js
+++ b/lib/rules/no-empty-glimmer-component-classes.js
@@ -40,6 +40,7 @@ module.exports = {
         } else if (
           node.body.body.length === 1 &&
           node.body.body[0].type === 'GlimmerTemplate' &&
+          !node.decorators?.length &&
           !subClassHasTypeDefinition
         ) {
           context.report({ node, message: ERROR_MESSAGE_TEMPLATE_TAG });

--- a/tests/lib/rules/no-empty-glimmer-component-classes.js
+++ b/tests/lib/rules/no-empty-glimmer-component-classes.js
@@ -12,7 +12,7 @@ const { ERROR_MESSAGE } = rule;
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parser: require.resolve('ember-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2022,
     sourceType: 'module',
@@ -34,6 +34,13 @@ ruleTester.run('no-empty-glimmer-component-classes', rule, {
 
     @MyDecorator
     class MyComponent extends Component {}`,
+    `import Component from '@glimmer/component';
+    import MyDecorator from 'my-decorator';
+
+    @MyDecorator
+    class MyComponent extends Component {
+      <template>foo</template>
+    }`,
     {
       code: `
       import Component from '@glimmer/component';


### PR DESCRIPTION
…in `no-empty-glimmer-component-classes`, as it already allows decorated empty glimmer classes (w/o the tag template)