### PR TITLE
Post-merge-review: Fix `template-no-chained-this` autofix: also update the closing tag

### DIFF
--- a/lib/rules/template-no-chained-this.js
+++ b/lib/rules/template-no-chained-this.js
@@ -57,9 +57,20 @@ module.exports = {
           node,
           messageId: 'noChainedThis',
           fix(fixer) {
+            const fixes = [];
+
             // Replace the tag name after '<'
             const openStart = node.range[0] + 1;
-            return fixer.replaceTextRange([openStart, openStart + node.tag.length], fixedTag);
+            fixes.push(fixer.replaceTextRange([openStart, openStart + node.tag.length], fixedTag));
+
+            // For non-self-closing elements, also fix the closing tag </tag>
+            if (!node.selfClosing) {
+              const closingEnd = node.range[1] - 1; // before '>'
+              const closingStart = closingEnd - node.tag.length; // start of tag name in </tag>
+              fixes.push(fixer.replaceTextRange([closingStart, closingEnd], fixedTag));
+            }
+
+            return fixes;
           },
         });
       },

--- a/tests/lib/rules/template-no-chained-this.js
+++ b/tests/lib/rules/template-no-chained-this.js
@@ -47,5 +47,10 @@ ruleTester.run('template-no-chained-this', rule, {
       output: '<template>{{component this.dynamicComponent}}</template>',
       errors: [{ messageId: 'noChainedThis' }],
     },
+    {
+      code: '<template><this.this.Component>content</this.this.Component></template>',
+      output: '<template><this.Component>content</this.Component></template>',
+      errors: [{ messageId: 'noChainedThis' }],
+    },
   ],
 });


### PR DESCRIPTION
### What's broken on `master`
For `GlimmerElementNode` autofix, master replaces only the opening tag name. For non-self-closing elements this produces invalid HTML:

```hbs
<this.this.Component>content</this.this.Component>
→ <this.Component>content</this.this.Component>   ❌
```

### Fix
When `!node.selfClosing`, return a second `replaceTextRange` for the closing tag name. Upstream gets this for free because it mutates `node.tag` directly and `ember-template-recast` serializes both tags from the single property ([`no-chained-this.js` L28](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-chained-this.js#L28)). The port's ESLint fixer operates on text ranges, so both tags need explicit handling.

### Test plan
- 13/13 tests pass on the branch
- 1 new invalid test (`<this.this.Foo>text</this.this.Foo>`) fails on master with a parse error in the autofix output

---

Co-written by Claude.