### PR TITLE
Extract rule: template-no-arguments-for-html-elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,12 @@ rules in templates can be disabled with eslint directives with mustache or html 
 
 ### Best Practices
 
-| Name                                                                                       | Description                                               | 💼 | 🔧 | 💡 |
-| :----------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :- | :- |
-| [template-builtin-component-arguments](docs/rules/template-builtin-component-arguments.md) | disallow setting certain attributes on builtin components |    |    |    |
-| [template-no-debugger](docs/rules/template-no-debugger.md)                                 | disallow {{debugger}} in templates                        |    |    |    |
-| [template-no-log](docs/rules/template-no-log.md)                                           | disallow {{log}} in templates                             |    |    |    |
+| Name                                                                                             | Description                                               | 💼 | 🔧 | 💡 |
+| :----------------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :- | :- |
+| [template-builtin-component-arguments](docs/rules/template-builtin-component-arguments.md)       | disallow setting certain attributes on builtin components |    |    |    |
+| [template-no-arguments-for-html-elements](docs/rules/template-no-arguments-for-html-elements.md) | disallow @arguments on HTML elements                      |    |    |    |
+| [template-no-debugger](docs/rules/template-no-debugger.md)                                       | disallow {{debugger}} in templates                        |    |    |    |
+| [template-no-log](docs/rules/template-no-log.md)                                                 | disallow {{log}} in templates                             |    |    |    |
 
 ### Components
 

--- a/docs/rules/template-no-arguments-for-html-elements.md
+++ b/docs/rules/template-no-arguments-for-html-elements.md
@@ -1,0 +1,64 @@
+# ember/template-no-arguments-for-html-elements
+
+<!-- end auto-generated rule header -->
+
+💼 This rule is enabled in the following [configs](https://github.com/ember-cli/eslint-plugin-ember#-configurations): `strict-gjs`, `strict-gts`.
+
+Disallow `@arguments` on HTML elements.
+
+Arguments (using the `@` prefix) are a feature specific to Ember components. They should not be used on regular HTML elements, which only support standard HTML attributes.
+
+## Rule Details
+
+This rule disallows using `@arguments` on HTML elements. Use regular attributes instead.
+
+## Examples
+
+### Incorrect ❌
+
+```gjs
+<template>
+  <div @title="Hello">Content</div>
+</template>
+```
+
+```gjs
+<template>
+  <button @onClick={{this.handler}}>Click</button>
+</template>
+```
+
+```gjs
+<template>
+  <span @data={{this.info}}>Text</span>
+</template>
+```
+
+### Correct ✅
+
+```gjs
+<template>
+  <div title="Hello">Content</div>
+</template>
+```
+
+```gjs
+<template>
+  <button {{on "click" this.handler}}>Click</button>
+</template>
+```
+
+```gjs
+<template>
+  <MyComponent @title="Hello" @onClick={{this.handler}} />
+</template>
+```
+
+## Related Rules
+
+- [template-no-block-params-for-html-elements](./template-no-block-params-for-html-elements.md)
+
+## References
+
+- [Ember Guides - Component Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/)
+- [eslint-plugin-ember template-no-args-paths](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/template-no-args-paths.md)

--- a/lib/rules/template-no-arguments-for-html-elements.js
+++ b/lib/rules/template-no-arguments-for-html-elements.js
@@ -1,0 +1,52 @@
+/** @type {import('eslint').Rule.RuleModule} */
+const htmlTags = require('html-tags');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow @arguments on HTML elements',
+      category: 'Best Practices',
+      strictGjs: true,
+      strictGts: true,
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-arguments-for-html-elements.md',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noArgumentsForHtmlElements:
+        '@arguments can only be used on components, not HTML elements. Use regular attributes instead.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const HTML_ELEMENTS = new Set(htmlTags);
+
+    return {
+      GlimmerElementNode(node) {
+        // Check if this is an HTML element (lowercase)
+        if (!HTML_ELEMENTS.has(node.tag)) {
+          return;
+        }
+
+        // If the tag name is a variable in scope, it's being used as a component, not an HTML element
+        const scope = sourceCode.getScope(node.parent);
+        const isVariable = scope.references.some((ref) => ref.identifier === node.parts[0]);
+        if (isVariable) {
+          return;
+        }
+
+        // Check for @arguments
+        for (const attr of node.attributes) {
+          if (attr.type === 'GlimmerAttrNode' && attr.name.startsWith('@')) {
+            context.report({
+              node: attr,
+              messageId: 'noArgumentsForHtmlElements',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",
+    "html-tags": "^3.3.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "requireindex": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       estraverse:
         specifier: ^5.3.0
         version: 5.3.0
+      html-tags:
+        specifier: ^3.3.1
+        version: 3.3.1
       lodash.camelcase:
         specifier: ^4.3.0
         version: 4.3.0

--- a/tests/lib/rules/template-no-arguments-for-html-elements.js
+++ b/tests/lib/rules/template-no-arguments-for-html-elements.js
@@ -1,0 +1,58 @@
+const rule = require('../../../lib/rules/template-no-arguments-for-html-elements');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('template-no-arguments-for-html-elements', rule, {
+  valid: [
+    '<template><div class="container">Content</div></template>',
+    '<template><button type="submit">Submit</button></template>',
+    '<template><MyComponent @title="Hello" @onClick={{this.handler}} /></template>',
+    '<template><CustomButton @disabled={{true}} /></template>',
+    '<template><input value={{this.value}} /></template>',
+    `let div = <template>{{@greeting}}</template>
+
+<template>
+  <div @greeting="hello" />
+</template>`,
+  ],
+
+  invalid: [
+    {
+      code: '<template><div @title="Hello">Content</div></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            '@arguments can only be used on components, not HTML elements. Use regular attributes instead.',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    {
+      code: '<template><button @onClick={{this.handler}}>Click</button></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            '@arguments can only be used on components, not HTML elements. Use regular attributes instead.',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    {
+      code: '<template><span @data={{this.info}}>Text</span></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            '@arguments can only be used on components, not HTML elements. Use regular attributes instead.',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Split from #2371.