### PR TITLE
Add strict-gjs and strict-gts configs so that users could opt in to these new rules from ember-template-lint before we do our next major

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ rules in templates can be disabled with eslint directives with mustache or html 
 | ✅                               | `recommended`     |
 | ![gjs logo](/docs/svgs/gjs.svg) | `recommended-gjs` |
 | ![gts logo](/docs/svgs/gts.svg) | `recommended-gts` |
+|                                 | `strict-gjs`      |
+|                                 | `strict-gts`      |
 
 <!-- end auto-generated configs list -->
 

--- a/lib/config-legacy/strict-gjs.js
+++ b/lib/config-legacy/strict-gjs.js
@@ -1,0 +1,5 @@
+const base = require('./base');
+
+module.exports = {
+  ...base,
+};

--- a/lib/config-legacy/strict-gts.js
+++ b/lib/config-legacy/strict-gts.js
@@ -1,0 +1,5 @@
+const base = require('./base');
+
+module.exports = {
+  ...base,
+};

--- a/lib/config/strict-gjs.js
+++ b/lib/config/strict-gjs.js
@@ -1,0 +1,3 @@
+const base = require('./base');
+
+module.exports = [...base];

--- a/lib/config/strict-gts.js
+++ b/lib/config/strict-gts.js
@@ -1,0 +1,3 @@
+const base = require('./base');
+
+module.exports = [...base];

--- a/tests/plugin-exports.js
+++ b/tests/plugin-exports.js
@@ -6,6 +6,8 @@ const base = require('../lib/config-legacy/base');
 const recommended = require('../lib/config-legacy/recommended');
 const recommendedGjs = require('../lib/config-legacy/recommended-gjs');
 const recommendedGts = require('../lib/config-legacy/recommended-gts');
+const strictGjs = require('../lib/config-legacy/strict-gjs');
+const strictGts = require('../lib/config-legacy/strict-gts');
 
 describe('plugin exports', () => {
   describe('utils', () => {
@@ -21,6 +23,8 @@ describe('plugin exports', () => {
         recommended,
         'recommended-gjs': recommendedGjs,
         'recommended-gts': recommendedGts,
+        'strict-gjs': strictGjs,
+        'strict-gts': strictGts,
       });
     });
   });


### PR DESCRIPTION
It's unclear how long porting over rules from ember-template-lint will take, but for the intrepid developers, this will be a much easier way to help us test