### PR TITLE
Post-merge-review: Fix `template-no-outlet-outside-routes` false positive on imported `outlet`

### DIFF
--- a/lib/rules/template-no-outlet-outside-routes.js
+++ b/lib/rules/template-no-outlet-outside-routes.js
@@ -51,13 +51,33 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.sourceCode;
     const filename = context.filename;
 
     const routeTemplate = isRouteTemplate(filename);
 
+    function isJsScopeVariable(node) {
+      if (!sourceCode || !node.path?.original) {
+        return false;
+      }
+      const name = node.path.original;
+      try {
+        let scope = sourceCode.getScope(node);
+        while (scope) {
+          if (scope.variables.some((v) => v.name === name)) {
+            return true;
+          }
+          scope = scope.upper;
+        }
+      } catch {
+        // sourceCode.getScope may not be available in .hbs-only mode; ignore.
+      }
+      return false;
+    }
+
     function checkForOutlet(node) {
       if (node.path.type === 'GlimmerPathExpression' && node.path.original === 'outlet') {
-        if (!routeTemplate) {
+        if (!routeTemplate && !isJsScopeVariable(node)) {
           context.report({
             node,
             messageId: 'noOutletOutsideRoutes',

--- a/tests/lib/rules/template-no-outlet-outside-routes.js
+++ b/tests/lib/rules/template-no-outlet-outside-routes.js
@@ -30,6 +30,17 @@ ruleTester.run('template-no-outlet-outside-routes', rule, {
       filename: 'app/routes/foo.gjs',
       code: '<template>{{#outlet}}content{{/outlet}}</template>',
     },
+    // GJS/GTS: imported JS bindings are not flagged
+    {
+      filename: 'app/components/my-component.gjs',
+      code: `import outlet from './my-outlet';
+export default <template>{{outlet}}</template>;`,
+    },
+    {
+      filename: 'app/components/my-component.gts',
+      code: `import outlet from '@company/ui';
+export default <template>{{outlet}}</template>;`,
+    },
   ],
   invalid: [
     // Co-located component (explicit filename)


### PR DESCRIPTION
### What's broken on `master`
Flags `{{outlet}}` in non-route templates. Doesn't check whether `outlet` resolves to a JS binding — in GJS/GTS a user could `import outlet from '…'` and use it in any component.

### Fix
Add JS scope check alongside the existing route-template filename check.

### Test plan
25/25 tests pass. 2 new GJS valid tests with imported `outlet` fail on master.

---

Co-written by Claude.