### PR TITLE
Post-merge-review: template-no-implicit-this support regex patterns in allow option

### DIFF
--- a/lib/rules/template-no-implicit-this.js
+++ b/lib/rules/template-no-implicit-this.js
@@ -108,8 +108,8 @@ module.exports = {
         properties: {
           allow: {
             type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
+            items: { anyOf: [{ type: 'string' }, { instanceof: 'RegExp' }] },
+            uniqueItems: false,
           },
         },
         additionalProperties: false,
@@ -145,8 +145,8 @@ module.exports = {
           return;
         }
 
-        // Skip paths matching the allow list (exact match only)
-        if (allowList.includes(path)) {
+        // Skip paths matching the allow list (exact string or regex)
+        if (allowList.some((item) => (item instanceof RegExp ? item.test(path) : item === path))) {
           return;
         }
 

--- a/tests/lib/rules/template-no-implicit-this.js
+++ b/tests/lib/rules/template-no-implicit-this.js
@@ -204,6 +204,11 @@ hbsRuleTester.run('template-no-implicit-this', rule, {
       code: '{{book-details}}',
       options: [{ allow: ['book-details'] }],
     },
+    // Allow config option — regex pattern
+    {
+      code: '{{data-test-foo}}',
+      options: [{ allow: [/^data-test-.+/] }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## Summary

- Extends the `allow` option to accept `RegExp` instances in addition to exact strings
- Teams can now allowlist entire naming conventions with one entry, e.g. `allow: [/^data-test-.+/]`
- Works in `eslint.config.js` (flat config) and `.eslintrc.cjs`; not in `.eslintrc.json` (which doesn't support non-JSON values)

## Schema change

`items` changed from `{ type: 'string' }` to `{ anyOf: [{ type: 'string' }, { instanceof: 'RegExp' }] }`. The `instanceof` keyword is non-standard JSON Schema but is handled by Ajv (which ESLint uses internally).

## Reference

| Rule | ember-template-lint test |
|------|--------------------------|
| `template-no-implicit-this` | [`no-implicit-this-test.js` line 28](https://github.com/ember-template-lint/ember-template-lint/blob/main/test/unit/rules/no-implicit-this-test.js#L28) |