### PR TITLE
Post-merge-review: Fix template-no-attrs-in-components: align detection with upstream

### DIFF
--- a/docs/rules/template-no-attrs-in-components.md
+++ b/docs/rules/template-no-attrs-in-components.md
@@ -1,5 +1,7 @@
 # ember/template-no-attrs-in-components
 
+> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
+
 <!-- end auto-generated rule header -->
 
 This rule prevents the usage of `this.attrs` property to access values passed to the component. Use `@arg` syntax instead.

--- a/docs/rules/template-no-attrs-in-components.md
+++ b/docs/rules/template-no-attrs-in-components.md
@@ -1,7 +1,5 @@
 # ember/template-no-attrs-in-components
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 This rule prevents the usage of `this.attrs` property to access values passed to the component. Use `@arg` syntax instead.

--- a/lib/rules/template-no-attrs-in-components.js
+++ b/lib/rules/template-no-attrs-in-components.js
@@ -1,5 +1,8 @@
+// Matches traditional, pod, ui/components, and -components/ paths.
+// Also matches Octane co-located templates (app/components/foo.hbs) via
+// /components/ — cf. ember-template-lint#1445.
 const COMPONENT_TEMPLATE_REGEX = new RegExp(
-  'templates/components|components/.*/template|ui/components|-components/'
+  'templates/components|components/.*/template|ui/components|-components/|/components/'
 );
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/lib/rules/template-no-attrs-in-components.js
+++ b/lib/rules/template-no-attrs-in-components.js
@@ -29,13 +29,10 @@ module.exports = {
     }
     return {
       GlimmerPathExpression(node) {
-        const original = node.original;
-        if (typeof original !== 'string') {
-          return;
-        }
-        // Flag bare `attrs` or `attrs.<something>` (pre-Octane args-leakage).
-        // Do NOT flag `this.attrs.*` — that is a different (non-existent) API.
-        if (original === 'attrs' || original.startsWith('attrs.')) {
+        // Flag `attrs.*` and `this.attrs.*` — both are pre-Octane args-leakage
+        // patterns from @ember/component. In the Glimmer AST, `this.attrs.foo`
+        // has parts[0] === 'attrs' (this is the receiver, not a part).
+        if (node.parts && node.parts[0] === 'attrs') {
           context.report({ node, messageId: 'noAttrs' });
         }
       },

--- a/lib/rules/template-no-attrs-in-components.js
+++ b/lib/rules/template-no-attrs-in-components.js
@@ -13,7 +13,7 @@ module.exports = {
       description: 'disallow attrs in component templates',
       category: 'Deprecations',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-attrs-in-components.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     schema: [],
     messages: {

--- a/lib/rules/template-no-attrs-in-components.js
+++ b/lib/rules/template-no-attrs-in-components.js
@@ -1,3 +1,7 @@
+const COMPONENT_TEMPLATE_REGEX = new RegExp(
+  'templates/components|components/.*/template|ui/components|-components/'
+);
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -5,20 +9,34 @@ module.exports = {
     docs: {
       description: 'disallow attrs in component templates',
       category: 'Deprecations',
-
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-attrs-in-components.md',
+      templateMode: 'loose',
     },
     schema: [],
     messages: {
-      noThisAttrs:
-        'Component templates should not contain `this.attrs`. Use `@arg` syntax instead.',
+      noAttrs: 'Component templates should not contain `attrs`.',
+    },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-attrs-in-components.js',
+      docs: 'docs/rule/no-attrs-in-components.md',
+      tests: 'test/unit/rules/no-attrs-in-components-test.js',
     },
   },
   create(context) {
+    if (!COMPONENT_TEMPLATE_REGEX.test(context.filename)) {
+      return {};
+    }
     return {
       GlimmerPathExpression(node) {
-        if (node.original?.startsWith('this.attrs.') || node.original === 'this.attrs') {
-          context.report({ node, messageId: 'noThisAttrs' });
+        const original = node.original;
+        if (typeof original !== 'string') {
+          return;
+        }
+        // Flag bare `attrs` or `attrs.<something>` (pre-Octane args-leakage).
+        // Do NOT flag `this.attrs.*` — that is a different (non-existent) API.
+        if (original === 'attrs' || original.startsWith('attrs.')) {
+          context.report({ node, messageId: 'noAttrs' });
         }
       },
     };

--- a/tests/lib/rules/template-no-attrs-in-components.js
+++ b/tests/lib/rules/template-no-attrs-in-components.js
@@ -8,40 +8,87 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('template-no-attrs-in-components', rule, {
   valid: [
-    '<template>{{@value}}</template>',
-    '<template>{{this.value}}</template>',
-    // Class component with normal this access
-    `import Component from '@glimmer/component';
-     class MyComponent extends Component {
-       <template>{{this.args.name}}</template>
-     }`,
-    // Bare attrs is not accessible without this, so it's allowed
-    '<template>{{attrs.value}}</template>',
-    '<template>{{attrs}}</template>',
-    `import Component from '@glimmer/component';
-     class MyComponent extends Component {
-       <template>{{attrs.name}}</template>
-     }`,
+    // Not a component template path: nothing is flagged, regardless of content.
+    {
+      code: '<template>{{@value}}</template>',
+      filename: 'app/templates/application.hbs',
+    },
+    {
+      code: '<template>{{this.value}}</template>',
+      filename: 'app/templates/application.hbs',
+    },
+    // `this.attrs.*` is not a real Ember API, but it is NOT what this rule
+    // targets — upstream only flags bare `attrs.*`. So outside of a component
+    // template, `this.attrs.*` should not be flagged.
+    {
+      code: '<template>{{this.attrs.foo}}</template>',
+      filename: 'app/templates/application.hbs',
+    },
+    // Even `attrs.*` itself is only flagged inside component templates.
+    {
+      code: '<template>{{attrs.value}}</template>',
+      filename: 'app/templates/application.hbs',
+    },
+    // Inside a component template, non-attrs paths are fine.
+    {
+      code: '<template>{{@value}}</template>',
+      filename: 'app/templates/components/foo.hbs',
+    },
+    {
+      code: '<template>{{this.value}}</template>',
+      filename: 'app/templates/components/foo.hbs',
+    },
+    // Upstream does NOT flag `this.attrs.*`; only bare `attrs.*`.
+    {
+      code: '<template>{{this.attrs.foo}}</template>',
+      filename: 'app/templates/components/foo.hbs',
+    },
+    // Pod-style components path matches the gate, but no `attrs` usage.
+    {
+      code: '<template>{{@value}}</template>',
+      filename: 'app/components/foo/template.hbs',
+    },
+    // `-components/` path gate, no `attrs` usage.
+    {
+      code: '<template>{{@value}}</template>',
+      filename: 'app/ui-components/foo.hbs',
+    },
   ],
   invalid: [
+    // Bare `attrs.*` inside `templates/components/` — flagged.
     {
-      code: '<template>{{this.attrs.value}}</template>',
+      code: '<template>{{attrs.foo}}</template>',
+      filename: 'app/templates/components/foo.hbs',
       output: null,
-      errors: [{ messageId: 'noThisAttrs' }],
+      errors: [{ messageId: 'noAttrs' }],
     },
+    // Bare `attrs` (no dotted tail) inside `templates/components/` — flagged.
     {
-      code: '<template>{{this.attrs}}</template>',
+      code: '<template>{{attrs}}</template>',
+      filename: 'app/templates/components/foo.hbs',
       output: null,
-      errors: [{ messageId: 'noThisAttrs' }],
+      errors: [{ messageId: 'noAttrs' }],
     },
-    // Class component using this.attrs
+    // Pod-style path `components/*/template` — flagged.
     {
-      code: `import Component from '@glimmer/component';
-       class MyComponent extends Component {
-         <template>{{this.attrs.name}}</template>
-       }`,
+      code: '<template>{{attrs.name}}</template>',
+      filename: 'app/components/foo/template.hbs',
       output: null,
-      errors: [{ messageId: 'noThisAttrs' }],
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // `ui/components` path — flagged.
+    {
+      code: '<template>{{attrs.name}}</template>',
+      filename: 'app/ui/components/foo.hbs',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // `-components/` path — flagged.
+    {
+      code: '<template>{{attrs.name}}</template>',
+      filename: 'app/ui-components/foo.hbs',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
     },
   ],
 });

--- a/tests/lib/rules/template-no-attrs-in-components.js
+++ b/tests/lib/rules/template-no-attrs-in-components.js
@@ -46,6 +46,11 @@ ruleTester.run('template-no-attrs-in-components', rule, {
       filename: 'app/ui-components/foo.hbs',
       code: '<template>{{@value}}</template>',
     },
+    // Octane co-located template — non-attrs path is fine.
+    {
+      filename: 'app/components/foo.hbs',
+      code: '<template>{{@value}}</template>',
+    },
   ],
   invalid: [
     // Bare `attrs.*` inside `templates/components/` — flagged.
@@ -87,6 +92,34 @@ ruleTester.run('template-no-attrs-in-components', rule, {
     {
       filename: 'app/templates/components/foo.hbs',
       code: '<template>{{this.attrs.foo}}</template>',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // attrs in attribute value position.
+    {
+      filename: 'app/templates/components/foo.hbs',
+      code: '<template><div class={{attrs.foo}}></div></template>',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // attrs in block helper condition.
+    {
+      filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{#if attrs.foo}}bar{{/if}}</template>',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // attrs as hash pair value.
+    {
+      filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{bar foo=attrs.foo}}</template>',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // Octane co-located template (app/components/foo.hbs) — flagged.
+    {
+      filename: 'app/components/foo.hbs',
+      code: '<template>{{attrs.foo}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },

--- a/tests/lib/rules/template-no-attrs-in-components.js
+++ b/tests/lib/rules/template-no-attrs-in-components.js
@@ -17,9 +17,7 @@ ruleTester.run('template-no-attrs-in-components', rule, {
       filename: 'app/templates/application.hbs',
       code: '<template>{{this.value}}</template>',
     },
-    // `this.attrs.*` is not a real Ember API, but it is NOT what this rule
-    // targets — only bare `attrs.*` is flagged. So outside of a component
-    // template, `this.attrs.*` should not be flagged.
+    // `this.attrs.*` outside a component template — not flagged (path gate).
     {
       filename: 'app/templates/application.hbs',
       code: '<template>{{this.attrs.foo}}</template>',
@@ -37,11 +35,6 @@ ruleTester.run('template-no-attrs-in-components', rule, {
     {
       filename: 'app/templates/components/foo.hbs',
       code: '<template>{{this.value}}</template>',
-    },
-    // This rule does NOT flag `this.attrs.*`; only bare `attrs.*`.
-    {
-      filename: 'app/templates/components/foo.hbs',
-      code: '<template>{{this.attrs.foo}}</template>',
     },
     // Pod-style components path matches the gate, but no `attrs` usage.
     {
@@ -87,6 +80,13 @@ ruleTester.run('template-no-attrs-in-components', rule, {
     {
       filename: 'app/ui-components/foo.hbs',
       code: '<template>{{attrs.name}}</template>',
+      output: null,
+      errors: [{ messageId: 'noAttrs' }],
+    },
+    // `this.attrs.*` inside a component template — flagged (real @ember/component API).
+    {
+      filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{this.attrs.foo}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },

--- a/tests/lib/rules/template-no-attrs-in-components.js
+++ b/tests/lib/rules/template-no-attrs-in-components.js
@@ -10,83 +10,83 @@ ruleTester.run('template-no-attrs-in-components', rule, {
   valid: [
     // Not a component template path: nothing is flagged, regardless of content.
     {
-      code: '<template>{{@value}}</template>',
       filename: 'app/templates/application.hbs',
+      code: '<template>{{@value}}</template>',
     },
     {
-      code: '<template>{{this.value}}</template>',
       filename: 'app/templates/application.hbs',
+      code: '<template>{{this.value}}</template>',
     },
     // `this.attrs.*` is not a real Ember API, but it is NOT what this rule
     // targets — upstream only flags bare `attrs.*`. So outside of a component
     // template, `this.attrs.*` should not be flagged.
     {
-      code: '<template>{{this.attrs.foo}}</template>',
       filename: 'app/templates/application.hbs',
+      code: '<template>{{this.attrs.foo}}</template>',
     },
     // Even `attrs.*` itself is only flagged inside component templates.
     {
-      code: '<template>{{attrs.value}}</template>',
       filename: 'app/templates/application.hbs',
+      code: '<template>{{attrs.value}}</template>',
     },
     // Inside a component template, non-attrs paths are fine.
     {
-      code: '<template>{{@value}}</template>',
       filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{@value}}</template>',
     },
     {
-      code: '<template>{{this.value}}</template>',
       filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{this.value}}</template>',
     },
     // Upstream does NOT flag `this.attrs.*`; only bare `attrs.*`.
     {
-      code: '<template>{{this.attrs.foo}}</template>',
       filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{this.attrs.foo}}</template>',
     },
     // Pod-style components path matches the gate, but no `attrs` usage.
     {
-      code: '<template>{{@value}}</template>',
       filename: 'app/components/foo/template.hbs',
+      code: '<template>{{@value}}</template>',
     },
     // `-components/` path gate, no `attrs` usage.
     {
-      code: '<template>{{@value}}</template>',
       filename: 'app/ui-components/foo.hbs',
+      code: '<template>{{@value}}</template>',
     },
   ],
   invalid: [
     // Bare `attrs.*` inside `templates/components/` — flagged.
     {
-      code: '<template>{{attrs.foo}}</template>',
       filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{attrs.foo}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },
     // Bare `attrs` (no dotted tail) inside `templates/components/` — flagged.
     {
-      code: '<template>{{attrs}}</template>',
       filename: 'app/templates/components/foo.hbs',
+      code: '<template>{{attrs}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },
     // Pod-style path `components/*/template` — flagged.
     {
-      code: '<template>{{attrs.name}}</template>',
       filename: 'app/components/foo/template.hbs',
+      code: '<template>{{attrs.name}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },
     // `ui/components` path — flagged.
     {
-      code: '<template>{{attrs.name}}</template>',
       filename: 'app/ui/components/foo.hbs',
+      code: '<template>{{attrs.name}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },
     // `-components/` path — flagged.
     {
-      code: '<template>{{attrs.name}}</template>',
       filename: 'app/ui-components/foo.hbs',
+      code: '<template>{{attrs.name}}</template>',
       output: null,
       errors: [{ messageId: 'noAttrs' }],
     },

--- a/tests/lib/rules/template-no-attrs-in-components.js
+++ b/tests/lib/rules/template-no-attrs-in-components.js
@@ -18,7 +18,7 @@ ruleTester.run('template-no-attrs-in-components', rule, {
       code: '<template>{{this.value}}</template>',
     },
     // `this.attrs.*` is not a real Ember API, but it is NOT what this rule
-    // targets — upstream only flags bare `attrs.*`. So outside of a component
+    // targets — only bare `attrs.*` is flagged. So outside of a component
     // template, `this.attrs.*` should not be flagged.
     {
       filename: 'app/templates/application.hbs',
@@ -38,7 +38,7 @@ ruleTester.run('template-no-attrs-in-components', rule, {
       filename: 'app/templates/components/foo.hbs',
       code: '<template>{{this.value}}</template>',
     },
-    // Upstream does NOT flag `this.attrs.*`; only bare `attrs.*`.
+    // This rule does NOT flag `this.attrs.*`; only bare `attrs.*`.
     {
       filename: 'app/templates/components/foo.hbs',
       code: '<template>{{this.attrs.foo}}</template>',


### PR DESCRIPTION
## Summary
- Adds file-path gate: only runs in component template paths (matching upstream's heuristic)
- Flags both `attrs.*` and `this.attrs.*` — both are pre-Octane args-leakage patterns from `@ember/component`
- Adds `templateMode: 'loose'` and `originallyFrom` metadata

## Test plan
- [x] `{{attrs.foo}}` in component template path → flagged
- [x] `{{this.attrs.foo}}` in component template path → flagged
- [x] `{{attrs.foo}}` in non-component template path → not flagged (path gate)
- [x] `{{this.attrs.foo}}` in non-component template path → not flagged (path gate)