### PR TITLE
Post-merge-review: Fix `template-no-dynamic-subexpression-invocations` false positive on body-position `this.*` mustaches

### DIFF
--- a/docs/rules/template-no-dynamic-subexpression-invocations.md
+++ b/docs/rules/template-no-dynamic-subexpression-invocations.md
@@ -26,12 +26,6 @@ This rule disallows invoking helpers dynamically using `this` or `@` properties.
 </template>
 ```
 
-```gjs
-<template>
-  {{this.formatter this.data}}
-</template>
-```
-
 ### Correct ✅
 
 ```gjs
@@ -49,6 +43,13 @@ This rule disallows invoking helpers dynamically using `this` or `@` properties.
 ```gjs
 <template>
   {{this.formattedData}}
+</template>
+```
+
+```gjs
+{{! Body-position dynamic helpers are allowed }}
+<template>
+  {{this.formatter this.data}}
 </template>
 ```
 

--- a/lib/rules/template-no-dynamic-subexpression-invocations.js
+++ b/lib/rules/template-no-dynamic-subexpression-invocations.js
@@ -138,17 +138,6 @@ module.exports = {
               node,
               messageId: 'noDynamicSubexpressionInvocations',
             });
-            return;
-          }
-
-          if (!inAttr && hasArgs) {
-            // In body context, only flag this.* paths (not @args)
-            if (node.path.head?.type === 'ThisHead') {
-              context.report({
-                node,
-                messageId: 'noDynamicSubexpressionInvocations',
-              });
-            }
           }
         }
       },

--- a/tests/lib/rules/template-no-dynamic-subexpression-invocations.js
+++ b/tests/lib/rules/template-no-dynamic-subexpression-invocations.js
@@ -29,6 +29,8 @@ ruleTester.run('template-no-dynamic-subexpression-invocations', rule, {
     '<template>{{null}}</template>',
     '<template>{{undefined}}</template>',
     '<template>{{"foo"}}</template>',
+    // MustacheStatements in body context are not flagged (only attr context is)
+    '<template>{{this.formatter this.data}}</template>',
   ],
 
   invalid: [
@@ -49,16 +51,6 @@ ruleTester.run('template-no-dynamic-subexpression-invocations', rule, {
         {
           message: 'Do not use dynamic helper invocations. Use explicit helper names instead.',
           type: 'GlimmerSubExpression',
-        },
-      ],
-    },
-    {
-      code: '<template>{{this.formatter this.data}}</template>',
-      output: null,
-      errors: [
-        {
-          message: 'Do not use dynamic helper invocations. Use explicit helper names instead.',
-          type: 'GlimmerMustacheStatement',
         },
       ],
     },


### PR DESCRIPTION
### What's broken on `master`
The extraction added a body-position check that upstream does not have: `{{this.formatter this.data}}` in body position is flagged. Upstream only flags `MustacheStatement` when it is in attribute position ([`no-dynamic-subexpression-invocations.js` L27–36](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-dynamic-subexpression-invocations.js#L27-L36)):

```js
case 'MustacheStatement': {
  let isAttr = parents.some((it) => it.node.type === 'AttrNode');
  if (isAttr && isDynamic && hasArguments) { this.log(...); }
}
```

`SubExpression` and `ElementModifierStatement` are still flagged unconditionally (matching upstream L17–24) — those branches of the rule are unchanged.

### Fix
Remove the 11-line body-position `MustacheStatement` branch. Update docs to move `{{this.formatter this.data}}` from "Incorrect" to "Correct" examples.

### Test plan
- 62/62 tests pass on the branch
- 1 existing invalid test (`{{this.formatter this.data}}`) moved to valid. Fails on master.

---

Co-written by Claude.