### PR TITLE
Post-merge-review: Fix `template-no-unbound` false positive in GJS/GTS

### DIFF
--- a/docs/rules/template-no-unbound.md
+++ b/docs/rules/template-no-unbound.md
@@ -1,7 +1,5 @@
 # ember/template-no-unbound
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 `{{unbound}}` is a legacy hold over from the days in which Ember's template engine was less performant. Its use today

--- a/lib/rules/template-no-unbound.js
+++ b/lib/rules/template-no-unbound.js
@@ -6,7 +6,7 @@ module.exports = {
       description: 'disallow {{unbound}} helper',
       category: 'Deprecations',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-unbound.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     schema: [],
     messages: { unexpected: 'Unexpected {{unboundHelper}} usage.' },
@@ -18,8 +18,38 @@ module.exports = {
     },
   },
   create(context) {
+    // `unbound` is an ambient strict-mode keyword (registered in Ember's
+    // STRICT_MODE_KEYWORDS, backed by BUILTIN_KEYWORD_HELPERS.unbound), so
+    // `{{unbound foo}}` works in .gjs/.gts without an import. Flag it
+    // everywhere unless shadowed by a JS binding or template block param —
+    // ember-eslint-parser registers template block params in scope, so a
+    // single getScope walk covers both.
+    const sourceCode = context.sourceCode;
+
+    function isInScope(node, name) {
+      if (!sourceCode) {
+        return false;
+      }
+      try {
+        let scope = sourceCode.getScope(node);
+        while (scope) {
+          if (scope.variables.some((v) => v.name === name)) {
+            return true;
+          }
+          scope = scope.upper;
+        }
+      } catch {
+        // getScope not available in .hbs-only mode
+      }
+      return false;
+    }
+
     function check(node) {
-      if (node.path?.type === 'GlimmerPathExpression' && node.path.original === 'unbound') {
+      if (
+        node.path?.type === 'GlimmerPathExpression' &&
+        node.path.original === 'unbound' &&
+        !isInScope(node, 'unbound')
+      ) {
         context.report({
           node,
           messageId: 'unexpected',
@@ -27,6 +57,7 @@ module.exports = {
         });
       }
     }
+
     return {
       GlimmerMustacheStatement: check,
       GlimmerBlockStatement: check,

--- a/tests/lib/rules/template-no-unbound.js
+++ b/tests/lib/rules/template-no-unbound.js
@@ -35,8 +35,40 @@ const gjsRuleTester = new RuleTester({
 });
 
 gjsRuleTester.run('template-no-unbound', rule, {
-  valid: validHbs.map(wrapTemplate),
-  invalid: invalidHbs.map(wrapTemplate),
+  valid: [
+    ...validHbs.map(wrapTemplate),
+    // JS-scope shadowing: a user-imported `unbound` is not the Glimmer keyword.
+    {
+      filename: 'test.gjs',
+      code: "import unbound from './my-unbound-helper';\n<template>{{unbound foo}}</template>",
+    },
+    {
+      filename: 'test.gts',
+      code: "import unbound from '@some/addon';\n<template>{{my-thing foo=(unbound foo)}}</template>",
+    },
+    // Local block-param shadowing.
+    {
+      filename: 'test.gjs',
+      code: '<template>{{#let (component "foo") as |unbound|}}{{unbound}}{{/let}}</template>',
+    },
+  ],
+  invalid: [
+    ...invalidHbs.map(wrapTemplate),
+    // `unbound` is an ambient Glimmer keyword in strict mode — flag bare uses
+    // without a shadowing import or block param.
+    {
+      filename: 'test.gjs',
+      code: '<template>{{unbound foo}}</template>',
+      output: null,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      filename: 'test.gts',
+      code: '<template>{{my-thing foo=(unbound foo)}}</template>',
+      output: null,
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
 });
 
 const hbsRuleTester = new RuleTester({


### PR DESCRIPTION
### What's broken on `master`
Flags `{{unbound}}` as the classic Ember resolver-resolved helper, but doesn't account for JS-scope shadowing in GJS/GTS strict mode. A user-imported `unbound` (`import unbound from './my-unbound-helper'`) or a block-param `unbound` (`{{#let (...) as |unbound|}}`) is incorrectly flagged.

### Why a JS-scope check (not an `.hbs`-only gate)
`unbound` is an **ambient strict-mode keyword** in Glimmer/Ember — registered in `STRICT_MODE_KEYWORDS` and backed by `BUILTIN_KEYWORD_HELPERS.unbound`. So `<template>{{unbound foo}}</template>` works in `.gjs`/`.gts` *without an import*. Gating the rule to `.hbs` would hide the very thing the rule exists to flag (false negative).

### Fix
Mirror the `template-no-log` pattern: walk `sourceCode.getScope().variables` to detect JS bindings, plus track template block params, and skip reporting only when the identifier resolves to a local. Update `templateMode` from `'loose'` to `'both'` to reflect that the rule now runs in strict mode.

### Test plan
13/13 tests pass on the branch.
- Bare `{{unbound foo}}` in `.gjs` is now correctly flagged again (would have been a false negative under an `.hbs`-only gate).
- `import unbound from '...'; {{unbound foo}}` in `.gjs`/`.gts` is correctly skipped (JS-scope binding).
- `{{#let (...) as |unbound|}}{{unbound}}{{/let}}` is correctly skipped (block-param shadowing).
- All HBS cases unchanged.