### PR TITLE
Post-merge-review: Fix `template-no-multiple-empty-lines`: detect trailing empty lines and fix reported location

### DIFF
--- a/lib/rules/template-no-multiple-empty-lines.js
+++ b/lib/rules/template-no-multiple-empty-lines.js
@@ -49,10 +49,40 @@ module.exports = {
           offset += line.length + 1; // +1 for the '\n'
         }
 
+        // Swallow the final newline, as some editors add it automatically
+        // and we don't want it to cause an issue.
+        const effectiveLines = lines.length > 0 && lines.at(-1) === '' ? lines.slice(0, -1) : lines;
+
         let emptyCount = 0;
         let firstEmptyLine = -1;
 
-        for (const [index, line] of lines.entries()) {
+        function reportExcess(endIndex) {
+          const startLine = firstEmptyLine + max;
+          const endLine = endIndex;
+
+          // Remove the excess empty lines: keep `max` empty lines,
+          // remove everything from the start of the (max+1)-th empty
+          // line to the start of the next non-empty line (or end of content).
+          const rangeStart = lineOffsets[firstEmptyLine + max];
+          const rangeEnd = endIndex < lines.length ? lineOffsets[endIndex] : text.length;
+
+          context.report({
+            loc: {
+              start: { line: startLine + 1, column: 0 },
+              end: { line: endLine + 1, column: 0 },
+            },
+            messageId: 'unexpected',
+            data: {
+              max,
+              pluralizedLines: max === 1 ? 'line' : 'lines',
+            },
+            fix(fixer) {
+              return fixer.replaceTextRange([rangeStart, rangeEnd], '');
+            },
+          });
+        }
+
+        for (const [index, line] of effectiveLines.entries()) {
           if (line.trim() === '') {
             if (emptyCount === 0) {
               firstEmptyLine = index;
@@ -60,33 +90,16 @@ module.exports = {
             emptyCount++;
           } else {
             if (emptyCount > max) {
-              const startLine = firstEmptyLine + max + 1;
-              const endLine = index;
-
-              // Remove the excess empty lines: keep `max` empty lines,
-              // remove everything from the start of the (max+1)-th empty
-              // line to the start of the next non-empty line.
-              const rangeStart = lineOffsets[firstEmptyLine + max];
-              const rangeEnd = lineOffsets[endLine];
-
-              context.report({
-                loc: {
-                  start: { line: startLine + 1, column: 0 },
-                  end: { line: endLine, column: 0 },
-                },
-                messageId: 'unexpected',
-                data: {
-                  max,
-                  pluralizedLines: max === 1 ? 'line' : 'lines',
-                },
-                fix(fixer) {
-                  return fixer.replaceTextRange([rangeStart, rangeEnd], '');
-                },
-              });
+              reportExcess(index);
             }
             emptyCount = 0;
             firstEmptyLine = -1;
           }
+        }
+
+        // Handle trailing empty lines at the end of the effective content
+        if (emptyCount > max) {
+          reportExcess(effectiveLines.length);
         }
       },
     };

--- a/tests/lib/rules/template-no-multiple-empty-lines.js
+++ b/tests/lib/rules/template-no-multiple-empty-lines.js
@@ -177,5 +177,22 @@ hbsRuleTester.run('template-no-multiple-empty-lines', rule, {
       options: [{ max: 3 }],
       errors: [{ message: 'More than 3 blank lines not allowed.' }],
     },
+    // loc fix: the excess empty line (line 3) is reported at the correct location
+    {
+      code: '<div>foo</div>\n\n\n<div>bar</div>',
+      output: '<div>foo</div>\n\n<div>bar</div>',
+      errors: [{ message: 'More than 1 blank line not allowed.', line: 3, endLine: 4 }],
+    },
+    // Trailing empty lines
+    {
+      code: '<div>foo</div>\n\n\n',
+      output: '<div>foo</div>\n\n',
+      errors: [{ message: 'More than 1 blank line not allowed.' }],
+    },
+    {
+      code: '<div>foo</div>\n\n\n\n\n',
+      output: '<div>foo</div>\n\n',
+      errors: [{ message: 'More than 1 blank line not allowed.' }],
+    },
   ],
 });


### PR DESCRIPTION
### What's broken on `master`
Two bugs in the line-scanning loop:

1. **Trailing empty lines silently ignored.** The rule reports only when a non-empty line is encountered after a streak of empty lines, so a file ending with `…foo\n\n\n` (three newlines) never reports. Upstream handles this by iterating `allLines.length + 1` ([`no-multiple-empty-lines.js` L49](https://github.com/ember-template-lint/ember-template-lint/blob/f43c6f11fdf8fc8ecb51ba04cea0f367b1af544b/lib/rules/no-multiple-empty-lines.js#L49)).
2. **Inverted error location.** Master computes `start.line = firstEmptyLine + max + 2` and `end.line = index`, producing `start.line > end.line` in real cases.

### Fix
- Swallow the final newline — strip the last element when it's empty, matching upstream L15 (`source.at(-1) === '' ? source.slice(0, -1) : source`).
- Add post-loop `reportExcess` call for trailing empty lines.
- Correct the loc computation.
- Extract the reporting into a shared `reportExcess` function so both the mid-file and trailing cases use identical logic.

### Test plan
- 27/27 tests pass on the branch
- 2 new trailing-empty-line tests fail on master (0 errors reported, 1 expected)
- 1 new test with explicit `line`/`endLine` assertions fails on master (the inverted loc bug)

---

Co-written by Claude.