### PR TITLE
Post-merge-review: Fix template-no-nested-landmark: drop port-only section/region

### DIFF
--- a/lib/rules/template-no-nested-landmark.js
+++ b/lib/rules/template-no-nested-landmark.js
@@ -5,11 +5,10 @@ const LANDMARK_ROLES = new Set([
   'form',
   'main',
   'navigation',
-  'region',
   'search',
 ]);
 
-const LANDMARK_ELEMENTS = new Set(['header', 'aside', 'footer', 'form', 'main', 'nav', 'section']);
+const LANDMARK_ELEMENTS = new Set(['header', 'aside', 'footer', 'form', 'main', 'nav']);
 
 const EQUIVALENT_ROLE = {
   aside: 'complementary',

--- a/tests/lib/rules/template-no-nested-landmark.js
+++ b/tests/lib/rules/template-no-nested-landmark.js
@@ -45,7 +45,7 @@ ruleTester.run('template-no-nested-landmark', rule, {
 
     // `<section>` only gets the `region` landmark role when it has an accessible name
     // (aria-label/aria-labelledby/title). Without one it has the generic role — see
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section.
+    // https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/HTML5.html.
     // This rule does not inspect accessible names, so unnamed sections are excluded.
     '<template><section><section>Content</section></section></template>',
     // `role="region"` is the landmark role a named `<section>` gets. Nesting it is

--- a/tests/lib/rules/template-no-nested-landmark.js
+++ b/tests/lib/rules/template-no-nested-landmark.js
@@ -45,7 +45,7 @@ ruleTester.run('template-no-nested-landmark', rule, {
 
     // `<section>` only gets the `region` landmark role when it has an accessible name
     // (aria-label/aria-labelledby/title). Without one it has the generic role — see
-    // https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/HTML5.html.
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role.
     // This rule does not inspect accessible names, so unnamed sections are excluded.
     '<template><section><section>Content</section></section></template>',
     // `role="region"` is the landmark role a named `<section>` gets. Nesting it is

--- a/tests/lib/rules/template-no-nested-landmark.js
+++ b/tests/lib/rules/template-no-nested-landmark.js
@@ -43,9 +43,13 @@ ruleTester.run('template-no-nested-landmark', rule, {
     '<template><header><div role="navigation"></div></header></template>',
     '<template><div role="banner"><div role="navigation"></div></div></template>',
 
-    // `<section>` is not a landmark element per upstream, so nested sections are allowed.
+    // `<section>` only gets the `region` landmark role when it has an accessible name
+    // (aria-label/aria-labelledby/title). Without one it has the generic role — see
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section.
+    // This rule does not inspect accessible names, so unnamed sections are excluded.
     '<template><section><section>Content</section></section></template>',
-    // `role="region"` is not a landmark role per upstream, so nested regions are allowed.
+    // `role="region"` is the landmark role a named `<section>` gets. Nesting it is
+    // excluded for the same reason: the rule cannot verify an accessible name is present.
     '<template><div role="region"><div role="region">Content</div></div></template>',
   ],
 

--- a/tests/lib/rules/template-no-nested-landmark.js
+++ b/tests/lib/rules/template-no-nested-landmark.js
@@ -42,6 +42,11 @@ ruleTester.run('template-no-nested-landmark', rule, {
     '<template><div role="banner"><nav></nav></div></template>',
     '<template><header><div role="navigation"></div></header></template>',
     '<template><div role="banner"><div role="navigation"></div></div></template>',
+
+    // `<section>` is not a landmark element per upstream, so nested sections are allowed.
+    '<template><section><section>Content</section></section></template>',
+    // `role="region"` is not a landmark role per upstream, so nested regions are allowed.
+    '<template><div role="region"><div role="region">Content</div></div></template>',
   ],
 
   invalid: [

--- a/tests/lib/rules/template-no-nested-landmark.js
+++ b/tests/lib/rules/template-no-nested-landmark.js
@@ -45,7 +45,7 @@ ruleTester.run('template-no-nested-landmark', rule, {
 
     // `<section>` only gets the `region` landmark role when it has an accessible name
     // (aria-label/aria-labelledby/title). Without one it has the generic role — see
-    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role.
+    // https://www.w3.org/TR/html-aam-1.0/#el-section
     // This rule does not inspect accessible names, so unnamed sections are excluded.
     '<template><section><section>Content</section></section></template>',
     // `role="region"` is the landmark role a named `<section>` gets. Nesting it is


### PR DESCRIPTION
## Summary
- Removes `<section>` from `LANDMARK_ELEMENTS` and `'region'` from `LANDMARK_ROLES` to match upstream
- Port was over-flagging legitimate nested `<section>` elements

## Test plan
- [ ] `<section><section>...</section></section>` → valid
- [ ] `<div role="region"><div role="region">...</div></div>` → valid
- [ ] `<main><nav>...</nav></main>` → still flagged