### PR TITLE
Post-merge-review: Fix `template-deprecated-inline-view-helper` false positive in GJS/GTS

### DIFF
--- a/lib/rules/template-deprecated-inline-view-helper.js
+++ b/lib/rules/template-deprecated-inline-view-helper.js
@@ -23,6 +23,11 @@ module.exports = {
   },
 
   create(context) {
+    const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');
+    if (isStrictMode) {
+      return {};
+    }
+
     const sourceCode = context.sourceCode;
 
     // Track block param names to avoid false positives on locals like:

--- a/tests/lib/rules/template-deprecated-inline-view-helper.js
+++ b/tests/lib/rules/template-deprecated-inline-view-helper.js
@@ -30,6 +30,15 @@ ruleTester.run('template-deprecated-inline-view-helper', rule, {
     '<template>{{yield hash=view.foo}}</template>',
     // hash pair with key "to" should not be flagged
     '<template>{{some-component to=view.foo}}</template>',
+    // Rule is HBS-only: `view` in GJS/GTS may be a legitimate imported JS binding
+    {
+      filename: 'test.gjs',
+      code: "<template>{{view 'awful-fishsticks'}}</template>",
+    },
+    {
+      filename: 'test.gts',
+      code: '<template>{{view.bad-fishsticks}}</template>',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
### What's broken on `master`
Flags `{{view ...}}` and `view.*` paths. Block-param shadowing is tracked but JS imports/consts are not, so in GJS/GTS a legitimate `import view from '…'` would be flagged.

### Fix
Gate to `.hbs` only. The classic `view` helper/namespace only exists in HBS.

### Test plan
53/53 tests pass. 2 new GJS valid tests fail on master.

---

Co-written by Claude.