### PR TITLE
Post-merge-review: Fix `template-no-unused-block-params`: detect angle-bracket block params and walk modifiers

### DIFF
--- a/lib/rules/template-no-unused-block-params.js
+++ b/lib/rules/template-no-unused-block-params.js
@@ -24,6 +24,9 @@ function collectChildNodes(n) {
   if (n.children) {
     children.push(...n.children);
   }
+  if (n.modifiers) {
+    children.push(...n.modifiers);
+  }
   // GlimmerPathExpression also has 'parts', so make sure we're not treating
   // concat'd path string parts as AST nodes.
   if (n.type === 'GlimmerConcatStatement' && n.parts) {
@@ -56,6 +59,113 @@ function buildShadowedSet(shadowedParams, innerBlockParams, outerBlockParams) {
   return newShadowed;
 }
 
+function checkBlockParts(n, blockParams, usedParams, shadowedParams, newShadowed, checkNodeFn) {
+  // Check the path/params of the block statement itself with current scope
+  if (n.path) {
+    checkNodeFn(n.path, shadowedParams);
+  }
+  if (n.params) {
+    for (const param of n.params) {
+      checkNodeFn(param, shadowedParams);
+    }
+  }
+  if (n.hash?.pairs) {
+    for (const pair of n.hash.pairs) {
+      checkNodeFn(pair.value, shadowedParams);
+    }
+  }
+
+  // Check the program body with the updated shadowed set
+  if (n.program) {
+    checkNodeFn(n.program, newShadowed);
+  }
+  if (n.inverse) {
+    checkNodeFn(n.inverse, newShadowed);
+  }
+}
+
+/**
+ * Scan child nodes for usage of blockParams, then report the first unused
+ * trailing param. Shared by both GlimmerBlockStatement and GlimmerElementNode.
+ */
+function checkUnusedBlockParams(context, node, blockParams, startNodes) {
+  const usedParams = new Set();
+
+  function checkNode(n, shadowedParams) {
+    if (!n) {
+      return;
+    }
+
+    if (n.type === 'GlimmerPathExpression') {
+      markParamIfUsed(n.original, blockParams, usedParams, shadowedParams);
+    }
+
+    if (n.type === 'GlimmerElementNode') {
+      markParamIfUsed(n.tag, blockParams, usedParams, shadowedParams);
+    }
+
+    if (isPartialStatement(n)) {
+      for (const p of blockParams) {
+        if (!shadowedParams.has(p)) {
+          usedParams.add(p);
+        }
+      }
+    }
+
+    // Nested block with its own blockParams — shadow them
+    if (n.type === 'GlimmerBlockStatement' && n.program?.blockParams?.length > 0) {
+      const newShadowed = buildShadowedSet(shadowedParams, n.program.blockParams, blockParams);
+      checkBlockParts(n, blockParams, usedParams, shadowedParams, newShadowed, checkNode);
+      return;
+    }
+
+    // Nested element with block params (e.g. <Component as |x|>) — shadow them
+    if (n.type === 'GlimmerElementNode' && n.blockParams?.length > 0) {
+      const newShadowed = buildShadowedSet(shadowedParams, n.blockParams, blockParams);
+      if (n.attributes) {
+        for (const attr of n.attributes) {
+          checkNode(attr.value, shadowedParams);
+        }
+      }
+      if (n.children) {
+        for (const child of n.children) {
+          checkNode(child, newShadowed);
+        }
+      }
+      return;
+    }
+
+    for (const child of collectChildNodes(n)) {
+      checkNode(child, shadowedParams);
+    }
+  }
+
+  for (const startNode of startNodes) {
+    checkNode(startNode, new Set());
+  }
+
+  // Find the last index of a used param
+  let lastUsedIndex = -1;
+  for (let i = blockParams.length - 1; i >= 0; i--) {
+    if (usedParams.has(blockParams[i])) {
+      lastUsedIndex = i;
+      break;
+    }
+  }
+
+  // Only report trailing unused params (after the last used one)
+  const unusedTrailing = blockParams.slice(lastUsedIndex + 1);
+  const firstUnusedTrailing = unusedTrailing[0];
+
+  if (firstUnusedTrailing) {
+    context.report({
+      node,
+      messageId: 'unusedBlockParam',
+      data: { param: firstUnusedTrailing },
+    });
+  }
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -82,98 +192,17 @@ module.exports = {
     return {
       GlimmerBlockStatement(node) {
         const blockParams = node.program?.blockParams || [];
-        if (blockParams.length === 0) {
-          return;
+        if (blockParams.length > 0) {
+          checkUnusedBlockParams(context, node, blockParams, [node.program]);
         }
+      },
 
-        const usedParams = new Set();
-
-        function checkNode(n, shadowedParams) {
-          if (!n) {
-            return;
-          }
-
-          if (n.type === 'GlimmerPathExpression') {
-            markParamIfUsed(n.original, blockParams, usedParams, shadowedParams);
-          }
-
-          if (n.type === 'GlimmerElementNode') {
-            markParamIfUsed(n.tag, blockParams, usedParams, shadowedParams);
-          }
-
-          if (isPartialStatement(n)) {
-            for (const p of blockParams) {
-              if (!shadowedParams.has(p)) {
-                usedParams.add(p);
-              }
-            }
-          }
-
-          // When entering a nested block, add its blockParams to the shadowed set
-          if (n.type === 'GlimmerBlockStatement' && n.program?.blockParams?.length > 0) {
-            const newShadowed = buildShadowedSet(
-              shadowedParams,
-              n.program.blockParams,
-              blockParams
-            );
-            checkBlockParts(n, blockParams, usedParams, shadowedParams, newShadowed, checkNode);
-            return;
-          }
-
-          // Recursively check children
-          for (const child of collectChildNodes(n)) {
-            checkNode(child, shadowedParams);
-          }
-        }
-
-        checkNode(node.program, new Set());
-
-        // Find the last index of a used param
-        let lastUsedIndex = -1;
-        for (let i = blockParams.length - 1; i >= 0; i--) {
-          if (usedParams.has(blockParams[i])) {
-            lastUsedIndex = i;
-            break;
-          }
-        }
-
-        // Only report trailing unused params (after the last used one)
-        const unusedTrailing = blockParams.slice(lastUsedIndex + 1);
-        const firstUnusedTrailing = unusedTrailing[0];
-
-        if (firstUnusedTrailing) {
-          context.report({
-            node,
-            messageId: 'unusedBlockParam',
-            data: { param: firstUnusedTrailing },
-          });
+      GlimmerElementNode(node) {
+        const blockParams = node.blockParams || [];
+        if (blockParams.length > 0) {
+          checkUnusedBlockParams(context, node, blockParams, node.children || []);
         }
       },
     };
   },
 };
-
-function checkBlockParts(n, blockParams, usedParams, shadowedParams, newShadowed, checkNodeFn) {
-  // Check the path/params of the block statement itself with current scope
-  if (n.path) {
-    checkNodeFn(n.path, shadowedParams);
-  }
-  if (n.params) {
-    for (const param of n.params) {
-      checkNodeFn(param, shadowedParams);
-    }
-  }
-  if (n.hash?.pairs) {
-    for (const pair of n.hash.pairs) {
-      checkNodeFn(pair.value, shadowedParams);
-    }
-  }
-
-  // Check the program body with the updated shadowed set
-  if (n.program) {
-    checkNodeFn(n.program, newShadowed);
-  }
-  if (n.inverse) {
-    checkNodeFn(n.inverse, newShadowed);
-  }
-}

--- a/tests/lib/rules/template-no-unused-block-params.js
+++ b/tests/lib/rules/template-no-unused-block-params.js
@@ -90,6 +90,12 @@ const validHbs = [
   '{{#with (component "foo-bar") as |FooBar|}}<FooBar />{{/with}}',
   '<BurgerMenu as |menu|><header>Something</header><menu.item>Text</menu.item></BurgerMenu>',
   '{{#burger-menu as |menu|}}<header>Something</header>{{#menu.item}}Text{{/menu.item}}{{/burger-menu}}',
+  '<MyComponent as |item|>{{item}}</MyComponent>',
+  // Outer `item` is used via @value (outer scope); inner `as |item|` shadows
+  // outer in <Inner>'s children.
+  '<Outer as |item|><Inner @value={{item}} as |item|>{{item}}</Inner></Outer>',
+  '<MyComponent as |handler|><button {{on "click" handler}}>X</button></MyComponent>',
+  '{{#let this.fn as |handler|}}<button {{on "click" handler}}>X</button>{{/let}}',
 ];
 
 const invalidHbs = [
@@ -122,6 +128,23 @@ const invalidHbs = [
     code: '{{#each cats as |cat|}}{{a.different.cat}}{{/each}}',
     output: null,
     errors: [{ messageId: 'unusedBlockParam', data: { param: 'cat' } }],
+  },
+  {
+    code: '<MyComponent as |item unused|>{{item}}</MyComponent>',
+    output: null,
+    errors: [{ messageId: 'unusedBlockParam', data: { param: 'unused' } }],
+  },
+  {
+    code: '<MyComponent as |unused|>content</MyComponent>',
+    output: null,
+    errors: [{ messageId: 'unusedBlockParam', data: { param: 'unused' } }],
+  },
+  // The outer `item` is only "used" inside <Inner> where it is shadowed by
+  // the inner `as |item|`, so the outer should be reported as unused.
+  {
+    code: '<Outer as |item|><Inner as |item|>{{item}}</Inner></Outer>',
+    output: null,
+    errors: [{ messageId: 'unusedBlockParam', data: { param: 'item' } }],
   },
 ];
 


### PR DESCRIPTION
Closes two false-negative gaps in `template-no-unused-block-params` that leave dead block params unflagged in modern (gjs/gts and angle-bracket) Ember templates.

### What's broken on `master`
1. **Angle-bracket components are completely ignored.** The rule only registers `GlimmerBlockStatement`, so:
   ```hbs
   <MyComponent as |unused|>{{static}}</MyComponent>
   ```
   silently passes lint. The [ember-template-lint original](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-unused-block-params.js) handles both `Block.exit` and `ElementNode.children.exit` (delegated to the framework's scope tracker). The eslint-plugin-ember port only did the curly side.

2. **Element modifiers are not walked.** `collectChildNodes` traverses `program`/`inverse`/`params`/`hash`/`body`/`path`/`attributes`/`children`, but **not** `modifiers`. So a yielded handler used only inside a modifier:
   ```hbs
   <Outer as |handler|>
     <button {{on "click" handler}}>X</button>
   </Outer>
   ```
   is falsely reported as unused. This was latent before fix #1, but the moment the rule starts walking children of angle-bracket components — where `{{on "click" ...}}` is the standard pattern — it becomes a real false positive.

### Changes
- **GlimmerElementNode visitor.** A second visitor handles `<Component as |...|>` by reusing the same `checkUnusedBlockParams` helper that the curly visitor goes through. Includes a nested-element shadowing branch for `<Outer as |item|><Inner as |item|>{{item}}</Inner></Outer>` so that the outer `item` is correctly reported as unused (the inner shadows it). Without this branch, the recursive walker would walk Inner's children with Outer's scope, marking outer's `item` as used even though it isn't. Verified the new invalid test fails when the shadowing branch is removed.
- **Modifier walking.** `collectChildNodes` now also pushes `n.modifiers`. Two valid regression tests cover both the angle-bracket path (`<MyComponent as |handler|><button {{on "click" handler}}>X</button></MyComponent>`) and the curly path (`{{#let this.fn as |handler|}}<button {{on "click" handler}}>X</button>{{/let}}`); both fail without the lib change.

### Test plan
- 70/70 tests in `tests/lib/rules/template-no-unused-block-params.js` pass
- New test cases verified to fail without the corresponding lib changes
- Existing `{{#each}}` / `{{#let}}` / `{{#with}}` coverage unchanged

### Reference
- [`no-unused-block-params.js`](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-unused-block-params.js)

Cowritten by claude