### PR TITLE
Post-merge-review: Fix `template-no-curly-component-invocation`: preserve `this.`/`@`/local names in suggestions, and skip JS scope bindings

### DIFF
--- a/lib/rules/template-no-curly-component-invocation.js
+++ b/lib/rules/template-no-curly-component-invocation.js
@@ -38,7 +38,12 @@ const BUILT_INS = new Set([
 
 const ALWAYS_CURLY = new Set(['yield']);
 
-function transformTagName(name) {
+function transformTagName(name, isLocal) {
+  // Preserve this.*, @*, and local variable names as-is
+  if (name.startsWith('@') || name.startsWith('this.') || isLocal) {
+    return name;
+  }
+
   // Convert kebab-case to PascalCase for angle bracket syntax
   const parts = name.split('/');
   return parts
@@ -159,6 +164,34 @@ module.exports = {
       return blockParamStack.some((params) => params.includes(name));
     }
 
+    /**
+     * Returns true if the mustache/block node's path head resolves to a
+     * JavaScript scope binding (import, const, function param, etc.) —
+     * i.e. the template reference is an explicit GJS/GTS binding, not an
+     * implicit resolver lookup. Such references should not be flagged as
+     * ambiguous curly invocations. Walks `scope.variables` up the chain by
+     * name, which handles Glimmer built-in names that don't appear in
+     * `scope.references`.
+     */
+    function isJsScopeBinding(node) {
+      const name = node.path?.original?.split('.')[0];
+      if (!sourceCode || !name) {
+        return false;
+      }
+      try {
+        let scope = sourceCode.getScope(node);
+        while (scope) {
+          if (scope.variables.some((v) => v.name === name)) {
+            return true;
+          }
+          scope = scope.upper;
+        }
+      } catch {
+        // sourceCode.getScope may not be available in .hbs-only mode; ignore.
+      }
+      return false;
+    }
+
     function reportMustache(node, pathOriginal) {
       const angleBracketName = transformTagName(pathOriginal);
       context.report({
@@ -167,10 +200,16 @@ module.exports = {
       });
     }
 
-    function checkMustacheWithNamedArgs(node, pathOriginal, explicitThis) {
+    function checkMustacheWithNamedArgs(node, pathOriginal, explicitThis, local) {
       // {{foo.bar bar=baz}} - multi-part path (not this./@ prefix) with named args
       if (!explicitThis && pathOriginal.includes('.')) {
         reportMustache(node, pathOriginal);
+        return;
+      }
+
+      // Explicit JS scope binding or block param — user already imported/scoped
+      // the value by that exact name; converting to angle-bracket would break.
+      if (local) {
         return;
       }
 
@@ -266,12 +305,12 @@ module.exports = {
 
         const explicitThis = isExplicitThisPath(pathOriginal);
         const firstPart = pathOriginal.split('.')[0];
-        const local = isLocalVar(firstPart);
+        const local = isLocalVar(firstPart) || isJsScopeBinding(node);
 
         const hasNamedArguments = node.hash && node.hash.pairs && node.hash.pairs.length > 0;
 
         if (hasNamedArguments) {
-          checkMustacheWithNamedArgs(node, pathOriginal, explicitThis);
+          checkMustacheWithNamedArgs(node, pathOriginal, explicitThis, local);
         } else {
           checkMustacheWithoutNamedArgs(node, pathOriginal, explicitThis, local);
         }
@@ -311,7 +350,17 @@ module.exports = {
           return;
         }
 
-        const angleBracketName = transformTagName(pathOriginal);
+        const firstPart = pathOriginal.split('.')[0];
+        const local = isLocalVar(firstPart) || isJsScopeBinding(node);
+
+        // Explicit JS scope binding: the user imported this exact identifier.
+        // Converting {{#fooBar}}...{{/fooBar}} to <FooBar>...</FooBar> would
+        // reference a different (unbound) name. Skip the report entirely.
+        if (local && !isLocalVar(firstPart)) {
+          return;
+        }
+
+        const angleBracketName = transformTagName(pathOriginal, local);
         context.report({
           node,
           message: `You are using the component {{#${pathOriginal}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${pathOriginal}'] }\`.`,

--- a/tests/lib/rules/template-no-curly-component-invocation.js
+++ b/tests/lib/rules/template-no-curly-component-invocation.js
@@ -47,6 +47,18 @@ ruleTester.run('template-no-curly-component-invocation', rule, {
       code: '<template>{{foo-bar}}</template>',
       options: [{ allow: ['foo-bar'] }],
     },
+
+    // GJS/GTS: JS scope bindings (imports, const) used as curly invocations
+    // are explicit by name. Converting to <Foo> would reference an unbound
+    // identifier, so skip both single-word and named-args forms.
+    `import fooBar from './foo-bar';
+     export default <template>{{fooBar}}</template>;`,
+    `import fooBar from './foo-bar';
+     export default <template>{{fooBar arg=1}}</template>;`,
+    `import fooBar from './foo-bar';
+     export default <template>{{#fooBar}}content{{/fooBar}}</template>;`,
+    `const someHelper = () => 'x';
+     export default <template>{{someHelper}}</template>;`,
   ],
   invalid: [
     {
@@ -140,42 +152,19 @@ const hbsRuleTester = new RuleTester({
   },
 });
 
-function generateBlockError(name) {
-  const parts = name.split('/');
-  const angleBracketName = parts
-    .map((part) => {
-      return part
-        .split('-')
-        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-        .join('');
-    })
-    .join('::');
-  return `You are using the component {{#${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
-}
-
-function generateThisBlockError(name) {
-  const displayName = name.replace(/^(this\.|@)/, '');
-  const parts = displayName.split('/');
-  const prefix = name.startsWith('@') ? '@' : name.startsWith('this.') ? 'This.' : '';
+function generateBlockError(name, isLocal) {
   let angleBracketName;
-  if (name.startsWith('@')) {
-    angleBracketName = `@${parts[0]
-      .split('-')
-      .map((p, i) => (i === 0 ? p : p.charAt(0).toUpperCase() + p.slice(1)))
-      .join('')}`;
-  } else if (name.startsWith('this.')) {
-    angleBracketName = `This.${parts[0]
-      .split('-')
-      .map((p, i) => (i === 0 ? p : p.charAt(0).toUpperCase() + p.slice(1)))
-      .join('')}`;
+  if (name.startsWith('@') || name.startsWith('this.') || isLocal) {
+    angleBracketName = name;
   } else {
+    const parts = name.split('/');
     angleBracketName = parts
-      .map((part) =>
-        part
+      .map((part) => {
+        return part
           .split('-')
           .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-          .join('')
-      )
+          .join('');
+      })
       .join('::');
   }
   return `You are using the component {{#${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
@@ -315,7 +304,7 @@ hbsRuleTester.run('template-no-curly-component-invocation', rule, {
       output: '<FooBar as |foo-baz|>{{#foo-baz as |foo-boo|}}{{foo-boo}}{{/foo-baz}}</FooBar>',
       errors: [
         { message: generateBlockError('foo-bar') },
-        { message: generateBlockError('foo-baz') },
+        { message: generateBlockError('foo-baz', true) },
         { message: generateError('foo-boo') },
       ],
     },
@@ -326,15 +315,15 @@ hbsRuleTester.run('template-no-curly-component-invocation', rule, {
     },
     {
       code: '{{#this.foo-bar as |foo-baz|}}{{foos-baz}}{{/this.foo-bar}}',
-      output: '<This.fooBar as |foo-baz|>{{foos-baz}}</This.fooBar>',
+      output: '<this.foo-bar as |foo-baz|>{{foos-baz}}</this.foo-bar>',
       errors: [
-        { message: generateThisBlockError('this.foo-bar') },
+        { message: generateBlockError('this.foo-bar') },
         { message: generateError('foos-baz') },
       ],
     },
     {
       code: '{{#this.fooBar as |foo-baz|}}{{foos-baz}}{{/this.fooBar}}',
-      output: '<This.fooBar as |foo-baz|>{{foos-baz}}</This.fooBar>',
+      output: '<this.fooBar as |foo-baz|>{{foos-baz}}</this.fooBar>',
       errors: [
         { message: generateBlockError('this.fooBar') },
         { message: generateError('foos-baz') },
@@ -342,11 +331,8 @@ hbsRuleTester.run('template-no-curly-component-invocation', rule, {
     },
     {
       code: '{{#@foo-bar as |foo-baz|}}{{foos-baz}}{{/@foo-bar}}',
-      output: '<@fooBar as |foo-baz|>{{foos-baz}}</@fooBar>',
-      errors: [
-        { message: generateThisBlockError('@foo-bar') },
-        { message: generateError('foos-baz') },
-      ],
+      output: '<@foo-bar as |foo-baz|>{{foos-baz}}</@foo-bar>',
+      errors: [{ message: generateBlockError('@foo-bar') }, { message: generateError('foos-baz') }],
     },
     {
       code: '{{#@fooBar as |foo-baz|}}{{foos-baz}}{{/@fooBar}}',
@@ -355,8 +341,8 @@ hbsRuleTester.run('template-no-curly-component-invocation', rule, {
     },
     {
       code: '{{#let (component "foo") as |my-component|}}{{#my-component}}{{/my-component}}{{/let}}',
-      output: '{{#let (component "foo") as |my-component|}}<MyComponent></MyComponent>{{/let}}',
-      errors: [{ message: generateBlockError('my-component') }],
+      output: '{{#let (component "foo") as |my-component|}}<my-component></my-component>{{/let}}',
+      errors: [{ message: generateBlockError('my-component', true) }],
     },
     // Curly component invocations with hash params
     {


### PR DESCRIPTION
### What's broken on `master`
Two related false positives:

1. **Autofix PascalCases path prefixes.** `transformTagName` unconditionally PascalCases the curly path when generating the suggested angle-bracket form, corrupting three categories of names:

   ```hbs
   {{#this.foo-bar}}…{{/this.foo-bar}}   → <This.fooBar>…</This.fooBar>   ❌
   {{#@foo-bar}}…{{/@foo-bar}}           → <@fooBar>…</@fooBar>           ❌
   {{#my-component}}…                    → <MyComponent>…                 ❌ (when my-component is a block param)
   ```

2. **GJS/GTS JS scope bindings flagged.** The port has no JS scope tracker, so valid imported/const identifiers used in curly form are flagged as needing angle-bracket conversion. The "fix" would break: `import fooBar from './foo-bar'; <template>{{fooBar}}</template>` would be rewritten to `<FooBar />` which references an unbound name.

### Fix
- Pass `isLocal` to `transformTagName` and return the name verbatim when it starts with `@`, starts with `this.`, or is a local (block-param) binding. Matches upstream exactly ([`curly-component-invocation.js` L1–2](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/helpers/curly-component-invocation.js#L1-L2)).
- Add `isJsScopeBinding(node)` using `sourceCode.getScope()`. When the mustache/block path head resolves to a JS binding, skip reporting entirely. Pattern already used by [`template-no-redundant-fn`](lib/rules/template-no-redundant-fn.js#L33-L41) and [`template-no-restricted-invocations`](lib/rules/template-no-restricted-invocations.js) (`isJsScopeVariable`). Upstream ember-template-lint uses `this.isLocal(path)` via its own scope tracker for the same purpose.

### Test plan
- 103/103 tests pass on the branch
- 5 existing tests had wrong expected output (PascalCase suggestions); updated to correct form. All 5 fail on master.
- 4 new valid tests with JS scope bindings (`import fooBar from '…'; {{fooBar}}`, `{{fooBar arg=1}}`, `{{#fooBar}}…{{/fooBar}}`, `const someHelper = …; {{someHelper}}`) all fail on master.

---

Co-written by Claude.