### PR TITLE
Post-merge-review: Fix `template-no-invalid-link-title`: track `@ember/routing` LinkTo import

### DIFF
--- a/lib/rules/template-no-invalid-link-title.js
+++ b/lib/rules/template-no-invalid-link-title.js
@@ -45,21 +45,33 @@ module.exports = {
   },
 
   create(context) {
+    const filename = context.filename;
+    const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
+
+    // In HBS, <LinkTo> always refers to Ember's router link component.
+    // In GJS/GTS, LinkTo must be explicitly imported from '@ember/routing'.
+    // local alias → true (any truthy value marks it as a tracked link component)
+    const importedLinkComponents = new Map();
+
+    const linkTags = new Set(['a']);
+    if (!isStrictMode) {
+      linkTags.add('LinkTo');
+    }
+
     // eslint-disable-next-line complexity
     function checkElementNode(node) {
-      if (node.tag !== 'a' && node.tag !== 'LinkTo') {
+      if (!linkTags.has(node.tag)) {
         return;
       }
+      // Determine if this tag should be treated as <LinkTo> for @title handling
+      const isLinkTo = node.tag === 'LinkTo' || importedLinkComponents.has(node.tag);
 
       const titleAttr = node.attributes.find(
         (attr) => attr.type === 'GlimmerAttrNode' && attr.name === 'title'
       );
-      const titleArgAttr =
-        node.tag === 'LinkTo'
-          ? node.attributes.find(
-              (attr) => attr.type === 'GlimmerAttrNode' && attr.name === '@title'
-            )
-          : null;
+      const titleArgAttr = isLinkTo
+        ? node.attributes.find((attr) => attr.type === 'GlimmerAttrNode' && attr.name === '@title')
+        : null;
 
       // Get title attribute text value
       let titleAttrValue;
@@ -74,12 +86,12 @@ module.exports = {
       }
 
       // Collect all title values (lowercased, trimmed)
-      const titleValues = [titleAttrValue, node.tag === 'LinkTo' ? titleArgValue : null]
+      const titleValues = [titleAttrValue, isLinkTo ? titleArgValue : null]
         .filter((v) => typeof v === 'string')
         .map((v) => v.toLowerCase().trim());
 
       // Error if both title and @title are specified on LinkTo
-      if (node.tag === 'LinkTo' && titleAttrValue !== undefined && titleArgValue !== undefined) {
+      if (isLinkTo && titleAttrValue !== undefined && titleArgValue !== undefined) {
         context.report({
           node: titleAttr || node,
           messageId: 'noInvalidLinkTitle',
@@ -150,6 +162,19 @@ module.exports = {
     }
 
     return {
+      ImportDeclaration(node) {
+        if (!isStrictMode) {
+          return;
+        }
+        if (node.source.value === '@ember/routing') {
+          for (const specifier of node.specifiers) {
+            if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'LinkTo') {
+              importedLinkComponents.set(specifier.local.name, true);
+              linkTags.add(specifier.local.name);
+            }
+          }
+        }
+      },
       GlimmerElementNode: checkElementNode,
       GlimmerBlockStatement: checkBlockStatement,
     };

--- a/tests/lib/rules/template-no-invalid-link-title.js
+++ b/tests/lib/rules/template-no-invalid-link-title.js
@@ -12,6 +12,19 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('template-no-invalid-link-title', rule, {
   valid: [
+    // In GJS/GTS, <LinkTo> is only a router link if explicitly imported.
+    // Without an import, it's a user-authored component and the rule shouldn't fire.
+    {
+      filename: 'test.gjs',
+      code: '<template><LinkTo title="x">x</LinkTo></template>',
+    },
+    // With the import, the rule correctly treats it as the router LinkTo.
+    {
+      filename: 'test.gjs',
+      code: `import { LinkTo } from '@ember/routing';
+        <template><LinkTo title="More about page">Page</LinkTo></template>`,
+    },
+
     '<template><a href="/page" title="More information about page">Page</a></template>',
     '<template><a href="/page">Page</a></template>',
     '<template><a href="/page" title={{dynamic}}>Page</a></template>',
@@ -33,6 +46,14 @@ ruleTester.run('template-no-invalid-link-title', rule, {
     </template>`,
   ],
   invalid: [
+    // Imported <LinkTo> in GJS/GTS: rule still applies
+    {
+      filename: 'test.gjs',
+      code: `import { LinkTo } from '@ember/routing';
+        <template><LinkTo title="quickstart">Quickstart</LinkTo></template>`,
+      output: null,
+      errors: [{ messageId: 'noInvalidLinkTitle' }],
+    },
     {
       code: '<template><a href="/page" title="">Page</a></template>',
       output: null,


### PR DESCRIPTION
### What's broken on `master`
Flags `<LinkTo>` in all files. In GJS/GTS strict mode, `LinkTo` only refers to Ember's router link when explicitly imported from `@ember/routing`. A user-authored component named `LinkTo` is falsely flagged.

### Fix
Track `ImportDeclaration` from `@ember/routing`, matching the pattern in `template-no-invalid-link-text`.

### Test plan
47/47 tests pass. 1 new GJS valid test (unimported `<LinkTo>`) fails on master.

---

Co-written by Claude.