### PR TITLE
Consider .test.{js|ts|gjs|gts} as a test file pattern

### DIFF
--- a/lib/utils/ember.js
+++ b/lib/utils/ember.js
@@ -176,7 +176,7 @@ function isModuleByFilePath(filePath, module) {
 }
 
 const validFileExtensions = ['js', 'ts', 'gjs', 'gts'];
-const validTestFilePatterns = ['-test', '_test'];
+const validTestFilePatterns = ['-test', '_test', '.test'];
 
 function isTestFile(fileName) {
   return validFileExtensions.some((ext) =>

--- a/tests/lib/utils/ember-test.js
+++ b/tests/lib/utils/ember-test.js
@@ -150,6 +150,13 @@ describe('isTestFile', () => {
     expect(emberUtils.isTestFile('some_test.gts')).toBeTruthy();
   });
 
+  it('detects test files ending with .test', () => {
+    expect(emberUtils.isTestFile('some.test.js')).toBeTruthy();
+    expect(emberUtils.isTestFile('some.test.ts')).toBeTruthy();
+    expect(emberUtils.isTestFile('some.test.gjs')).toBeTruthy();
+    expect(emberUtils.isTestFile('some.test.gts')).toBeTruthy();
+  });
+
   it('does not detect other files', () => {
     expect(emberUtils.isTestFile('some-component.js')).toBeFalsy();
     expect(emberUtils.isTestFile('my-testing-component.js')).toBeFalsy();


### PR DESCRIPTION
Hello 👋 could you consider `.test` too as a valid test file pattern?

👀 This PR is similar to #2157, but for the `.test` test file pattern.

### The rationale

`.test.js` is a widely used test file pattern:

* it’s used by  CLI tools like Jest (cf. https://jestjs.io/docs/getting-started), Vitest (https://vitest.dev/guide/), TAP (cf. https://node-tap.org/cli/), etc.
* it’s recognized by IDEs like VSCode see the following screenshot where `.test.js` files (colored in brown) are specifically differentiated from other "source" files (colored in some shade of yellow):

<img width="432" height="796" alt="dot-test_files_in_VSCode" src="https://github.com/user-attachments/assets/8a64fb10-1ee4-4892-b411-0b5b38b9ab82" />

#### Concrete benefit (for the world 😁)

For example that would make possible to use the `.test.js` test file pattern for all the code of the https://github.com/1024pix/pix/ big monorepo which contains both Backend code and Ember Frontend code.