### PR TITLE
Post-merge-review: Fix template-require-mandatory-role-attributes: read StringLiteral .value not .original

### DIFF
--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -22,7 +22,7 @@ function getStaticRoleFromMustache(node) {
   const rolePair = node.hash?.pairs?.find((pair) => pair.key === 'role');
 
   if (rolePair?.value?.type === 'GlimmerStringLiteral') {
-    return rolePair.value.original;
+    return rolePair.value.value;
   }
 
   return undefined;

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -61,6 +61,20 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       output: null,
       errors: [{ message: 'The attribute aria-level is required by the role heading' }],
     },
+    {
+      code: '<template>{{foo role="slider"}}</template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attribute aria-valuenow is required by the role slider',
+        },
+      ],
+    },
+    {
+      code: '<template>{{foo role="checkbox"}}</template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-checked is required by the role checkbox' }],
+    },
   ],
 });
 
@@ -117,6 +131,20 @@ hbsRuleTester.run('template-require-mandatory-role-attributes', rule, {
       code: '{{some-component role="heading"}}',
       output: null,
       errors: [{ message: 'The attribute aria-level is required by the role heading' }],
+    },
+    {
+      code: '{{foo role="slider"}}',
+      output: null,
+      errors: [
+        {
+          message: 'The attribute aria-valuenow is required by the role slider',
+        },
+      ],
+    },
+    {
+      code: '{{foo role="checkbox"}}',
+      output: null,
+      errors: [{ message: 'The attribute aria-checked is required by the role checkbox' }],
     },
   ],
 });


### PR DESCRIPTION
## Summary
- The mustache branch was dead code: `GlimmerStringLiteral.original` returns `undefined`; `.value` is the correct accessor
- Required-ARIA-property errors on curly invocations like `{{foo role="slider"}}` were silently dropped; now reported correctly

## Test plan
- [ ] `{{foo role="slider"}}` → flagged (missing `aria-valuenow`)
- [ ] `{{foo role="checkbox"}}` → flagged (missing `aria-checked`)