### PR TITLE
Post-merge-review: Set templateMode: 'both' on template-no-invalid-interactive

### DIFF
--- a/lib/rules/template-no-invalid-interactive.js
+++ b/lib/rules/template-no-invalid-interactive.js
@@ -37,7 +37,7 @@ module.exports = {
     docs: {
       description: 'disallow non-interactive elements with interactive handlers',
       category: 'Accessibility',
-
+      templateMode: 'both',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-invalid-interactive.md',
     },
     schema: [


### PR DESCRIPTION
## Summary
- Adds missing `templateMode: 'both'` to rule metadata
- Rule already ran in both `.hbs` and `.gjs`/`.gts` at runtime; this fixes the eslint-doc-generator output

## Test plan
- [ ] Rule metadata reflects correct template mode