### PR TITLE
Post-merge-review: Fix `template-no-inline-linkto` false positive in GJS/GTS

### DIFF
--- a/docs/rules/template-no-inline-linkto.md
+++ b/docs/rules/template-no-inline-linkto.md
@@ -62,6 +62,19 @@ Examples of **correct** code for this rule:
 </template>
 ```
 
+```gjs
+// User-authored `<LinkTo>` (not from `@ember/routing`) is not flagged in
+// strict mode, even when childless.
+import LinkTo from './my-link-to-component';
+<template>
+  <LinkTo />
+</template>
+```
+
+## Strict-mode behavior
+
+In `.gjs`/`.gts` strict mode, `<LinkTo>` only refers to Ember's router link when explicitly imported from `@ember/routing` (this also covers renamed imports such as `import { LinkTo as Link } from '@ember/routing'`). Without that import, `<LinkTo>` is treated as a user-authored component and the rule does not fire. The curly `{{link-to ...}}` form is unreachable in strict mode (`link-to` cannot be a JS identifier) and the autofix is skipped there.
+
 ## References
 
 - [eslint-plugin-ember template-no-inline-link-to](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/template-no-inline-link-to.md)

--- a/lib/rules/template-no-inline-linkto.js
+++ b/lib/rules/template-no-inline-linkto.js
@@ -23,10 +23,42 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.sourceCode;
+    const filename = context.filename;
+    const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
+
+    // In HBS, `<LinkTo>` always refers to Ember's router link component.
+    // In GJS/GTS, `<LinkTo>` must be explicitly imported from '@ember/routing'
+    // (and may be renamed, e.g. `import { LinkTo as Link } from '@ember/routing'`).
+    // local alias → true
+    const importedLinkComponents = new Map();
+
+    function isLinkToComponent(node) {
+      if (isStrictMode) {
+        return importedLinkComponents.has(node.tag);
+      }
+      return node.tag === 'LinkTo';
+    }
 
     return {
+      ImportDeclaration(node) {
+        if (!isStrictMode) {
+          return;
+        }
+        if (node.source.value !== '@ember/routing') {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'LinkTo') {
+            importedLinkComponents.set(specifier.local.name, true);
+          }
+        }
+      },
+
       GlimmerElementNode(node) {
-        if (node.tag === 'LinkTo' && node.children && node.children.length === 0) {
+        if (!isLinkToComponent(node)) {
+          return;
+        }
+        if (node.children && node.children.length === 0) {
           context.report({
             node,
             messageId: 'noInlineLinkTo',
@@ -34,8 +66,15 @@ module.exports = {
         }
       },
 
-      // {{link-to 'text' 'route'}} inline curly form
+      // {{link-to 'text' 'route'}} inline curly form — HBS-only.
+      // The `link-to` kebab path is not a valid JS identifier, so it cannot
+      // be a user binding in strict mode; the strict-mode compiler would
+      // already reject the source. Skip the curly handler in strict mode to
+      // avoid emitting a fix that produces also-broken `{{#link-to ...}}`.
       GlimmerMustacheStatement(node) {
+        if (isStrictMode) {
+          return;
+        }
         if (node.path?.type === 'GlimmerPathExpression' && node.path.original === 'link-to') {
           const titleNode = node.params[0];
           const isFixable =

--- a/lib/rules/template-no-inline-linkto.js
+++ b/lib/rules/template-no-inline-linkto.js
@@ -22,15 +22,16 @@ module.exports = {
   },
 
   create(context) {
-    const sourceCode = context.sourceCode;
     const filename = context.filename;
     const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
 
     // In HBS, `<LinkTo>` always refers to Ember's router link component.
     // In GJS/GTS, `<LinkTo>` must be explicitly imported from '@ember/routing'
     // (and may be renamed, e.g. `import { LinkTo as Link } from '@ember/routing'`).
-    // local alias → true
-    const importedLinkComponents = new Map();
+    // Limitation: namespace imports (`import * as routing from '@ember/routing'`
+    // → `<routing.LinkTo />`) are not tracked — dotted tag paths would need a
+    // separate match and are not a realistic usage pattern for this component.
+    const importedLinkComponents = new Set();
 
     function isLinkToComponent(node) {
       if (isStrictMode) {
@@ -49,7 +50,7 @@ module.exports = {
         }
         for (const specifier of node.specifiers) {
           if (specifier.type === 'ImportSpecifier' && specifier.imported.name === 'LinkTo') {
-            importedLinkComponents.set(specifier.local.name, true);
+            importedLinkComponents.add(specifier.local.name);
           }
         }
       },
@@ -76,6 +77,7 @@ module.exports = {
           return;
         }
         if (node.path?.type === 'GlimmerPathExpression' && node.path.original === 'link-to') {
+          const sourceCode = context.sourceCode;
           const titleNode = node.params[0];
           const isFixable =
             titleNode &&

--- a/tests/lib/rules/template-no-inline-linkto.js
+++ b/tests/lib/rules/template-no-inline-linkto.js
@@ -27,6 +27,30 @@ ruleTester.run('template-no-inline-linkto', rule, {
     `<template>
       <div></div>
     </template>`,
+
+    // GJS/GTS: without an `@ember/routing` import, `<LinkTo>` is a
+    // user-authored component — flagging it would corrupt the user's intent.
+    {
+      filename: 'test.gjs',
+      code: '<template><LinkTo @route="index" /></template>',
+    },
+    {
+      filename: 'test.gts',
+      code: '<template><LinkTo /></template>',
+    },
+
+    // GJS/GTS with the canonical `@ember/routing` import: still allow when
+    // the LinkTo has children (block form).
+    {
+      filename: 'test.gjs',
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="index">Home</LinkTo></template>',
+    },
+
+    // Renamed import: also allowed when the renamed LinkTo has children.
+    {
+      filename: 'test.gjs',
+      code: 'import { LinkTo as Link } from \'@ember/routing\';\n<template><Link @route="index">Home</Link></template>',
+    },
   ],
 
   invalid: [
@@ -65,6 +89,29 @@ ruleTester.run('template-no-inline-linkto', rule, {
           type: 'GlimmerElementNode',
         },
       ],
+    },
+
+    // GJS/GTS with `@ember/routing` import: childless LinkTo is flagged.
+    {
+      filename: 'test.gjs',
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="index" /></template>',
+      output: null,
+      errors: [{ messageId: 'noInlineLinkTo', type: 'GlimmerElementNode' }],
+    },
+    {
+      filename: 'test.gts',
+      code: 'import { LinkTo } from \'@ember/routing\';\n<template><LinkTo @route="contact"></LinkTo></template>',
+      output: null,
+      errors: [{ messageId: 'noInlineLinkTo', type: 'GlimmerElementNode' }],
+    },
+
+    // Renamed import: childless `<Link>` is flagged because it resolves to
+    // the framework `LinkTo`.
+    {
+      filename: 'test.gjs',
+      code: 'import { LinkTo as Link } from \'@ember/routing\';\n<template><Link @route="index" /></template>',
+      output: null,
+      errors: [{ messageId: 'noInlineLinkTo', type: 'GlimmerElementNode' }],
     },
   ],
 });


### PR DESCRIPTION
### What's broken on `master`

The angle-bracket visitor checks `node.tag === 'LinkTo'` by bare name. In GJS/GTS this produces two false signals:

- A user-authored `<LinkTo>` from any non-`@ember/routing` source is falsely flagged when childless:

  ```gjs
  import LinkTo from './my-link-to-component';
  <template><LinkTo /></template>   // false-positive on master
  ```

- A renamed framework import is missed entirely:

  ```gjs
  import { LinkTo as Link } from '@ember/routing';
  <template><Link /></template>   // false-negative on master — should flag
  ```

### Fix

Track `ImportDeclaration` from `@ember/routing` for `LinkTo` (including renamed imports) in `.gjs`/`.gts`. Only flag elements whose tag is in the tracked set. The curly `{{link-to ...}}` handler is now gated to HBS only — `link-to` is not a valid JS identifier, so it cannot be a user binding in strict mode, and the strict-mode compiler would already reject the source. Skipping the autofix in strict mode avoids producing also-broken `{{#link-to ...}}`.

### Note on related rules

The same bug class (bare-name `LinkTo`/`link-to` match with no awareness of `@ember/routing` imports) also exists in `template-no-link-to-tagname`, `template-no-invalid-link-text`, and `template-no-invalid-link-title` on `master`. Those should be fixed in follow-up PRs using the same pattern.

### Limitations

Namespace imports (`import * as routing from '@ember/routing'; <routing.LinkTo />`) are not tracked — dotted tag paths would need a separate match and are not a realistic usage pattern for this component. Documented in a code comment.

### Test plan

21 tests pass on the branch (was 14). New cases:

- 2 valid GJS/GTS without import (`.gjs` and `.gts`) — user component, not flagged
- 2 valid GJS with `@ember/routing` import — block-form `<LinkTo>...</LinkTo>` and renamed `<Link>...</Link>` not flagged (have children)
- 2 invalid GJS/GTS with import — childless `<LinkTo />` flagged
- 1 invalid GJS with renamed import — childless `<Link />` flagged

HBS path is unchanged. Lint and prettier pass.