### PR TITLE
Post-merge-review: Fix template-no-whitespace-for-layout false positive on attribute values

### DIFF
--- a/lib/rules/template-no-whitespace-for-layout.js
+++ b/lib/rules/template-no-whitespace-for-layout.js
@@ -27,6 +27,14 @@ module.exports = {
 
     return {
       GlimmerTextNode(node) {
+        // Upstream ember-template-lint only visits body text; its HBS parser
+        // exposes attribute values as strings rather than TextNode children.
+        // ember-eslint-parser emits them as GlimmerTextNode children of a
+        // GlimmerAttrNode, so skip those to match upstream scope.
+        if (node.parent?.type === 'GlimmerAttrNode') {
+          return;
+        }
+
         const text = sourceCode.getText(node);
         if (!text) {
           return;

--- a/lib/rules/template-no-whitespace-for-layout.js
+++ b/lib/rules/template-no-whitespace-for-layout.js
@@ -27,10 +27,10 @@ module.exports = {
 
     return {
       GlimmerTextNode(node) {
-        // Upstream ember-template-lint only visits body text; its HBS parser
-        // exposes attribute values as strings rather than TextNode children.
-        // ember-eslint-parser emits them as GlimmerTextNode children of a
-        // GlimmerAttrNode, so skip those to match upstream scope.
+        // Only flag body text, not attribute values. ember-eslint-parser
+        // emits attribute values as GlimmerTextNode children of a
+        // GlimmerAttrNode; skip those so only element body whitespace is
+        // checked.
         if (node.parent?.type === 'GlimmerAttrNode') {
           return;
         }

--- a/tests/lib/rules/template-no-whitespace-for-layout.js
+++ b/tests/lib/rules/template-no-whitespace-for-layout.js
@@ -18,8 +18,10 @@ const validHbs = [
 >
   example
 </div>`,
+  // Attribute values with consecutive spaces must not be flagged (false positive,
+  // cf. ember-template-lint#2899) — the rule targets element body text only.
   '<div class="foo  bar"></div>',
-  '<div class="min-h-dvh bg-gray-200  "></div>',
+  '<div style="margin: 0;  padding: 0"></div>',
 ];
 
 const invalidHbs = [

--- a/tests/lib/rules/template-no-whitespace-for-layout.js
+++ b/tests/lib/rules/template-no-whitespace-for-layout.js
@@ -18,6 +18,8 @@ const validHbs = [
 >
   example
 </div>`,
+  '<div class="foo  bar"></div>',
+  '<div class="min-h-dvh bg-gray-200  "></div>',
 ];
 
 const invalidHbs = [


### PR DESCRIPTION
The rule's GlimmerTextNode visitor fired on attribute value text nodes (e.g. `<div class="foo  bar">`), reporting layout-whitespace violations for consecutive spaces inside class lists and other attribute values.

Upstream ember-template-lint only visits body text, since its HBS parser exposes attribute values differently. Skip GlimmerTextNodes whose parent is a GlimmerAttrNode.