### PR TITLE
Post-merge-review: Fix `template-require-has-block-helper`: skip JS scope bindings

### DIFF
--- a/lib/rules/template-require-has-block-helper.js
+++ b/lib/rules/template-require-has-block-helper.js
@@ -50,11 +50,38 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.sourceCode;
+
+    // Returns true if the identifier resolves to a JS binding. In GJS/GTS a
+    // user can legitimately `import { hasBlock } from 'somewhere'`; rewriting
+    // their reference to the `has-block` keyword would change semantics.
+    // Note: `node` here is the GlimmerPathExpression itself (this visitor is
+    // on PathExpression directly, not a wrapping MustacheStatement), so we
+    // read `node.original` rather than `node.path.original`.
+    function isJsScopeVariable(node) {
+      if (!sourceCode || !node.original) {
+        return false;
+      }
+      const name = node.original;
+      try {
+        let scope = sourceCode.getScope(node);
+        while (scope) {
+          if (scope.variables.some((v) => v.name === name)) {
+            return true;
+          }
+          scope = scope.upper;
+        }
+      } catch {
+        // sourceCode.getScope may not be available in .hbs-only mode; ignore.
+      }
+      return false;
+    }
+
     return {
       GlimmerPathExpression(node) {
         const replacement = TRANSFORMATIONS[node.original];
 
-        if (replacement) {
+        if (replacement && !isJsScopeVariable(node)) {
           context.report({
             node,
             message: getErrorMessage(node.original),

--- a/tests/lib/rules/template-require-has-block-helper.js
+++ b/tests/lib/rules/template-require-has-block-helper.js
@@ -166,7 +166,15 @@ const gjsRuleTester = new RuleTester({
 });
 
 gjsRuleTester.run('template-require-has-block-helper', rule, {
-  valid: validHbs.map(wrapTemplate),
+  valid: [
+    ...validHbs.map(wrapTemplate),
+    // GJS/GTS: an imported/local hasBlock binding is a user's own reference,
+    // not the Glimmer built-in — rewriting to `has-block` would change semantics.
+    `import hasBlock from './my-has-block';
+     export default <template>{{hasBlock}}</template>;`,
+    `const hasBlockParams = () => true;
+     export default <template>{{hasBlockParams}}</template>;`,
+  ],
   invalid: invalidHbs.map((test) => ({
     code: wrapTemplate(test.code),
     output: wrapTemplate(test.output),


### PR DESCRIPTION
### What's broken on `master`
Flags `hasBlock`/`hasBlockParams` and rewrites them to `has-block`/`has-block-params` (Glimmer keywords). In GJS/GTS, a user could import their own `hasBlock` — and the autofix would silently replace their reference with the built-in keyword, changing semantics.

### Fix
Add JS scope check. Skip the report when the identifier resolves to a user binding.

### Test plan
64/64 tests pass. 2 new GJS valid tests fail on master.

---

Co-written by Claude.