### PR TITLE
Post-merge-review: Fix `template-no-class-bindings` false positive in GJS/GTS

### DIFF
--- a/lib/rules/template-no-class-bindings.js
+++ b/lib/rules/template-no-class-bindings.js
@@ -23,6 +23,11 @@ module.exports = {
   },
 
   create(context) {
+    const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');
+    if (isStrictMode) {
+      return {};
+    }
+
     const FORBIDDEN_ATTR_NAMES = new Set([
       'classBinding',
       '@classBinding',

--- a/tests/lib/rules/template-no-class-bindings.js
+++ b/tests/lib/rules/template-no-class-bindings.js
@@ -13,6 +13,15 @@ ruleTester.run('template-no-class-bindings', rule, {
     '<template>{{true}}</template>',
     '<template>{{"hehe"}}</template>',
     '<template><div class="foo"></div></template>',
+    // Rule is HBS-only: @classBinding in GJS/GTS may be a legitimate component argument
+    {
+      filename: 'test.gjs',
+      code: '<template><SomeThing @classBinding="lol:wat" /></template>',
+    },
+    {
+      filename: 'test.gts',
+      code: '<template>{{some-thing classNameBindings="lol:foo:bar"}}</template>',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
### What's broken on `master`
Flags `classBinding`/`classNameBindings` attributes as classic-Ember mixin patterns. In GJS/GTS a user-authored component could legitimately accept these as argument names with any meaning.

### Fix
Gate to `.hbs` only.

### Test plan
19/19 tests pass. 2 new GJS valid tests fail on master.

---

Co-written by Claude.