### PR TITLE
Post-merge-review: Fix template-require-aria-activedescendant-tabindex: autofix for non-div tags

### DIFF
--- a/lib/rules/template-require-aria-activedescendant-tabindex.js
+++ b/lib/rules/template-require-aria-activedescendant-tabindex.js
@@ -103,7 +103,8 @@ module.exports = {
                   return fixer.insertTextAfterRange(lastAttribute.range, ` ${FIXED_TABINDEX}`);
                 }
 
-                const insertPos = node.parts.at(-1)?.range[1] ?? node.range[0] + '<div'.length;
+                const insertPos =
+                  node.parts.at(-1)?.range[1] ?? node.range[0] + 1 + node.tag.length;
                 return fixer.insertTextAfterRange([insertPos, insertPos], ` ${FIXED_TABINDEX}`);
               }
 

--- a/tests/lib/rules/template-require-aria-activedescendant-tabindex.js
+++ b/tests/lib/rules/template-require-aria-activedescendant-tabindex.js
@@ -36,6 +36,16 @@ const invalidHbs = [
     output: '<div aria-activedescendant="fixme" tabindex="0"></div>',
     errors: [{ message: ERROR_MESSAGE }],
   },
+  {
+    code: '<a aria-activedescendant="x"></a>',
+    output: '<a aria-activedescendant="x" tabindex="0"></a>',
+    errors: [{ message: ERROR_MESSAGE }],
+  },
+  {
+    code: '<button aria-activedescendant="x" tabindex="-1"></button>',
+    output: '<button aria-activedescendant="x" tabindex="0"></button>',
+    errors: [{ message: ERROR_MESSAGE }],
+  },
 ];
 
 function wrapTemplate(entry) {


### PR DESCRIPTION
## Summary
- Replaces hardcoded `'<div'.length` with computed `1 + node.tag.length`
- Previous code mis-positioned `tabindex` insertion on `<a>`, `<button>`, and other non-3-char tags

## Test plan
- [ ] `<a aria-activedescendant="x">` autofixes to `<a aria-activedescendant="x" tabindex="0">`
- [ ] `<button aria-activedescendant="x" tabindex="-1">` autofixes to `tabindex="0"`