### PR TITLE
Post-merge-review: Fix template-table-groups: align with upstream's table semantics

### DIFF
--- a/lib/rules/template-table-groups.js
+++ b/lib/rules/template-table-groups.js
@@ -178,18 +178,6 @@ module.exports = {
           return;
         }
 
-        // Truly empty table (no content at all between tags) must have table groups
-        if (!node.children || node.children.length === 0) {
-          const sourceCode = context.sourceCode;
-          const text = sourceCode.getText(node);
-          const openEnd = text.indexOf('>') + 1;
-          const closeStart = text.lastIndexOf('</');
-          if (closeStart >= 0 && closeStart <= openEnd) {
-            context.report({ node, messageId: 'missing' });
-            return;
-          }
-        }
-
         const children = getEffectiveChildren(node.children);
 
         let currentAllowedMinimumIndices = new Set([0]);
@@ -198,7 +186,9 @@ module.exports = {
         for (const child of children) {
           if (child === CONTROL_FLOW_START_MARK) {
             scopedIndices.push(currentAllowedMinimumIndices);
-            currentAllowedMinimumIndices = new Set(currentAllowedMinimumIndices);
+            currentAllowedMinimumIndices = new Set(
+              scopedIndices.reduce((acc, indices) => [...acc, ...indices])
+            );
             continue;
           }
           if (child === CONTROL_FLOW_END_MARK) {

--- a/tests/lib/rules/template-table-groups.js
+++ b/tests/lib/rules/template-table-groups.js
@@ -145,6 +145,8 @@ ruleTester.run('template-table-groups', rule, {
     '<template><table><!-- this --></table></template>',
     '<template><table>{{! or this }}</table></template>',
     '<template><table> </table></template>',
+    // Empty <table></table> matches upstream (ember-template-lint) behavior of not flagging.
+    '<template><table></table></template>',
     '<template><table> <caption>Foo</caption></table></template>',
     '<template><table><colgroup><col style="background-color: red"></colgroup></table></template>',
     '<template><table><thead><tr><td>Header</td></tr></thead></table></template>',
@@ -307,11 +309,6 @@ ruleTester.run('template-table-groups', rule, {
     },
     {
       code: '<template><table>{{#each foo as |bar|}}{{bar}}{{/each}}</table></template>',
-      output: null,
-      errors: [{ messageId: 'missing' }],
-    },
-    {
-      code: '<template><table></table></template>',
       output: null,
       errors: [{ messageId: 'missing' }],
     },


### PR DESCRIPTION
## Summary
- Fixes false positives on legitimate conditional table layouts: scope-union `reduce` now merges all ancestor scopes when entering a control-flow branch (was copying only the current scope)
- Removes port-only empty-table synthetic check: upstream does not flag `<table></table>`

## Test plan
- [ ] `<table></table>` → valid (matches upstream)
- [ ] `<table>{{#if ...}}<tbody>...</tbody>{{/if}}</table>` → valid (no false positive)
- [ ] `<table>text<thead>...</thead></table>` → still flagged (whitespace before group)