### PR TITLE
Post-merge-review: template-no-negated-comparison: document name-clash; drop non-standard 'ne'

### DIFF
--- a/docs/rules/template-no-negated-comparison.md
+++ b/docs/rules/template-no-negated-comparison.md
@@ -2,11 +2,15 @@
 
 <!-- end auto-generated rule header -->
 
+> **Note**: This rule is NOT a port of upstream `ember-template-lint`'s `no-negated-condition`.
+> Upstream's rule prefers `not-eq` over `if/else`; this rule bans `not-eq` (and similar) entirely.
+> These are opposite goals.
+
 Disallows negated comparison operators in templates.
 
 ## Rule Details
 
-Use positive comparison operators with `{{unless}}` instead of negated comparison operators like `not-eq` or `ne`.
+Use positive comparison operators with `{{unless}}` instead of negated comparison operators like `not-eq`.
 
 ## Examples
 
@@ -15,14 +19,6 @@ Examples of **incorrect** code for this rule:
 ```gjs
 <template>
   {{#if (not-eq this.value 5)}}
-    Not equal
-  {{/if}}
-</template>
-```
-
-```gjs
-<template>
-  {{#if (ne this.a this.b)}}
     Not equal
   {{/if}}
 </template>

--- a/docs/rules/template-no-negated-comparison.md
+++ b/docs/rules/template-no-negated-comparison.md
@@ -2,10 +2,6 @@
 
 <!-- end auto-generated rule header -->
 
-> **Note**: This rule is NOT a port of `ember-template-lint`'s `no-negated-condition`.
-> That rule prefers `not-eq` over `if/else`; this rule bans `not-eq` (and similar) entirely.
-> These are opposite goals.
-
 Disallows negated comparison operators in templates.
 
 ## Rule Details

--- a/docs/rules/template-no-negated-comparison.md
+++ b/docs/rules/template-no-negated-comparison.md
@@ -37,4 +37,3 @@ Examples of **correct** code for this rule:
   {{/if}}
 </template>
 ```
-

--- a/docs/rules/template-no-negated-comparison.md
+++ b/docs/rules/template-no-negated-comparison.md
@@ -38,6 +38,3 @@ Examples of **correct** code for this rule:
 </template>
 ```
 
-## References
-
-- [eslint-plugin-ember template-no-negated-condition](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/template-no-negated-condition.md)

--- a/docs/rules/template-no-negated-comparison.md
+++ b/docs/rules/template-no-negated-comparison.md
@@ -2,8 +2,8 @@
 
 <!-- end auto-generated rule header -->
 
-> **Note**: This rule is NOT a port of upstream `ember-template-lint`'s `no-negated-condition`.
-> Upstream's rule prefers `not-eq` over `if/else`; this rule bans `not-eq` (and similar) entirely.
+> **Note**: This rule is NOT a port of `ember-template-lint`'s `no-negated-condition`.
+> That rule prefers `not-eq` over `if/else`; this rule bans `not-eq` (and similar) entirely.
 > These are opposite goals.
 
 Disallows negated comparison operators in templates.

--- a/lib/rules/template-no-negated-comparison.js
+++ b/lib/rules/template-no-negated-comparison.js
@@ -21,7 +21,7 @@ module.exports = {
         if (
           node.path &&
           node.path.type === 'GlimmerPathExpression' &&
-          (node.path.original === 'not-eq' || node.path.original === 'ne')
+          node.path.original === 'not-eq'
         ) {
           context.report({
             node,

--- a/tests/lib/rules/template-no-negated-comparison.js
+++ b/tests/lib/rules/template-no-negated-comparison.js
@@ -29,26 +29,18 @@ ruleTester.run('template-no-negated-comparison', rule, {
     `<template>
       <div></div>
     </template>`,
+    // `ne` is not a standard Ember/ember-truth-helpers helper; the rule must not flag it.
+    `<template>
+      {{#if (ne this.a this.b)}}
+        Not equal
+      {{/if}}
+    </template>`,
   ],
 
   invalid: [
     {
       code: `<template>
         {{#if (not-eq this.value 5)}}
-          Not equal
-        {{/if}}
-      </template>`,
-      output: null,
-      errors: [
-        {
-          message: 'Use positive comparison operators instead of negated ones.',
-          type: 'GlimmerSubExpression',
-        },
-      ],
-    },
-    {
-      code: `<template>
-        {{#if (ne this.a this.b)}}
           Not equal
         {{/if}}
       </template>`,


### PR DESCRIPTION
## Summary
- Adds doc note: this rule is NOT a port of upstream's `no-negated-condition` — they have opposite goals
- Removes the `ne` alias: `ne` is not a real Ember/ember-truth-helpers helper (`not-eq` is standard)

## Test plan
- [ ] `{{#if (ne this.a this.b)}}` → valid (not flagged)
- [ ] `{{#if (not-eq this.a this.b)}}` → still flagged