### PR TITLE
Post-merge-review: Fix `template-no-at-ember-render-modifiers`: detect GJS/GTS imports

### DIFF
--- a/lib/rules/template-no-at-ember-render-modifiers.js
+++ b/lib/rules/template-no-at-ember-render-modifiers.js
@@ -1,12 +1,19 @@
-// Map of `@ember/render-modifiers` sub-path → canonical kebab-case modifier name.
-// Default-imported names are user-chosen, so we track local names to canonical.
+// Sub-path → canonical kebab-case modifier name (default import).
 const RENDER_MODIFIER_IMPORT_PATHS = {
   '@ember/render-modifiers/modifiers/did-insert': 'did-insert',
   '@ember/render-modifiers/modifiers/did-update': 'did-update',
   '@ember/render-modifiers/modifiers/will-destroy': 'will-destroy',
 };
 
+// Named exports of the root package `@ember/render-modifiers` → canonical kebab name.
+const ROOT_NAMED_EXPORTS = {
+  didInsert: 'did-insert',
+  didUpdate: 'did-update',
+  willDestroy: 'will-destroy',
+};
+
 const KEBAB_NAMES = new Set(['did-insert', 'did-update', 'will-destroy']);
+const ROOT_PACKAGE = '@ember/render-modifiers';
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -56,11 +63,27 @@ module.exports = {
         if (!isStrictMode) {
           return;
         }
-        const canonical = RENDER_MODIFIER_IMPORT_PATHS[node.source.value];
+        const source = node.source.value;
+
+        if (source === ROOT_PACKAGE) {
+          // `import { didInsert, didUpdate as x } from '@ember/render-modifiers'`
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportSpecifier') {
+              const exportedName = specifier.imported.name;
+              const canonical = ROOT_NAMED_EXPORTS[exportedName];
+              if (canonical) {
+                importedModifiers.set(specifier.local.name, canonical);
+              }
+            }
+          }
+          return;
+        }
+
+        // Sub-path: `import didInsert from '@ember/render-modifiers/modifiers/did-insert'`
+        const canonical = RENDER_MODIFIER_IMPORT_PATHS[source];
         if (!canonical) {
           return;
         }
-        // Default import (`import didInsert from '...'`) is the supported form
         for (const specifier of node.specifiers) {
           if (specifier.type === 'ImportDefaultSpecifier') {
             importedModifiers.set(specifier.local.name, canonical);

--- a/lib/rules/template-no-at-ember-render-modifiers.js
+++ b/lib/rules/template-no-at-ember-render-modifiers.js
@@ -1,3 +1,13 @@
+// Map of `@ember/render-modifiers` sub-path → canonical kebab-case modifier name.
+// Default-imported names are user-chosen, so we track local names to canonical.
+const RENDER_MODIFIER_IMPORT_PATHS = {
+  '@ember/render-modifiers/modifiers/did-insert': 'did-insert',
+  '@ember/render-modifiers/modifiers/did-update': 'did-update',
+  '@ember/render-modifiers/modifiers/will-destroy': 'will-destroy',
+};
+
+const KEBAB_NAMES = new Set(['did-insert', 'did-update', 'will-destroy']);
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -23,24 +33,56 @@ module.exports = {
   },
 
   create(context) {
+    const filename = context.filename;
+    const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
+
+    // local import name → canonical kebab name. Only populated in GJS/GTS.
+    const importedModifiers = new Map();
+
+    function isRenderModifier(name) {
+      if (isStrictMode) {
+        return importedModifiers.has(name);
+      }
+      // HBS: resolver-resolved by canonical kebab name
+      return KEBAB_NAMES.has(name);
+    }
+
+    function canonicalName(name) {
+      return importedModifiers.get(name) || name;
+    }
+
     return {
+      ImportDeclaration(node) {
+        if (!isStrictMode) {
+          return;
+        }
+        const canonical = RENDER_MODIFIER_IMPORT_PATHS[node.source.value];
+        if (!canonical) {
+          return;
+        }
+        // Default import (`import didInsert from '...'`) is the supported form
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            importedModifiers.set(specifier.local.name, canonical);
+          }
+        }
+      },
+
       GlimmerElementNode(node) {
         if (!node.modifiers) {
           return;
         }
 
         for (const modifier of node.modifiers) {
-          if (
-            modifier.path &&
-            modifier.path.type === 'GlimmerPathExpression' &&
-            (modifier.path.original === 'did-insert' ||
-              modifier.path.original === 'did-update' ||
-              modifier.path.original === 'will-destroy')
-          ) {
+          if (modifier.path?.type !== 'GlimmerPathExpression') {
+            continue;
+          }
+          const name = modifier.path.original;
+          if (isRenderModifier(name)) {
             context.report({
               node: modifier,
               messageId: 'noRenderModifier',
-              data: { modifier: modifier.path.original },
+              data: { modifier: canonicalName(name) },
             });
           }
         }

--- a/tests/lib/rules/template-no-at-ember-render-modifiers.js
+++ b/tests/lib/rules/template-no-at-ember-render-modifiers.js
@@ -32,6 +32,19 @@ ruleTester.run('template-no-at-ember-render-modifiers', rule, {
     '<template>{{did-insert}}</template>',
     '<template>{{did-update}}</template>',
     '<template>{{will-destroy}}</template>',
+
+    // In GJS/GTS, kebab identifiers cannot be imports; these are bare paths
+    // that happen to share the canonical name but are not the render modifier.
+    {
+      filename: 'test.gjs',
+      code: '<template><div {{did-insert this.setup}}></div></template>',
+    },
+    // Unrelated imports with matching local names should not match
+    {
+      filename: 'test.gjs',
+      code: `import didInsert from './my-lib';
+        <template><div {{didInsert this.setup}}></div></template>`,
+    },
   ],
 
   invalid: [
@@ -84,6 +97,37 @@ ruleTester.run('template-no-at-ember-render-modifiers', rule, {
     },
     {
       code: '<template><div {{will-destroy}}></div></template>',
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+
+    // GJS/GTS import-based forms — local name is user-chosen
+    {
+      filename: 'test.gjs',
+      code: `import didInsert from '@ember/render-modifiers/modifiers/did-insert';
+        <template><div {{didInsert this.setup}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    {
+      filename: 'test.gjs',
+      code: `import didUpdate from '@ember/render-modifiers/modifiers/did-update';
+        <template><div {{didUpdate this.update}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    {
+      filename: 'test.gjs',
+      code: `import willDestroy from '@ember/render-modifiers/modifiers/will-destroy';
+        <template><div {{willDestroy this.cleanup}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    // Renamed default import still flags
+    {
+      filename: 'test.gjs',
+      code: `import myInsert from '@ember/render-modifiers/modifiers/did-insert';
+        <template><div {{myInsert this.setup}}></div></template>`,
       output: null,
       errors: [{ messageId: 'noRenderModifier' }],
     },

--- a/tests/lib/rules/template-no-at-ember-render-modifiers.js
+++ b/tests/lib/rules/template-no-at-ember-render-modifiers.js
@@ -45,6 +45,12 @@ ruleTester.run('template-no-at-ember-render-modifiers', rule, {
       code: `import didInsert from './my-lib';
         <template><div {{didInsert this.setup}}></div></template>`,
     },
+    // Root-package import of an unknown named export is not a render modifier
+    {
+      filename: 'test.gjs',
+      code: `import { somethingElse } from '@ember/render-modifiers';
+        <template><div {{somethingElse this.setup}}></div></template>`,
+    },
   ],
 
   invalid: [
@@ -128,6 +134,37 @@ ruleTester.run('template-no-at-ember-render-modifiers', rule, {
       filename: 'test.gjs',
       code: `import myInsert from '@ember/render-modifiers/modifiers/did-insert';
         <template><div {{myInsert this.setup}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+
+    // Root-package named imports — all three modifiers
+    {
+      filename: 'test.gjs',
+      code: `import { didInsert } from '@ember/render-modifiers';
+        <template><div {{didInsert this.setup}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    {
+      filename: 'test.gjs',
+      code: `import { didUpdate } from '@ember/render-modifiers';
+        <template><div {{didUpdate this.update}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    {
+      filename: 'test.gjs',
+      code: `import { willDestroy } from '@ember/render-modifiers';
+        <template><div {{willDestroy this.cleanup}}></div></template>`,
+      output: null,
+      errors: [{ messageId: 'noRenderModifier' }],
+    },
+    // Aliased root-package import still flags
+    {
+      filename: 'test.gjs',
+      code: `import { didInsert as myModifier } from '@ember/render-modifiers';
+        <template><div {{myModifier this.setup}}></div></template>`,
       output: null,
       errors: [{ messageId: 'noRenderModifier' }],
     },


### PR DESCRIPTION
### What's broken on `master`
The rule matches a hardcoded kebab-case list (`did-insert`, `did-update`, `will-destroy`). That works for classic `.hbs` where the resolver exposes modifiers by their canonical name, but it misses the GJS/GTS usage entirely:

```gjs
import didInsert from '@ember/render-modifiers/modifiers/did-insert';

<template>
  <div {{didInsert this.setup}}></div>
</template>
```

Here the local name is user-chosen (could be `didInsert`, `onInsert`, `myInsert`, anything). The rule has no way to match the user's identifier against the render-modifier import.

### Fix
In `.gjs`/`.gts` files, track `ImportDeclaration` nodes whose source is one of `@ember/render-modifiers/modifiers/did-insert` / `did-update` / `will-destroy`, recording the default-import local name → canonical kebab name. Flag modifier usages whose identifier matches a tracked local name. In `.hbs`, keep the kebab-case matching (matches upstream ember-template-lint exactly — upstream is HBS-only).

Pattern is the same as [`template-no-builtin-form-components`](lib/rules/template-no-builtin-form-components.js#L27-L86), which already tracks `@ember/component` imports in strict mode.

### Test plan
- 30/30 tests pass on the branch
- 4 new invalid GJS tests covering `didInsert` / `didUpdate` / `willDestroy` imports (and a renamed `myInsert`) fail on master — master silently ignores them all
- 2 new valid GJS tests confirm that (a) a bare kebab-looking identifier without an import is not flagged, and (b) an unrelated local import named `didInsert` from a non-render-modifiers path is not flagged
- Existing HBS tests unchanged (the kebab-case HBS path is preserved)

---

Co-written by Claude.