### PR TITLE
Post-merge-review: Fix `template-no-aria-unsupported-elements` false positives on `title`/`base`/`head`/`link`

### DIFF
--- a/lib/rules/template-no-aria-unsupported-elements.js
+++ b/lib/rules/template-no-aria-unsupported-elements.js
@@ -18,8 +18,18 @@ module.exports = {
   },
 
   create(context) {
-    // Elements that don't support ARIA
-    const ELEMENTS_WITHOUT_ARIA_SUPPORT = new Set(['meta', 'html', 'script', 'style']);
+    // Elements that don't support ARIA per the W3C ARIA in HTML spec.
+    // Includes metadata/structural elements that have no UI representation.
+    const ELEMENTS_WITHOUT_ARIA_SUPPORT = new Set([
+      'meta',
+      'html',
+      'script',
+      'style',
+      'title',
+      'base',
+      'head',
+      'link',
+    ]);
 
     return {
       GlimmerElementNode(node) {

--- a/lib/rules/template-no-aria-unsupported-elements.js
+++ b/lib/rules/template-no-aria-unsupported-elements.js
@@ -19,16 +19,7 @@ module.exports = {
 
   create(context) {
     // Elements that don't support ARIA
-    const ELEMENTS_WITHOUT_ARIA_SUPPORT = new Set([
-      'meta',
-      'html',
-      'script',
-      'style',
-      'title',
-      'base',
-      'head',
-      'link',
-    ]);
+    const ELEMENTS_WITHOUT_ARIA_SUPPORT = new Set(['meta', 'html', 'script', 'style']);
 
     return {
       GlimmerElementNode(node) {

--- a/tests/lib/rules/template-no-aria-unsupported-elements.js
+++ b/tests/lib/rules/template-no-aria-unsupported-elements.js
@@ -11,11 +11,11 @@ ruleTester.run('template-no-aria-unsupported-elements', rule, {
     '<template><div role="button" aria-label="Submit"></div></template>',
     '<template><button aria-pressed="true">Toggle</button></template>',
     '<template><input aria-label="Username"></template>',
-    // These elements are not in the unsupported set (only html, meta, script, style are)
-    '<template><title aria-label="Page Title"></title></template>',
-    '<template><head role="banner"></head></template>',
-    '<template><base aria-hidden="true"></template>',
-    '<template><link aria-label="Stylesheet"></template>',
+    // No ARIA attributes — these are fine
+    '<template><title>Page Title</title></template>',
+    '<template><head></head></template>',
+    '<template><base href="/"></template>',
+    '<template><link rel="stylesheet" href="style.css"></template>',
   ],
 
   invalid: [
@@ -36,6 +36,26 @@ ruleTester.run('template-no-aria-unsupported-elements', rule, {
     },
     {
       code: '<template><html role="application"></html></template>',
+      output: null,
+      errors: [{ messageId: 'unsupported' }],
+    },
+    {
+      code: '<template><title aria-label="Page Title"></title></template>',
+      output: null,
+      errors: [{ messageId: 'unsupported' }],
+    },
+    {
+      code: '<template><head role="banner"></head></template>',
+      output: null,
+      errors: [{ messageId: 'unsupported' }],
+    },
+    {
+      code: '<template><base aria-hidden="true"></template>',
+      output: null,
+      errors: [{ messageId: 'unsupported' }],
+    },
+    {
+      code: '<template><link aria-label="Stylesheet"></template>',
       output: null,
       errors: [{ messageId: 'unsupported' }],
     },

--- a/tests/lib/rules/template-no-aria-unsupported-elements.js
+++ b/tests/lib/rules/template-no-aria-unsupported-elements.js
@@ -11,6 +11,11 @@ ruleTester.run('template-no-aria-unsupported-elements', rule, {
     '<template><div role="button" aria-label="Submit"></div></template>',
     '<template><button aria-pressed="true">Toggle</button></template>',
     '<template><input aria-label="Username"></template>',
+    // These elements are not in the unsupported set (only html, meta, script, style are)
+    '<template><title aria-label="Page Title"></title></template>',
+    '<template><head role="banner"></head></template>',
+    '<template><base aria-hidden="true"></template>',
+    '<template><link aria-label="Stylesheet"></template>',
   ],
 
   invalid: [
@@ -26,6 +31,11 @@ ruleTester.run('template-no-aria-unsupported-elements', rule, {
     },
     {
       code: '<template><style role="presentation"></style></template>',
+      output: null,
+      errors: [{ messageId: 'unsupported' }],
+    },
+    {
+      code: '<template><html role="application"></html></template>',
       output: null,
       errors: [{ messageId: 'unsupported' }],
     },


### PR DESCRIPTION
### What's broken on `master`
`ELEMENTS_WITHOUT_ARIA_SUPPORT` contains 8 tags. Upstream has only 4: `html`, `meta`, `script`, `style` ([`no-aria-unsupported-elements.js` L7](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-aria-unsupported-elements.js#L7)). Master flags valid usage of ARIA attributes on `<title>`, `<base>`, `<head>`, and `<link>`.

### Fix
Remove `title`, `base`, `head`, `link` from the disallowed set, matching upstream exactly.

### Test plan
- 11/11 tests pass on the branch
- 4 new valid test cases (one per removed element) fail on master

---

Co-written by Claude.