### PR TITLE
chore: add originallyFrom metadata to 26 ported rules

### DIFF
--- a/lib/rules/template-attribute-order.js
+++ b/lib/rules/template-attribute-order.js
@@ -26,6 +26,12 @@ module.exports = {
     messages: {
       wrongOrder: 'Attribute "{{currentAttr}}" should come {{position}} "{{expectedAttr}}".',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/attribute-order.js',
+      docs: 'docs/rule/attribute-order.md',
+      tests: 'test/unit/rules/attribute-order-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-builtin-component-arguments.js
+++ b/lib/rules/template-builtin-component-arguments.js
@@ -20,6 +20,12 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {},
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/builtin-component-arguments.js',
+      docs: 'docs/rule/builtin-component-arguments.md',
+      tests: 'test/unit/rules/builtin-component-arguments-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-link-href-attributes.js
+++ b/lib/rules/template-link-href-attributes.js
@@ -14,6 +14,12 @@ module.exports = {
       missingHref:
         '<a> elements must have an href attribute. Use <button> for clickable elements that are not links.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/link-href-attributes.js',
+      docs: 'docs/rule/link-href-attributes.md',
+      tests: 'test/unit/rules/link-href-attributes-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-link-rel-noopener.js
+++ b/lib/rules/template-link-rel-noopener.js
@@ -13,6 +13,12 @@ module.exports = {
     messages: {
       missingRel: 'links with target="_blank" must have rel="noopener noreferrer"',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/link-rel-noopener.js',
+      docs: 'docs/rule/link-rel-noopener.md',
+      tests: 'test/unit/rules/link-rel-noopener-test.js',
+    },
   },
   create(context) {
     return {

--- a/lib/rules/template-no-abstract-roles.js
+++ b/lib/rules/template-no-abstract-roles.js
@@ -29,6 +29,12 @@ module.exports = {
       abstractRole:
         '{{role}} is an abstract role, and is not a valid value for the role attribute.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-abstract-roles.js',
+      docs: 'docs/rule/no-abstract-roles.md',
+      tests: 'test/unit/rules/no-abstract-roles-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-accesskey-attribute.js
+++ b/lib/rules/template-no-accesskey-attribute.js
@@ -14,6 +14,12 @@ module.exports = {
       noAccesskey:
         'No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreader and keyboard only users create accessibility complications.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-accesskey-attribute.js',
+      docs: 'docs/rule/no-accesskey-attribute.md',
+      tests: 'test/unit/rules/no-accesskey-attribute-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-action-modifiers.js
+++ b/lib/rules/template-no-action-modifiers.js
@@ -34,6 +34,12 @@ module.exports = {
     messages: {
       noActionModifier: 'Do not use action modifiers. Use on modifier with a function instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-action-modifiers.js',
+      docs: 'docs/rule/no-action-modifiers.md',
+      tests: 'test/unit/rules/no-action-modifiers-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-action.js
+++ b/lib/rules/template-no-action.js
@@ -36,6 +36,12 @@ module.exports = {
       modifier:
         'Do not use `action` as an element modifier — deprecated in Ember 5.9, removed in 6.0. Use the `on` modifier instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-action.js',
+      docs: 'docs/rule/no-action.md',
+      tests: 'test/unit/rules/no-action-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-arguments-for-html-elements.js
+++ b/lib/rules/template-no-arguments-for-html-elements.js
@@ -16,6 +16,12 @@ module.exports = {
       noArgumentsForHtmlElements:
         '@arguments can only be used on components, not HTML elements. Use regular attributes instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-arguments-for-html-elements.js',
+      docs: 'docs/rule/no-arguments-for-html-elements.md',
+      tests: 'test/unit/rules/no-arguments-for-html-elements-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-aria-hidden-body.js
+++ b/lib/rules/template-no-aria-hidden-body.js
@@ -14,6 +14,12 @@ module.exports = {
       noAriaHiddenBody:
         'The aria-hidden attribute should never be present on the <body> element, as it hides the entire document from assistive technology',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-aria-hidden-body.js',
+      docs: 'docs/rule/no-aria-hidden-body.md',
+      tests: 'test/unit/rules/no-aria-hidden-body-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-aria-unsupported-elements.js
+++ b/lib/rules/template-no-aria-unsupported-elements.js
@@ -15,6 +15,12 @@ module.exports = {
       unsupported:
         'ARIA attribute "{{attribute}}" is not supported on <{{element}}> elements. Consider using a different element.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-aria-unsupported-elements.js',
+      docs: 'docs/rule/no-aria-unsupported-elements.md',
+      tests: 'test/unit/rules/no-aria-unsupported-elements-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-array-prototype-extensions.js
+++ b/lib/rules/template-no-array-prototype-extensions.js
@@ -89,6 +89,12 @@ module.exports = {
       lastObject: ERROR_MESSAGES.LAST_OBJECT,
       firstObject: ERROR_MESSAGES.FIRST_OBJECT,
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-array-prototype-extensions.js',
+      docs: 'docs/rule/no-array-prototype-extensions.md',
+      tests: 'test/unit/rules/no-array-prototype-extensions-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-attrs-in-components.js
+++ b/lib/rules/template-no-attrs-in-components.js
@@ -13,6 +13,12 @@ module.exports = {
       noThisAttrs:
         'Component templates should not contain `this.attrs`. Use `@arg` syntax instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-attrs-in-components.js',
+      docs: 'docs/rule/no-attrs-in-components.md',
+      tests: 'test/unit/rules/no-attrs-in-components-test.js',
+    },
   },
   create(context) {
     return {

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -14,6 +14,12 @@ module.exports = {
       noAutofocus:
         'Avoid using autofocus attribute. Autofocusing elements can cause usability issues for sighted and non-sighted users.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-autofocus-attribute.js',
+      docs: 'docs/rule/no-autofocus-attribute.md',
+      tests: 'test/unit/rules/no-autofocus-attribute-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-block-params-for-html-elements.js
+++ b/lib/rules/template-no-block-params-for-html-elements.js
@@ -16,6 +16,12 @@ module.exports = {
       noBlockParamsForHtmlElements:
         'Block params can only be used with components, not HTML elements.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-block-params-for-html-elements.js',
+      docs: 'docs/rule/no-block-params-for-html-elements.md',
+      tests: 'test/unit/rules/no-block-params-for-html-elements-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-capital-arguments.js
+++ b/lib/rules/template-no-capital-arguments.js
@@ -18,6 +18,12 @@ module.exports = {
         'Argument names should start with lowercase. Use @{{lowercase}} instead of @{{name}}.',
       reservedArgument: '{{name}} is a reserved argument name, try to use another.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-capital-arguments.js',
+      docs: 'docs/rule/no-capital-arguments.md',
+      tests: 'test/unit/rules/no-capital-arguments-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-chained-this.js
+++ b/lib/rules/template-no-chained-this.js
@@ -14,6 +14,12 @@ module.exports = {
       noChainedThis:
         'this.this.* is not allowed in templates. This is likely a mistake — remove the redundant this.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-chained-this.js',
+      docs: 'docs/rule/no-chained-this.md',
+      tests: 'test/unit/rules/no-chained-this-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-debugger.js
+++ b/lib/rules/template-no-debugger.js
@@ -12,6 +12,12 @@ module.exports = {
     messages: {
       unexpected: 'Unexpected debugger statement in template.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-debugger.js',
+      docs: 'docs/rule/no-debugger.md',
+      tests: 'test/unit/rules/no-debugger-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-element-event-actions.js
+++ b/lib/rules/template-no-element-event-actions.js
@@ -21,6 +21,12 @@ module.exports = {
     messages: {
       noElementEventActions: 'Do not use element event actions. Use the `on` modifier instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-element-event-actions.js',
+      docs: 'docs/rule/no-element-event-actions.md',
+      tests: 'test/unit/rules/no-element-event-actions-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -102,6 +102,12 @@ module.exports = {
       emptyHeading:
         'Headings must contain accessible text content (or helper/component that provides text).',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-empty-headings.js',
+      docs: 'docs/rule/no-empty-headings.md',
+      tests: 'test/unit/rules/no-empty-headings-test.js',
+    },
   },
   create(context) {
     return {

--- a/lib/rules/template-no-heading-inside-button.js
+++ b/lib/rules/template-no-heading-inside-button.js
@@ -33,6 +33,12 @@ module.exports = {
     messages: {
       noHeading: 'Buttons should not contain heading elements',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-heading-inside-button.js',
+      docs: 'docs/rule/no-heading-inside-button.md',
+      tests: 'test/unit/rules/no-heading-inside-button-test.js',
+    },
   },
   create(context) {
     return {

--- a/lib/rules/template-no-inline-styles.js
+++ b/lib/rules/template-no-inline-styles.js
@@ -19,6 +19,12 @@ module.exports = {
       },
     ],
     messages: { noInlineStyles: 'Inline styles are not allowed' },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-inline-styles.js',
+      docs: 'docs/rule/no-inline-styles.md',
+      tests: 'test/unit/rules/no-inline-styles-test.js',
+    },
   },
   create(context) {
     const options = context.options[0] || {};

--- a/lib/rules/template-no-input-tagname.js
+++ b/lib/rules/template-no-input-tagname.js
@@ -11,6 +11,12 @@ module.exports = {
     },
     schema: [],
     messages: { unexpected: 'Unexpected tagName usage on input helper.' },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-input-tagname.js',
+      docs: 'docs/rule/no-input-tagname.md',
+      tests: 'test/unit/rules/no-input-tagname-test.js',
+    },
   },
   create(context) {
     const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');

--- a/lib/rules/template-no-invalid-interactive.js
+++ b/lib/rules/template-no-invalid-interactive.js
@@ -56,6 +56,12 @@ module.exports = {
       noInvalidInteractive:
         'Non-interactive element <{{tagName}}> should not have interactive handler "{{handler}}".',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-invalid-interactive.js',
+      docs: 'docs/rule/no-invalid-interactive.md',
+      tests: 'test/unit/rules/no-invalid-interactive-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-log.js
+++ b/lib/rules/template-no-log.js
@@ -12,6 +12,12 @@ module.exports = {
     messages: {
       unexpected: 'Unexpected log statement in template.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-log.js',
+      docs: 'docs/rule/no-log.md',
+      tests: 'test/unit/rules/no-log-test.js',
+    },
   },
 
   create(context) {

--- a/lib/rules/template-no-pointer-down-event-binding.js
+++ b/lib/rules/template-no-pointer-down-event-binding.js
@@ -13,6 +13,12 @@ module.exports = {
     messages: {
       unexpected: 'Avoid binding to a pointer `down` event; bind to a pointer `up` event instead.',
     },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-pointer-down-event-binding.js',
+      docs: 'docs/rule/no-pointer-down-event-binding.md',
+      tests: 'test/unit/rules/no-pointer-down-event-binding-test.js',
+    },
   },
 
   create(context) {


### PR DESCRIPTION
## Summary

- 26 rules ported from ember-template-lint were missing the `originallyFrom` metadata field in their `meta` object
- These were likely ported before the convention was established
- No behavior changes — metadata only

## Test plan

- [ ] `npm test` passes (only pre-existing worktree failures unrelated to these changes)