### PR TITLE
fix: allow <meta> in head.hbs templates (template-no-forbidden-elements)

### DIFF
--- a/lib/rules/template-no-forbidden-elements.js
+++ b/lib/rules/template-no-forbidden-elements.js
@@ -50,6 +50,8 @@ module.exports = {
     }
 
     const forbidden = new Set(forbiddenList);
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    const isHeadTemplate = filename.endsWith('head.hbs');
 
     // Track element stack for <meta> in <head> exception
     const elementStack = [];
@@ -62,8 +64,8 @@ module.exports = {
           return;
         }
 
-        // Exception: <meta> inside <head> is allowed
-        if (node.tag === 'meta' && elementStack.includes('head')) {
+        // Exception: <meta> inside <head> element, or in a head.hbs template
+        if (node.tag === 'meta' && (elementStack.includes('head') || isHeadTemplate)) {
           return;
         }
 

--- a/tests/lib/rules/template-no-forbidden-elements.js
+++ b/tests/lib/rules/template-no-forbidden-elements.js
@@ -15,6 +15,11 @@ ruleTester.run('template-no-forbidden-elements', rule, {
     '<template><footer></footer></template>',
     '<template><p></p></template>',
     '<template><head><meta charset="utf-8"></head></template>',
+    // <meta> is allowed in app/templates/head.hbs without a wrapping <head>
+    {
+      code: '<template><meta charset="utf-8"></template>',
+      filename: 'app/templates/head.hbs',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## Summary

`template-no-forbidden-elements` did not implement the `head.hbs` file path exception present in ember-template-lint. When the file being linted is `app/templates/head.hbs`, `<meta>` elements are valid (the template renders directly into the document `<head>`).

Previously the rule only exempted `<meta>` when it appeared inside a `<head>` *element* in the template. This adds the complementary file-path check.

## Reference

[`no-forbidden-elements-test.js` — filePath test cases](https://github.com/ember-template-lint/ember-template-lint/blob/master/test/unit/rules/no-forbidden-elements-test.js)

## Test plan

- [x] Added failing test first, then fixed the rule
- [x] `node tests/lib/rules/template-no-forbidden-elements.js` passes