### PR TITLE
Post-merge-review: Fix template-require-media-caption: skip caption check when muted is dynamic

### DIFF
--- a/lib/rules/template-require-media-caption.js
+++ b/lib/rules/template-require-media-caption.js
@@ -58,10 +58,7 @@ module.exports = {
           // or muted={{#if ...}}...{{/if}} → BlockStatement) → treat as exempt.
           // Matches upstream ember-template-lint behavior where MustacheStatement,
           // BlockStatement, or any non-text/non-"false" value is considered muted.
-          if (
-            value.type !== 'GlimmerTextNode' &&
-            value.type !== 'GlimmerMustacheStatement'
-          ) {
+          if (value.type !== 'GlimmerTextNode' && value.type !== 'GlimmerMustacheStatement') {
             return;
           }
         }

--- a/lib/rules/template-require-media-caption.js
+++ b/lib/rules/template-require-media-caption.js
@@ -53,6 +53,17 @@ module.exports = {
               return;
             }
           }
+
+          // Any other dynamic value (e.g. muted="{{isMuted}}" → ConcatStatement,
+          // or muted={{#if ...}}...{{/if}} → BlockStatement) → treat as exempt.
+          // Matches upstream ember-template-lint behavior where MustacheStatement,
+          // BlockStatement, or any non-text/non-"false" value is considered muted.
+          if (
+            value.type !== 'GlimmerTextNode' &&
+            value.type !== 'GlimmerMustacheStatement'
+          ) {
+            return;
+          }
         }
 
         // Check if there's a track element with kind="captions" as a child

--- a/lib/rules/template-require-media-caption.js
+++ b/lib/rules/template-require-media-caption.js
@@ -56,8 +56,7 @@ module.exports = {
 
           // Any other dynamic value (e.g. muted="{{isMuted}}" → ConcatStatement,
           // or muted={{#if ...}}...{{/if}} → BlockStatement) → treat as exempt.
-          // Matches upstream ember-template-lint behavior where MustacheStatement,
-          // BlockStatement, or any non-text/non-"false" value is considered muted.
+          // These cannot be statically evaluated, so assume the element may be muted.
           if (value.type !== 'GlimmerTextNode' && value.type !== 'GlimmerMustacheStatement') {
             return;
           }

--- a/tests/lib/rules/template-require-media-caption.js
+++ b/tests/lib/rules/template-require-media-caption.js
@@ -34,6 +34,8 @@ ruleTester.run('template-require-media-caption', rule, {
     '<template><audio muted="true"></audio></template>',
     '<template><video muted></video></template>',
     '<template><audio muted={{this.muted}}></audio></template>',
+    '<template><video muted="{{isMuted}}"><source src="movie.mp4" /></video></template>',
+    '<template><audio muted="{{this.isMuted}}"></audio></template>',
     '<template><video><track kind="captions" /><track kind="descriptions" /></video></template>',
   ],
 
@@ -148,6 +150,8 @@ hbsRuleTester.run('template-require-media-caption', rule, {
     '<audio muted="true"></audio>',
     '<video muted></video>',
     '<audio muted={{this.muted}}></audio>',
+    '<video muted="{{isMuted}}"><source src="movie.mp4" /></video>',
+    '<audio muted="{{this.isMuted}}"></audio>',
     '<video><track kind="captions" /><track kind="descriptions" /></video>',
   ],
   invalid: [


### PR DESCRIPTION
## Summary
- `muted="{{isMuted}}"` (ConcatStatement) was not handled → false positive requiring captions
- Any non-text/non-mustache muted value is now treated as exempt (matches upstream)

## Test plan
- [ ] `<video muted="{{isMuted}}">` → valid (no caption required)
- [ ] `<audio muted="{{this.isMuted}}">` → valid
- [ ] `<video muted={{false}}>` → still requires captions (explicit false)