### PR TITLE
Post merge-review: Fix `template-no-quoteless-attributes` false positive on quoted values

### DIFF
--- a/lib/rules/template-no-quoteless-attributes.js
+++ b/lib/rules/template-no-quoteless-attributes.js
@@ -21,28 +21,27 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode;
     return {
       GlimmerAttrNode(node) {
-        // Check if attribute has text value without quotes
-        if (node.value?.type === 'GlimmerTextNode' && !/^["']/.test(node.value.chars)) {
-          const sourceCode = context.sourceCode;
-          const attrText = sourceCode.getText(node);
-
-          // If value looks unquoted (no = or =value without quotes)
-          if (/=\s*[^"'{]/.test(attrText)) {
-            const type = node.name?.startsWith('@') ? 'Argument' : 'Attribute';
-            context.report({
-              node,
-              messageId: 'missing',
-              data: { type, name: node.name },
-              fix(fixer) {
-                const valueText = node.value.chars;
-                const replacementText = `${node.name}="${valueText}"`;
-                return fixer.replaceText(node, replacementText);
-              },
-            });
-          }
+        if (node.value?.type !== 'GlimmerTextNode') {
+          return;
         }
+
+        const valueSource = sourceCode.getText(node.value);
+        if (valueSource.length === 0 || valueSource[0] === '"' || valueSource[0] === "'") {
+          return;
+        }
+
+        const type = node.name?.startsWith('@') ? 'Argument' : 'Attribute';
+        context.report({
+          node,
+          messageId: 'missing',
+          data: { type, name: node.name },
+          fix(fixer) {
+            return fixer.replaceText(node, `${node.name}="${node.value.chars}"`);
+          },
+        });
       },
     };
   },

--- a/tests/lib/rules/template-no-quoteless-attributes.js
+++ b/tests/lib/rules/template-no-quoteless-attributes.js
@@ -17,6 +17,7 @@ ruleTester.run('template-no-quoteless-attributes', rule, {
     '<template><SomeThing ...attributes /></template>',
     '<template><div></div></template>',
     '<template><input disabled></template>',
+    '<template><div data-x="foo=bar"></div></template>',
   ],
   invalid: [
     {
@@ -57,6 +58,7 @@ hbsRuleTester.run('template-no-quoteless-attributes', rule, {
     '<SomeThing ...attributes />',
     '<div></div>',
     '<input disabled>',
+    '<div data-x="foo=bar"></div>',
   ],
   invalid: [
     {


### PR DESCRIPTION
**The bug**: master uses fragile `/=\s*[^"'{]/` against the **full attribute source text** (unanchored). For `<div data-x="foo=bar">`, the regex matches the `=` between `foo` and `bar` (followed by `b`), incorrectly flagging the well-quoted attribute as quoteless. The "autofix" then replaces the attribute with itself — a no-op fix that still surfaces the spurious error. 

**The fix**:
```js
if (node.value?.type !== 'GlimmerTextNode') return;
const valueSource = sourceCode.getText(node.value);
if (valueSource.length === 0 || valueSource[0] === '"' || valueSource[0] === "'") return;
// report
```
`sourceCode.getText(node.value)` returns the value node verbatim including its surrounding quotes when present (`"foo"` for `class="foo"`, `foo` for `class=foo`, `""` for the zero-length range of a valueless attribute). Checking the first character is sufficient and operates on the value node directly, not on unrelated `=` chars in the rest of the attribute.

Cowritten by claude