### PR TITLE
Post-merge-review: Fix `template-no-invalid-aria-attributes`: reject boolean strings for string-typed ARIA attributes

### DIFF
--- a/lib/rules/template-no-invalid-aria-attributes.js
+++ b/lib/rules/template-no-invalid-aria-attributes.js
@@ -28,9 +28,7 @@ function isValidAriaValue(attrName, value) {
     case 'tristate': {
       return isBoolean(value) || value === 'mixed';
     }
-    case 'string': {
-      return typeof value === 'string';
-    }
+    case 'string':
     case 'id': {
       return typeof value === 'string' && !isBoolean(value);
     }

--- a/tests/lib/rules/template-no-invalid-aria-attributes.js
+++ b/tests/lib/rules/template-no-invalid-aria-attributes.js
@@ -116,6 +116,11 @@ ruleTester.run('template-no-invalid-aria-attributes', rule, {
       output: null,
       errors: [{ messageId: 'invalidAriaAttributeValue' }],
     },
+    {
+      code: '<template><div aria-label="true"></div></template>',
+      output: null,
+      errors: [{ messageId: 'invalidAriaAttributeValue' }],
+    },
   ],
 });
 


### PR DESCRIPTION
### What's broken on `master`
The port split `case 'string'` and `case 'id'` in `isValidAriaValue` and let `'string'` accept any string — including `"true"` and `"false"`. Upstream uses an explicit fall-through ([`no-invalid-aria-attributes.js` L72–74](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-invalid-aria-attributes.js#L72-L74)):

```js
case 'string':
case 'id': {
  return typeof value === 'string' && !isBoolean(value);
}
```

So master allows nonsense like `aria-label="true"` (a screen reader would literally announce "true"). Affects 8 string-typed ARIA attributes: `aria-braillelabel`, `aria-brailleroledescription`, `aria-description`, `aria-keyshortcuts`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`.

### Fix
Restore the fall-through exactly as in upstream.

### Test plan
- 68/68 tests pass on the branch
- 1 new invalid test (`<div aria-label="true">`) fails on master

---

Co-written by Claude.