### PR TITLE
Post-merge-review: Fix `template-no-link-to-tagname`: only flag `@tagName`, not bare `tagName`, on angle-bracket `<LinkTo>`

### DIFF
--- a/lib/rules/template-no-link-to-tagname.js
+++ b/lib/rules/template-no-link-to-tagname.js
@@ -1,14 +1,3 @@
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function isLinkToComponent(node) {
-  if (node.type === 'GlimmerElementNode') {
-    return node.tag === 'LinkTo' || node.tag === 'link-to';
-  }
-  return false;
-}
-
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -32,6 +21,25 @@ module.exports = {
   },
 
   create(context) {
+    const filename = context.filename;
+    const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
+
+    // In HBS, LinkTo always refers to Ember's router link component.
+    // In GJS/GTS, LinkTo must be explicitly imported from '@ember/routing'
+    // (and may be renamed, e.g. `import { LinkTo as Link } from '@ember/routing'`).
+    // local alias → true
+    const importedLinkComponents = new Map();
+
+    function isLinkToComponent(node) {
+      if (node.type !== 'GlimmerElementNode') {
+        return false;
+      }
+      if (isStrictMode) {
+        return importedLinkComponents.has(node.tag);
+      }
+      return node.tag === 'LinkTo' || node.tag === 'link-to';
+    }
+
     function checkHashPairsForTagName(node) {
       if (!node.hash || !node.hash.pairs) {
         return;
@@ -46,14 +54,27 @@ module.exports = {
     }
 
     return {
+      ImportDeclaration(node) {
+        if (!isStrictMode) {
+          return;
+        }
+        if (node.source.value !== '@ember/routing') {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'LinkTo') {
+            importedLinkComponents.set(specifier.local.name, true);
+          }
+        }
+      },
+
       GlimmerElementNode(node) {
         if (!isLinkToComponent(node)) {
           return;
         }
 
         const tagNameAttr = node.attributes.find(
-          (attr) =>
-            attr.type === 'GlimmerAttrNode' && (attr.name === 'tagName' || attr.name === '@tagName')
+          (attr) => attr.type === 'GlimmerAttrNode' && attr.name === '@tagName'
         );
 
         if (tagNameAttr) {

--- a/lib/rules/template-no-link-to-tagname.js
+++ b/lib/rules/template-no-link-to-tagname.js
@@ -10,7 +10,8 @@ module.exports = {
     },
     schema: [],
     messages: {
-      noLinkToTagname: 'tagName attribute on LinkTo is deprecated',
+      noLinkToTagname:
+        '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.',
     },
     originallyFrom: {
       name: 'ember-template-lint',
@@ -24,7 +25,9 @@ module.exports = {
     const filename = context.filename;
     const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
 
-    // In HBS, LinkTo always refers to Ember's router link component.
+    // In HBS, `LinkTo` almost always refers to Ember's router link component; a
+    // user-defined `link-to` could shadow it, but detecting that in classic HBS
+    // would require resolver-level info the rule doesn't have.
     // In GJS/GTS, LinkTo must be explicitly imported from '@ember/routing'
     // (and may be renamed, e.g. `import { LinkTo as Link } from '@ember/routing'`).
     // local alias → true

--- a/tests/lib/rules/template-no-link-to-tagname.js
+++ b/tests/lib/rules/template-no-link-to-tagname.js
@@ -10,7 +10,7 @@ ruleTester.run('template-no-link-to-tagname', rule, {
   valid: [
     {
       filename: 'test.gjs',
-      code: '<template><LinkTo @route="index">Home</LinkTo></template>',
+      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"index\">Home</LinkTo></template>",
       output: null,
     },
     {
@@ -24,6 +24,24 @@ ruleTester.run('template-no-link-to-tagname', rule, {
       output: null,
     },
 
+    // User-authored LinkTo component (no @ember/routing import) — should NOT be flagged
+    {
+      filename: 'test.gjs',
+      code: '<template><LinkTo @tagName="button">Home</LinkTo></template>',
+      output: null,
+    },
+    {
+      filename: 'test.gts',
+      code: '<template><LinkTo @tagName="button">Home</LinkTo></template>',
+      output: null,
+    },
+
+    // Bare tagName (without @) is just an HTML attribute, not flagged
+    {
+      filename: 'test.gjs',
+      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"index\" tagName=\"button\">Home</LinkTo></template>",
+      output: null,
+    },
     '<template><Foo @route="routeName" @tagName="button">Link text</Foo></template>',
     '<template><LinkTo @route="routeName">Link text</LinkTo></template>',
     '<template>{{#link-to "routeName"}}Link text{{/link-to}}</template>',
@@ -35,19 +53,26 @@ ruleTester.run('template-no-link-to-tagname', rule, {
   invalid: [
     {
       filename: 'test.gjs',
-      code: '<template><LinkTo @route="index" tagName="button">Home</LinkTo></template>',
+      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"about\" @tagName=\"span\">About</LinkTo></template>",
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
     {
+      filename: 'test.gts',
+      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"about\" @tagName=\"span\">About</LinkTo></template>",
+      output: null,
+      errors: [{ messageId: 'noLinkToTagname' }],
+    },
+    // Renamed import
+    {
       filename: 'test.gjs',
-      code: '<template><LinkTo @route="about" @tagName="span">About</LinkTo></template>',
+      code: "import { LinkTo as Link } from '@ember/routing';\n<template><Link @tagName=\"button\">x</Link></template>",
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
     {
-      filename: 'test.gjs',
-      code: '<template><link-to @route="contact" tagName="div">Contact</link-to></template>',
+      filename: 'test.gts',
+      code: "import { LinkTo as Link } from '@ember/routing';\n<template><Link @route=\"index\" @tagName=\"button\">x</Link></template>",
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
@@ -80,6 +105,8 @@ const hbsRuleTester = new RuleTester({
 
 hbsRuleTester.run('template-no-link-to-tagname', rule, {
   valid: [
+    // Bare tagName (without @) is just an HTML attribute, not flagged
+    '<LinkTo @route="index" tagName="button">Home</LinkTo>',
     '<Foo @route="routeName" @tagName="button">Link text</Foo>',
     '<LinkTo @route="routeName">Link text</LinkTo>',
     '{{#link-to "routeName"}}Link text{{/link-to}}',
@@ -90,6 +117,11 @@ hbsRuleTester.run('template-no-link-to-tagname', rule, {
   invalid: [
     {
       code: '<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>',
+      output: null,
+      errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
+    },
+    {
+      code: '<link-to @route="contact" @tagName="div">Contact</link-to>',
       output: null,
       errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
     },

--- a/tests/lib/rules/template-no-link-to-tagname.js
+++ b/tests/lib/rules/template-no-link-to-tagname.js
@@ -118,22 +118,22 @@ hbsRuleTester.run('template-no-link-to-tagname', rule, {
     {
       code: '<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>',
       output: null,
-      errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
+      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
     },
     {
       code: '<link-to @route="contact" @tagName="div">Contact</link-to>',
       output: null,
-      errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
+      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
     },
     {
       code: '{{#link-to "routeName" tagName="button"}}Link text{{/link-to}}',
       output: null,
-      errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
+      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
     },
     {
       code: '{{link-to "Link text" "routeName" tagName="button"}}',
       output: null,
-      errors: [{ message: 'tagName attribute on LinkTo is deprecated' }],
+      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
     },
   ],
 });

--- a/tests/lib/rules/template-no-link-to-tagname.js
+++ b/tests/lib/rules/template-no-link-to-tagname.js
@@ -10,7 +10,7 @@ ruleTester.run('template-no-link-to-tagname', rule, {
   valid: [
     {
       filename: 'test.gjs',
-      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"index\">Home</LinkTo></template>",
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="index">Home</LinkTo></template>',
       output: null,
     },
     {
@@ -39,7 +39,7 @@ ruleTester.run('template-no-link-to-tagname', rule, {
     // Bare tagName (without @) is just an HTML attribute, not flagged
     {
       filename: 'test.gjs',
-      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"index\" tagName=\"button\">Home</LinkTo></template>",
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="index" tagName="button">Home</LinkTo></template>',
       output: null,
     },
     '<template><Foo @route="routeName" @tagName="button">Link text</Foo></template>',
@@ -53,26 +53,26 @@ ruleTester.run('template-no-link-to-tagname', rule, {
   invalid: [
     {
       filename: 'test.gjs',
-      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"about\" @tagName=\"span\">About</LinkTo></template>",
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="about" @tagName="span">About</LinkTo></template>',
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
     {
       filename: 'test.gts',
-      code: "import { LinkTo } from '@ember/routing';\n<template><LinkTo @route=\"about\" @tagName=\"span\">About</LinkTo></template>",
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="about" @tagName="span">About</LinkTo></template>',
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
     // Renamed import
     {
       filename: 'test.gjs',
-      code: "import { LinkTo as Link } from '@ember/routing';\n<template><Link @tagName=\"button\">x</Link></template>",
+      code: 'import { LinkTo as Link } from \'@ember/routing\';\n<template><Link @tagName="button">x</Link></template>',
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },
     {
       filename: 'test.gts',
-      code: "import { LinkTo as Link } from '@ember/routing';\n<template><Link @route=\"index\" @tagName=\"button\">x</Link></template>",
+      code: 'import { LinkTo as Link } from \'@ember/routing\';\n<template><Link @route="index" @tagName="button">x</Link></template>',
       output: null,
       errors: [{ messageId: 'noLinkToTagname' }],
     },

--- a/tests/lib/rules/template-no-link-to-tagname.js
+++ b/tests/lib/rules/template-no-link-to-tagname.js
@@ -118,22 +118,42 @@ hbsRuleTester.run('template-no-link-to-tagname', rule, {
     {
       code: '<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>',
       output: null,
-      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
+      errors: [
+        {
+          message:
+            '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.',
+        },
+      ],
     },
     {
       code: '<link-to @route="contact" @tagName="div">Contact</link-to>',
       output: null,
-      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
+      errors: [
+        {
+          message:
+            '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.',
+        },
+      ],
     },
     {
       code: '{{#link-to "routeName" tagName="button"}}Link text{{/link-to}}',
       output: null,
-      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
+      errors: [
+        {
+          message:
+            '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.',
+        },
+      ],
     },
     {
       code: '{{link-to "Link text" "routeName" tagName="button"}}',
       output: null,
-      errors: [{ message: '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.' }],
+      errors: [
+        {
+          message:
+            '@tagName on <LinkTo> is not supported (removed in Ember 4.0). <LinkTo> always renders an <a> element.',
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
## What's broken on master

- The rule matched every `<LinkTo>` tag by bare name. In strict-mode templates (`.gjs` / `.gts`) a component named `LinkTo` is only Ember's router link if it is imported from `@ember/routing`. This caused two bugs:
  1. **False positive:** a user-authored `<LinkTo @tagName="button">` component (no import from `@ember/routing`) was flagged even though it has nothing to do with Ember's router `LinkTo`.
  2. **False negative:** a renamed import such as `import { LinkTo as Link } from '@ember/routing'` used as `<Link @tagName="button">` was not detected because the tag name no longer matches the bare string `LinkTo`.
- Additionally, on angle-bracket `<LinkTo>` the rule previously flagged the bare HTML-attribute `tagName` as well as the Ember argument `@tagName`. Bare `tagName` on angle-bracket invocation is just a passthrough HTML attribute and is not deprecated; only `@tagName` is.

## Fix

- Detect strict mode via `context.filename` (`.gjs` / `.gts`).
- Add an `ImportDeclaration` visitor (strict mode only) that records every local alias imported as `LinkTo` from `@ember/routing` into `importedLinkComponents`. Mirrors the pattern used in `template-no-invalid-link-text`.
- In strict mode the angle-bracket visitor only flags elements whose tag is in the tracked set. In classic HBS it keeps the previous behavior (`LinkTo` / `link-to`), since HBS has no imports.
- The curly (`{{link-to}}` / `{{#link-to}}`) visitor is unchanged: there are no imports in HBS curly form.
- Only flag `@tagName` (not bare `tagName`) on angle-bracket `<LinkTo>`.

## Test plan

- [x] Valid: `<LinkTo @tagName="button">` in `.gjs` and `.gts` with no `@ember/routing` import (user-authored component must not be flagged).
- [x] Invalid: `import { LinkTo } from '@ember/routing';` + `<LinkTo @tagName=...>` in both `.gjs` and `.gts`.
- [x] Invalid: renamed import `import { LinkTo as Link } from '@ember/routing';` + `<Link @tagName="button">` flags `<Link>` in both `.gjs` and `.gts`.
- [x] Existing HBS cases still covered (including `<link-to @tagName>` via angle-bracket kebab form in classic templates).
- [x] All 30 rule tests pass (`pnpm vitest run tests/lib/rules/template-no-link-to-tagname.js`).