### PR TITLE
Post-merge-review: Fix `template-deprecated-render-helper` false positive in GJS/GTS

### DIFF
--- a/lib/rules/template-deprecated-render-helper.js
+++ b/lib/rules/template-deprecated-render-helper.js
@@ -23,6 +23,11 @@ module.exports = {
   },
 
   create(context) {
+    const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');
+    if (isStrictMode) {
+      return {};
+    }
+
     const sourceCode = context.sourceCode;
 
     function buildFix(node) {

--- a/tests/lib/rules/template-deprecated-render-helper.js
+++ b/tests/lib/rules/template-deprecated-render-helper.js
@@ -19,6 +19,15 @@ ruleTester.run('template-deprecated-render-helper', rule, {
     '<template>{{42}}</template>',
     '<template>{{null}}</template>',
     '<template>{{undefined}}</template>',
+    // Rule is HBS-only: `render` in GJS/GTS is a JS binding, not the classic helper
+    {
+      filename: 'test.gjs',
+      code: '<template>{{render "user"}}</template>',
+    },
+    {
+      filename: 'test.gts',
+      code: '<template>{{render "user"}}</template>',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
### What's broken on `master`
The rule flags `{{render ...}}` as the classic Ember resolver-resolved helper. In GJS/GTS, `render` is commonly imported from `@ember/test-helpers` or `@testing-library/ember` — unrelated to the classic `{{render}}` helper. `templateMode: 'loose'` metadata is not runtime-enforced.

### Fix
Gate to `.hbs` files only. The classic helper cannot be reached in strict mode.

### Test plan
27/27 tests pass. 2 new GJS/GTS valid tests fail on master.

---

Co-written by Claude.