### PR TITLE
Post-merge-review: Fix template-no-invalid-link-text: skip when link contains non-text children

### DIFF
--- a/lib/rules/template-no-invalid-link-text.js
+++ b/lib/rules/template-no-invalid-link-text.js
@@ -145,19 +145,19 @@ module.exports = {
         return;
       }
 
-      // Check text content
-      let fullText = '';
-      let hasDynamic = false;
-      for (const child of children || []) {
-        const result = getTextContentResult(child);
-        fullText += result.text;
-        if (result.hasDynamic) {
-          hasDynamic = true;
-        }
+      // Match upstream: if the link contains any non-TextNode child (component,
+      // mustache, sub/block expression), the content is dynamic/opaque — don't flag.
+      // See upstream no-invalid-link-text.js L53-56.
+      const childList = children || [];
+      const allTextNodes = childList.every((child) => child.type === 'GlimmerTextNode');
+      if (!allTextNodes) {
+        return;
       }
 
-      if (hasDynamic) {
-        return; // can't validate dynamic content
+      // Concatenate text content (only TextNode children at this point).
+      let fullText = '';
+      for (const child of childList) {
+        fullText += child.chars.replaceAll('&nbsp;', ' ');
       }
 
       const normalized = fullText.trim().toLowerCase().replaceAll(/\s+/g, ' ');

--- a/lib/rules/template-no-invalid-link-text.js
+++ b/lib/rules/template-no-invalid-link-text.js
@@ -145,9 +145,7 @@ module.exports = {
         return;
       }
 
-      // Match upstream: if the link contains any non-TextNode child (component,
-      // mustache, sub/block expression), the content is dynamic/opaque — don't flag.
-      // See upstream no-invalid-link-text.js L53-56.
+      // If the link contains any non-TextNode child, content is dynamic/opaque — don't flag.
       const childList = children || [];
       const allTextNodes = childList.every((child) => child.type === 'GlimmerTextNode');
       if (!allTextNodes) {

--- a/tests/lib/rules/template-no-invalid-link-text.js
+++ b/tests/lib/rules/template-no-invalid-link-text.js
@@ -8,6 +8,11 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('template-no-invalid-link-text', rule, {
   valid: [
+    // Link with component child — content is opaque, can't validate.
+    // Mirrors upstream no-invalid-link-text.js L53-56 ("do not flag when link contains additional dynamic (non-text) children").
+    { filename: 'test.gjs', code: '<template><a href="/x"><MyComponent /></a></template>' },
+    { filename: 'test.gjs', code: '<template><a href="/x">prefix <MyComponent /></a></template>' },
+
     { filename: 'test.gjs', code: '<template><a href="/about">About Us</a></template>' },
     {
       filename: 'test.gjs',
@@ -150,13 +155,6 @@ ruleTester.run('template-no-invalid-link-text', rule, {
       errors: [{ messageId: 'invalidText' }],
     },
     {
-      // Nested element content
-      filename: 'test.gjs',
-      code: '<template><a href="/page"><span>click here</span></a></template>',
-      output: null,
-      errors: [{ messageId: 'invalidText' }],
-    },
-    {
       // aria-label with disallowed text overrides content check
       filename: 'test.gjs',
       code: 'import { LinkTo } from \'@ember/routing\'; <template><LinkTo aria-label="click here">About Us</LinkTo></template>',
@@ -274,12 +272,6 @@ hbsRuleTester.run('template-no-invalid-link-text (hbs)', rule, {
     {
       code: `{{#link-to}} &nbsp;
 {{/link-to}}`,
-      output: null,
-      errors: [{ messageId: 'invalidText' }],
-    },
-    {
-      // nested element content — text is in a child element
-      code: '<a href="/page"><span>click here</span></a>',
       output: null,
       errors: [{ messageId: 'invalidText' }],
     },


### PR DESCRIPTION
Match upstream ember-template-lint's no-invalid-link-text behavior (lib/rules/no-invalid-link-text.js L53-56): if any child of the link is not a TextNode, the link content is opaque and should not be flagged. Handles real-world patterns like <a><MyComponent /> </a> where the link text comes from a component's template, which the linter cannot analyze.

Removes two tests that asserted stricter-than-upstream behavior on <a><span>click here</span></a>. Per upstream, this case can't be reliably analyzed and should not be flagged.