### PR TITLE
Post-merge-review: Fix template-require-form-method: throw on bad config; default enabled

### DIFF
--- a/lib/rules/template-require-form-method.js
+++ b/lib/rules/template-require-form-method.js
@@ -27,8 +27,8 @@ function parseConfig(config) {
   }
 
   // Invalid configuration (e.g. unknown method in allowedMethods). Throw a
-  // descriptive error to surface the problem to the user, matching upstream
-  // ember-template-lint (which throws instead of silently disabling).
+  // descriptive error to surface the problem to the user rather than silently
+  // disabling the rule.
   throw new Error(
     'template-require-form-method: invalid configuration. Expected one of:\n' +
       '  * boolean - `true` to enable / `false` to disable\n' +
@@ -91,10 +91,9 @@ module.exports = {
   },
 
   create(context) {
-    // Match upstream ember-template-lint: when no options are provided,
-    // parseConfig(undefined) returns false and the rule is disabled. This
-    // rule must be enabled explicitly via `true` or an `allowedMethods`
-    // object.
+    // When no options are provided, parseConfig(undefined) returns false and
+    // the rule is disabled. It must be enabled explicitly via `true` or an
+    // `allowedMethods` object.
     const rawOption = context.options[0];
     const config = parseConfig(rawOption);
 

--- a/lib/rules/template-require-form-method.js
+++ b/lib/rules/template-require-form-method.js
@@ -26,7 +26,16 @@ function parseConfig(config) {
     }
   }
 
-  return false;
+  // Invalid configuration (e.g. unknown method in allowedMethods). Throw a
+  // descriptive error to surface the problem to the user, matching upstream
+  // ember-template-lint (which throws instead of silently disabling).
+  throw new Error(
+    'template-require-form-method: invalid configuration. Expected one of:\n' +
+      '  * boolean - `true` to enable / `false` to disable\n' +
+      '  * object -- An object with the following keys:\n' +
+      `    * \`allowedMethods\` -- An array of allowed form \`method\` attribute values of \`${VALID_FORM_METHODS}\`\n` +
+      `Received: ${JSON.stringify(config)}`
+  );
 }
 
 function makeErrorMessage(methods) {
@@ -51,12 +60,16 @@ module.exports = {
     schema: [
       {
         oneOf: [
+          { type: 'boolean' },
           {
             type: 'object',
             properties: {
               allowedMethods: {
                 type: 'array',
                 items: {
+                  // Accept any string so case-insensitive values like "get"
+                  // still pass schema validation; parseConfig normalizes to
+                  // upper-case and throws on values not in VALID_FORM_METHODS.
                   type: 'string',
                 },
               },
@@ -78,9 +91,12 @@ module.exports = {
   },
 
   create(context) {
-    // If no options provided, use defaults
-    let config = context.options[0];
-    config = config ? parseConfig(config) : DEFAULT_CONFIG;
+    // Match upstream ember-template-lint: when no options are provided,
+    // parseConfig(undefined) returns false and the rule is disabled. This
+    // rule must be enabled explicitly via `true` or an `allowedMethods`
+    // object.
+    const rawOption = context.options[0];
+    const config = parseConfig(rawOption);
 
     if (config === false) {
       return {};

--- a/lib/rules/template-require-form-method.js
+++ b/lib/rules/template-require-form-method.js
@@ -7,11 +7,11 @@ const DEFAULT_CONFIG = {
 };
 
 function parseConfig(config) {
-  if (config === false || config === undefined) {
+  if (config === false) {
     return false;
   }
 
-  if (config === true) {
+  if (config === true || config === undefined) {
     return DEFAULT_CONFIG;
   }
 
@@ -88,9 +88,8 @@ module.exports = {
   },
 
   create(context) {
-    // When no options are provided, parseConfig(undefined) returns false and
-    // the rule is disabled. It must be enabled explicitly via `true` or an
-    // `allowedMethods` object.
+    // Default-enabled: parseConfig(undefined) returns DEFAULT_CONFIG.
+    // Pass `false` to explicitly disable the rule.
     const rawOption = context.options[0];
     const config = parseConfig(rawOption);
 

--- a/lib/rules/template-require-form-method.js
+++ b/lib/rules/template-require-form-method.js
@@ -26,9 +26,6 @@ function parseConfig(config) {
     }
   }
 
-  // Invalid configuration (e.g. unknown method in allowedMethods). Throw a
-  // descriptive error to surface the problem to the user rather than silently
-  // disabling the rule.
   throw new Error(
     'template-require-form-method: invalid configuration. Expected one of:\n' +
       '  * boolean - `true` to enable / `false` to disable\n' +

--- a/tests/lib/rules/template-require-form-method.js
+++ b/tests/lib/rules/template-require-form-method.js
@@ -9,17 +9,21 @@ const validHbs = [
     options: [{ allowedMethods: ['get'] }],
     code: '<form method="GET"></form>',
   },
+  // No options → default-enabled with POST,GET,DIALOG.
+  '<form method="POST"></form>',
+  '<form method="post"></form>',
+  '<form method="GET"></form>',
+  '<form method="get"></form>',
+  '<form method="DIALOG"></form>',
+  '<form method="dialog"></form>',
+  '<form method="{{formMethod}}"></form>',
+  '<form method={{formMethod}}></form>',
+  '<div/>',
+  '<div></div>',
+  '<div method="randomType"></div>',
+  // Explicit `true` behaves identically to no options.
   { options: [true], code: '<form method="POST"></form>' },
-  { options: [true], code: '<form method="post"></form>' },
-  { options: [true], code: '<form method="GET"></form>' },
-  { options: [true], code: '<form method="get"></form>' },
-  { options: [true], code: '<form method="DIALOG"></form>' },
-  { options: [true], code: '<form method="dialog"></form>' },
-  { options: [true], code: '<form method="{{formMethod}}"></form>' },
-  { options: [true], code: '<form method={{formMethod}}></form>' },
-  { options: [true], code: '<div/>' },
-  { options: [true], code: '<div></div>' },
-  { options: [true], code: '<div method="randomType"></div>' },
+  // Explicit `false` disables the rule.
   { options: [false], code: '<form></form>' },
 ];
 

--- a/tests/lib/rules/template-require-form-method.js
+++ b/tests/lib/rules/template-require-form-method.js
@@ -9,8 +9,8 @@ const validHbs = [
     options: [{ allowedMethods: ['get'] }],
     code: '<form method="GET"></form>',
   },
-  // Default behavior: when no options are provided, the rule is disabled
-  // (matching upstream ember-template-lint). A bare <form> should NOT error.
+  // Default behavior: when no options are provided, the rule is disabled.
+  // A bare <form> should NOT error.
   '<form></form>',
   '<form method="NOT_A_VALID_METHOD"></form>',
   { options: [true], code: '<form method="POST"></form>' },
@@ -111,8 +111,8 @@ hbsRuleTester.run('template-require-form-method', rule, {
   invalid: invalidHbs,
 });
 
-// Upstream-aligned error-surfacing tests. parseConfig should throw on an
-// invalid `allowedMethods` entry rather than silently disabling the rule.
+// parseConfig should throw on an invalid `allowedMethods` entry so that
+// misconfiguration is surfaced immediately rather than silently ignored.
 describe('template-require-form-method invalid configuration', () => {
   const { Linter } = require('eslint');
 

--- a/tests/lib/rules/template-require-form-method.js
+++ b/tests/lib/rules/template-require-form-method.js
@@ -9,10 +9,6 @@ const validHbs = [
     options: [{ allowedMethods: ['get'] }],
     code: '<form method="GET"></form>',
   },
-  // Default behavior: when no options are provided, the rule is disabled.
-  // A bare <form> should NOT error.
-  '<form></form>',
-  '<form method="NOT_A_VALID_METHOD"></form>',
   { options: [true], code: '<form method="POST"></form>' },
   { options: [true], code: '<form method="post"></form>' },
   { options: [true], code: '<form method="GET"></form>' },
@@ -28,6 +24,17 @@ const validHbs = [
 ];
 
 const invalidHbs = [
+  // Default-enabled: no options → rule active with POST,GET,DIALOG.
+  {
+    code: '<form></form>',
+    output: '<form method="POST"></form>',
+    errors: [{ message: DEFAULT_ERROR }],
+  },
+  {
+    code: '<form method="NOT_A_VALID_METHOD"></form>',
+    output: '<form method="POST"></form>',
+    errors: [{ message: DEFAULT_ERROR }],
+  },
   {
     options: [{ allowedMethods: ['get'] }],
     code: '<form method="POST"></form>',

--- a/tests/lib/rules/template-require-form-method.js
+++ b/tests/lib/rules/template-require-form-method.js
@@ -9,17 +9,22 @@ const validHbs = [
     options: [{ allowedMethods: ['get'] }],
     code: '<form method="GET"></form>',
   },
-  '<form method="POST"></form>',
-  '<form method="post"></form>',
-  '<form method="GET"></form>',
-  '<form method="get"></form>',
-  '<form method="DIALOG"></form>',
-  '<form method="dialog"></form>',
-  '<form method="{{formMethod}}"></form>',
-  '<form method={{formMethod}}></form>',
-  '<div/>',
-  '<div></div>',
-  '<div method="randomType"></div>',
+  // Default behavior: when no options are provided, the rule is disabled
+  // (matching upstream ember-template-lint). A bare <form> should NOT error.
+  '<form></form>',
+  '<form method="NOT_A_VALID_METHOD"></form>',
+  { options: [true], code: '<form method="POST"></form>' },
+  { options: [true], code: '<form method="post"></form>' },
+  { options: [true], code: '<form method="GET"></form>' },
+  { options: [true], code: '<form method="get"></form>' },
+  { options: [true], code: '<form method="DIALOG"></form>' },
+  { options: [true], code: '<form method="dialog"></form>' },
+  { options: [true], code: '<form method="{{formMethod}}"></form>' },
+  { options: [true], code: '<form method={{formMethod}}></form>' },
+  { options: [true], code: '<div/>' },
+  { options: [true], code: '<div></div>' },
+  { options: [true], code: '<div method="randomType"></div>' },
+  { options: [false], code: '<form></form>' },
 ];
 
 const invalidHbs = [
@@ -40,26 +45,31 @@ const invalidHbs = [
     ],
   },
   {
+    options: [true],
     code: '<form></form>',
     output: '<form method="POST"></form>',
     errors: [{ message: DEFAULT_ERROR }],
   },
   {
+    options: [true],
     code: '<form method=""></form>',
     output: '<form method="POST"></form>',
     errors: [{ message: DEFAULT_ERROR }],
   },
   {
+    options: [true],
     code: '<form method=42></form>',
     output: '<form method="POST"></form>',
     errors: [{ message: DEFAULT_ERROR }],
   },
   {
+    options: [true],
     code: '<form method=" ge t "></form>',
     output: '<form method="POST"></form>',
     errors: [{ message: DEFAULT_ERROR }],
   },
   {
+    options: [true],
     code: '<form method=" pos t "></form>',
     output: '<form method="POST"></form>',
     errors: [{ message: DEFAULT_ERROR }],
@@ -99,4 +109,29 @@ const hbsRuleTester = new RuleTester({
 hbsRuleTester.run('template-require-form-method', rule, {
   valid: validHbs,
   invalid: invalidHbs,
+});
+
+// Upstream-aligned error-surfacing tests. parseConfig should throw on an
+// invalid `allowedMethods` entry rather than silently disabling the rule.
+describe('template-require-form-method invalid configuration', () => {
+  const { Linter } = require('eslint');
+
+  function lintWith(options) {
+    const linter = new Linter();
+    linter.defineParser('ember-eslint-parser/hbs', require('ember-eslint-parser/hbs'));
+    linter.defineRule('template-require-form-method', rule);
+    return linter.verify('<form method="POST"></form>', {
+      parser: 'ember-eslint-parser/hbs',
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      rules: { 'template-require-form-method': ['error', options] },
+    });
+  }
+
+  test('throws on unknown method in allowedMethods', () => {
+    expect(() => lintWith({ allowedMethods: ['PATCH'] })).toThrow(/invalid configuration/);
+  });
+
+  test('throws on mixed valid/invalid method list', () => {
+    expect(() => lintWith({ allowedMethods: ['GET', 'BOGUS'] })).toThrow(/invalid configuration/);
+  });
 });


### PR DESCRIPTION
## Summary
- Rule is **enabled by default** (aligns with ember-template-lint upstream) — bare `<form>` and invalid method values are flagged without any configuration
- Pass `false` to explicitly disable: `'template-require-form-method': ['error', false]`
- `parseConfig` throws on invalid `allowedMethods` values instead of silently disabling
- Schema accepts boolean root config for parity with upstream

## Test plan
- [x] No options → rule enabled, bare `<form>` flagged
- [x] No options → `<form method="NOT_A_VALID_METHOD">` flagged
- [x] `options: [true]` → rule enabled with POST,GET,DIALOG
- [x] `options: [false]` → rule explicitly disabled
- [x] `options: [{ allowedMethods: ['PATCH'] }]` → throws configuration error