### PR TITLE
Post-merge-review: Fix template-quotes: accept boolean root config

### DIFF
--- a/lib/rules/template-quotes.js
+++ b/lib/rules/template-quotes.js
@@ -54,7 +54,7 @@ module.exports = {
     const rawOption = context.options[0];
 
     // Disabled when options omitted or explicitly set to `false`.
-    if (rawOption === undefined || rawOption === false) {
+    if (!rawOption) {
       return {};
     }
 

--- a/lib/rules/template-quotes.js
+++ b/lib/rules/template-quotes.js
@@ -23,6 +23,10 @@ module.exports = {
       {
         oneOf: [
           { enum: ['double', 'single'] },
+          // `false` as the root config disables the rule, matching upstream
+          // ember-template-lint which accepts `[rule, false]` as a valid
+          // disabled state without schema errors.
+          { type: 'boolean', enum: [false] },
           {
             type: 'object',
             required: ['curlies', 'html'],
@@ -49,7 +53,8 @@ module.exports = {
   create(context) {
     const rawOption = context.options[0];
 
-    if (rawOption === undefined) {
+    // Disabled when options omitted or explicitly set to `false`.
+    if (rawOption === undefined || rawOption === false) {
       return {};
     }
 

--- a/tests/lib/rules/template-quotes.js
+++ b/tests/lib/rules/template-quotes.js
@@ -28,6 +28,15 @@ const validHbs = [
     code: '<input type=\'checkbox\'> {{hello "test" x="test"}}',
     options: [{ curlies: 'double', html: 'single' }],
   },
+  // `false` as the root config disables the rule (matches upstream).
+  {
+    code: "{{component \"test\"}} {{hello x='test'}} <input type='checkbox'>",
+    options: [false],
+  },
+  {
+    code: "{{component 'test'}} <input type=\"checkbox\">",
+    options: [false],
+  },
 ];
 
 const invalidHbs = [

--- a/tests/lib/rules/template-quotes.js
+++ b/tests/lib/rules/template-quotes.js
@@ -34,7 +34,7 @@ const validHbs = [
     options: [false],
   },
   {
-    code: "{{component 'test'}} <input type=\"checkbox\">",
+    code: '{{component \'test\'}} <input type="checkbox">',
     options: [false],
   },
 ];


### PR DESCRIPTION
## Summary
- Schema now accepts `false` as root config (matches upstream's `[rule, false]` disabled state)
- `create()` short-circuits when config is `false`

## Test plan
- [ ] `options: [false]` with any quote style → no errors reported