### PR TITLE
Post-merge-review: Fix `template-no-empty-headings`: recognize `<this.X>`, `<@x>`, `<ns.X>` as accessible content

### DIFF
--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -19,7 +19,15 @@ function isComponent(node) {
     return false;
   }
   const tag = node.tag;
-  return /^[A-Z]/.test(tag) || tag.includes('::');
+  // PascalCase (<MyComponent>), namespaced (<Foo::Bar>), this.-prefixed
+  // (<this.Component>), arg-prefixed (<@component>), or dot-path (<ns.Widget>)
+  return (
+    /^[A-Z]/.test(tag) ||
+    tag.includes('::') ||
+    tag.startsWith('this.') ||
+    tag.startsWith('@') ||
+    tag.includes('.')
+  );
 }
 
 function isTextEmpty(text) {

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -38,6 +38,11 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h2><div><span>{{@title}}</span></div></h2></template>',
     '<template><h2><span>Some text{{@title}}</span></h2></template>',
     '<template><h2><span><div></div>{{@title}}</span></h2></template>',
+
+    // Non-PascalCase component forms count as accessible content
+    '<template><h1><this.Heading /></h1></template>',
+    '<template><h2><@heading /></h2></template>',
+    '<template><h3><ns.Heading /></h3></template>',
   ],
   invalid: [
     {


### PR DESCRIPTION
### What's broken on `master`
`isComponent` only considers PascalCase tags or `Foo::Bar` nested-component syntax. It misses three valid GTS component invocation forms per the [template tag format guide](https://guides.emberjs.com/release/components/template-tag-format/):
- `<this.Heading>` (class-scoped component reference)
- `<@heading>` (argument-passed component)
- `<ns.Heading>` (dot-path re-export)

When one of these appears as the only child of a heading, the rule walks the child list, fails to identify it as a component, and reports the heading as empty.

### Fix
Extend `isComponent` with three additional conditions: `tag.startsWith('this.')`, `tag.startsWith('@')`, `tag.includes('.')`. All three are component forms that cannot be HTML elements in any mode (HTML doesn't allow `this.`/`@`/`.` in tag names).

### Test plan
- 50/50 tests pass on the branch
- 3 new valid tests (`<h1><this.Heading />`, `<h2><@heading />`, `<h3><ns.Heading />`) all fail on master

---

Co-written by Claude.