### PR TITLE
Post-merge-review: Fix template-no-mut-helper: templateMode 'both' and unwrap setterAlternative

### DIFF
--- a/docs/rules/template-no-mut-helper.md
+++ b/docs/rules/template-no-mut-helper.md
@@ -1,7 +1,5 @@
 # ember/template-no-mut-helper
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 Disallow usage of the `(mut)` helper.

--- a/lib/rules/template-no-mut-helper.js
+++ b/lib/rules/template-no-mut-helper.js
@@ -36,7 +36,7 @@ module.exports = {
     // don't end up with `{{{{...}}}}` in the error message.
     const setterAlternative =
       typeof rawSetterAlternative === 'string'
-        ? rawSetterAlternative.replace(/^\{\{([\S\s]*)\}\}$/, '$1').trim()
+        ? rawSetterAlternative.replace(/^{{([\S\s]*)}}$/, '$1').trim()
         : rawSetterAlternative;
     const message = setterAlternative
       ? `Do not use the (mut) helper. Consider using a JS action or {{${setterAlternative}}} instead.`

--- a/lib/rules/template-no-mut-helper.js
+++ b/lib/rules/template-no-mut-helper.js
@@ -6,7 +6,7 @@ module.exports = {
       description: 'disallow usage of (mut) helper',
       category: 'Best Practices',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-mut-helper.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     fixable: null,
     schema: [
@@ -31,7 +31,13 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {};
-    const setterAlternative = options.setterAlternative;
+    const rawSetterAlternative = options.setterAlternative;
+    // If the user already wrapped their expression in `{{...}}`, strip it so we
+    // don't end up with `{{{{...}}}}` in the error message.
+    const setterAlternative =
+      typeof rawSetterAlternative === 'string'
+        ? rawSetterAlternative.replace(/^\{\{([\S\s]*)\}\}$/, '$1').trim()
+        : rawSetterAlternative;
     const message = setterAlternative
       ? `Do not use the (mut) helper. Consider using a JS action or {{${setterAlternative}}} instead.`
       : 'Do not use the (mut) helper. Use regular setters or actions instead.';

--- a/tests/lib/rules/template-no-mut-helper.js
+++ b/tests/lib/rules/template-no-mut-helper.js
@@ -144,6 +144,43 @@ ruleTester.run('template-no-mut-helper', rule, {
       output: null,
       errors: [{ message: 'Do not use the (mut) helper. Use regular setters or actions instead.' }],
     },
+    // `mut` is a strict-mode ambient keyword — no import needed in .gjs strict
+    // mode templates.
+    {
+      code: '<template>{{mut foo bar}}</template>',
+      output: null,
+      errors: [
+        {
+          message: 'Do not use the (mut) helper. Use regular setters or actions instead.',
+          type: 'GlimmerMustacheStatement',
+        },
+      ],
+    },
+    // Config: setterAlternative should produce exactly one `{{...}}` wrapping
+    // around the user-supplied expression — even when the user accidentally
+    // included the braces themselves.
+    {
+      code: '<template><MyComponent onchange={{action (mut this.val) value="target.value"}}/></template>',
+      output: null,
+      options: [{ setterAlternative: '(set this.foo)' }],
+      errors: [
+        {
+          message:
+            'Do not use the (mut) helper. Consider using a JS action or {{(set this.foo)}} instead.',
+        },
+      ],
+    },
+    {
+      code: '<template><MyComponent onchange={{action (mut this.val) value="target.value"}}/></template>',
+      output: null,
+      options: [{ setterAlternative: '{{(set this.foo)}}' }],
+      errors: [
+        {
+          message:
+            'Do not use the (mut) helper. Consider using a JS action or {{(set this.foo)}} instead.',
+        },
+      ],
+    },
   ],
 });
 


### PR DESCRIPTION
## Summary
- Changes `templateMode` from `'loose'` to `'both'` — `mut` is a strict-mode ambient keyword so the rule must run in `.gjs`/`.gts`
- Strips accidental `{{...}}` wrapping from `setterAlternative` option so the message shows exactly one level of braces

## Test plan
- [ ] `<template>{{mut foo bar}}</template>` → flagged in GJS context
- [ ] `setterAlternative: '{{(set this.foo)}}'` → message shows `{{(set this.foo)}}` not `{{{{(set this.foo)}}}}`