### PR TITLE
restore: template-no-negated-condition (accidentally deleted in 133a16fc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ rules in templates can be disabled with eslint directives with mustache or html 
 | [template-no-multiple-empty-lines](docs/rules/template-no-multiple-empty-lines.md)                                 | disallow multiple consecutive empty lines in templates                       |    | 🔧 |    |
 | [template-no-mut-helper](docs/rules/template-no-mut-helper.md)                                                     | disallow usage of (mut) helper                                               |    |    |    |
 | [template-no-negated-comparison](docs/rules/template-no-negated-comparison.md)                                     | disallow negated comparisons in templates                                    |    |    |    |
+| [template-no-negated-condition](docs/rules/template-no-negated-condition.md)                                       | disallow negated conditions in if/unless                                     |    | 🔧 |    |
 | [template-no-nested-splattributes](docs/rules/template-no-nested-splattributes.md)                                 | disallow nested ...attributes usage                                          |    |    |    |
 | [template-no-obscure-array-access](docs/rules/template-no-obscure-array-access.md)                                 | disallow obscure array access patterns like `objectPath.@each.property`      |    | 🔧 |    |
 | [template-no-obsolete-elements](docs/rules/template-no-obsolete-elements.md)                                       | disallow obsolete HTML elements                                              |    |    |    |

--- a/docs/rules/template-no-negated-condition.md
+++ b/docs/rules/template-no-negated-condition.md
@@ -1,0 +1,53 @@
+# ember/template-no-negated-condition
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Disallow negated conditions in `{{#if}}` blocks. Use `{{#unless}}` instead or rewrite the condition.
+
+## Rule Details
+
+This rule discourages the use of `{{#if (not condition)}}` in favor of `{{#unless condition}}` for better readability.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```gjs
+<template>
+  {{#if (not isValid)}}
+    Invalid
+  {{/if}}
+</template>
+```
+
+Examples of **correct** code for this rule:
+
+```gjs
+<template>
+  {{#unless isValid}}
+    Invalid
+  {{/unless}}
+</template>
+
+<template>
+  {{#if isValid}}
+    Valid
+  {{/if}}
+</template>
+```
+
+## Options
+
+| Name              | Type      | Default | Description                                                                                                             |
+| ----------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `simplifyHelpers` | `boolean` | `true`  | When `true`, also reports negated comparison helpers (e.g. `(not (eq ...))`) and suggests using `(not-eq ...)` instead. |
+
+## Related Rules
+
+- [simple-unless](template-simple-unless.md)
+
+## References
+
+- [no-negated-condition](https://eslint.org/docs/rules/no-negated-condition) from eslint

--- a/lib/rules/template-no-negated-condition.js
+++ b/lib/rules/template-no-negated-condition.js
@@ -1,0 +1,295 @@
+const ERROR_MESSAGE_FLIP_IF =
+  'Change `{{if (not condition)}} ... {{else}} ... {{/if}}` to `{{if condition}} ... {{else}} ... {{/if}}`.';
+const ERROR_MESSAGE_USE_IF = 'Change `unless (not condition)` to `if condition`.';
+const ERROR_MESSAGE_USE_UNLESS = 'Change `if (not condition)` to `unless condition`.';
+const ERROR_MESSAGE_NEGATED_HELPER = 'Simplify unnecessary negation of helper.';
+
+const INVERTIBLE_HELPERS = new Set(['not', 'eq', 'not-eq', 'gt', 'gte', 'lt', 'lte']);
+
+const HELPER_INVERSIONS = {
+  not: null, // special case
+  eq: 'not-eq',
+  'not-eq': 'eq',
+  gt: 'lte',
+  gte: 'lt',
+  lt: 'gte',
+  lte: 'gt',
+};
+
+function isIf(node) {
+  return node.path?.type === 'GlimmerPathExpression' && node.path.original === 'if';
+}
+
+function isUnless(node) {
+  return node.path?.type === 'GlimmerPathExpression' && node.path.original === 'unless';
+}
+
+function hasNotHelper(node) {
+  return (
+    node.params?.length > 0 &&
+    node.params[0].type === 'GlimmerSubExpression' &&
+    node.params[0].path?.type === 'GlimmerPathExpression' &&
+    node.params[0].path.original === 'not'
+  );
+}
+
+function hasNestedFixableHelper(node) {
+  const inner = node.params[0]?.params?.[0];
+  return (
+    inner &&
+    inner.path?.type === 'GlimmerPathExpression' &&
+    INVERTIBLE_HELPERS.has(inner.path.original)
+  );
+}
+
+function escapeRegExp(string) {
+  return string.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow negated conditions in if/unless',
+      category: 'Best Practices',
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-negated-condition.md',
+      templateMode: 'both',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          simplifyHelpers: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      flipIf: ERROR_MESSAGE_FLIP_IF,
+      useIf: ERROR_MESSAGE_USE_IF,
+      useUnless: ERROR_MESSAGE_USE_UNLESS,
+      negatedHelper: ERROR_MESSAGE_NEGATED_HELPER,
+    },
+    originallyFrom: {
+      name: 'ember-template-lint',
+      rule: 'lib/rules/no-negated-condition.js',
+      docs: 'docs/rule/no-negated-condition.md',
+      tests: 'test/unit/rules/no-negated-condition-test.js',
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const simplifyHelpers = options.simplifyHelpers === undefined ? true : options.simplifyHelpers;
+    const sourceCode = context.sourceCode;
+
+    /**
+     * Get the source text for the inner condition of a (not ...) sub-expression,
+     * with the nested helper optionally inverted.
+     */
+    function getUnwrappedConditionText(notExpr, invertHelper) {
+      const inner = notExpr.params[0];
+      if (invertHelper && inner.path?.type === 'GlimmerPathExpression') {
+        const helperName = inner.path.original;
+        const inverted = HELPER_INVERSIONS[helperName];
+        if (inverted !== undefined) {
+          if (inverted === null) {
+            if (inner.params.length > 1) {
+              // (not (not c1 c2)) -> (or c1 c2)
+              const paramsText = inner.params.map((p) => sourceCode.getText(p)).join(' ');
+              return `(or ${paramsText})`;
+            }
+            // (not (not x)) -> just x
+            return sourceCode.getText(inner.params[0]);
+          }
+          // (not (eq a b)) -> (not-eq a b)
+          const innerText = sourceCode.getText(inner);
+          return innerText.replace(`(${helperName} `, `(${inverted} `);
+        }
+      }
+      return sourceCode.getText(inner);
+    }
+
+    /**
+     * Build a fix function for block statements.
+     */
+    function buildBlockFix(node, messageId) {
+      return function fix(fixer) {
+        const fullText = sourceCode.getText(node);
+        const keyword = node.path.original;
+        const notExpr = node.params[0];
+
+        if (messageId === 'negatedHelper') {
+          const conditionText = getUnwrappedConditionText(notExpr, true);
+          const newText = fullText.replace(sourceCode.getText(notExpr), conditionText);
+          return fixer.replaceText(node, newText);
+        }
+
+        if (messageId === 'flipIf') {
+          // {{#if (not x)}}A{{else}}B{{/if}} -> {{#if x}}B{{else}}A{{/if}}
+          const conditionText = getUnwrappedConditionText(notExpr, false);
+          const programBody = node.program.body.map((n) => sourceCode.getText(n)).join('');
+          const inverseBody = node.inverse.body.map((n) => sourceCode.getText(n)).join('');
+
+          return fixer.replaceText(
+            node,
+            `{{#${keyword} ${conditionText}}}${inverseBody}{{else}}${programBody}{{/${keyword}}}`
+          );
+        }
+
+        if (messageId === 'useIf' || messageId === 'useUnless') {
+          const newKeyword = keyword === 'unless' ? 'if' : 'unless';
+          const conditionText = getUnwrappedConditionText(notExpr, false);
+          const notExprText = escapeRegExp(sourceCode.getText(notExpr));
+          const newText = fullText
+            .replace(
+              new RegExp(`^\\{\\{#${keyword} ${notExprText}`),
+              `{{#${newKeyword} ${conditionText}`
+            )
+            .replace(new RegExp(`\\{\\{/${keyword}\\}\\}$`), `{{/${newKeyword}}}`);
+          return fixer.replaceText(node, newText);
+        }
+
+        return null;
+      };
+    }
+
+    /**
+     * Build a fix function for inline (mustache/subexpression) statements.
+     */
+    function buildInlineFix(node, messageId) {
+      return function fix(fixer) {
+        const fullText = sourceCode.getText(node);
+        const keyword = node.path.original;
+        const notExpr = node.params[0];
+
+        if (messageId === 'negatedHelper') {
+          const conditionText = getUnwrappedConditionText(notExpr, true);
+          const newText = fullText.replace(sourceCode.getText(notExpr), conditionText);
+          return fixer.replaceText(node, newText);
+        }
+
+        if (messageId === 'flipIf') {
+          const conditionText = getUnwrappedConditionText(notExpr, false);
+          const param1Text = sourceCode.getText(node.params[1]);
+          const param2Text = sourceCode.getText(node.params[2]);
+          const isSubExpr = node.type === 'GlimmerSubExpression';
+          const open = isSubExpr ? '(' : '{{';
+          const close = isSubExpr ? ')' : '}}';
+          return fixer.replaceText(
+            node,
+            `${open}${keyword} ${conditionText} ${param2Text} ${param1Text}${close}`
+          );
+        }
+
+        if (messageId === 'useIf' || messageId === 'useUnless') {
+          const newKeyword = keyword === 'unless' ? 'if' : 'unless';
+          const conditionText = getUnwrappedConditionText(notExpr, false);
+          const isSubExpr = node.type === 'GlimmerSubExpression';
+          const open = isSubExpr ? '(' : '{{';
+          const close = isSubExpr ? ')' : '}}';
+          const remainingParams = node.params
+            .slice(1)
+            .map((p) => sourceCode.getText(p))
+            .join(' ');
+          return fixer.replaceText(
+            node,
+            `${open}${newKeyword} ${conditionText} ${remainingParams}${close}`
+          );
+        }
+
+        return null;
+      };
+    }
+
+    // eslint-disable-next-line complexity
+    function checkNode(node) {
+      const nodeIsIf = isIf(node);
+      const nodeIsUnless = isUnless(node);
+
+      if (!nodeIsIf && !nodeIsUnless) {
+        return;
+      }
+
+      // Skip `{{else if ...}}` / `{{else unless ...}}` chains for the outer check,
+      // unless they have a fixable negated helper inside
+      if (node.type === 'GlimmerBlockStatement') {
+        const text = sourceCode.getText(node);
+        if (text.startsWith('{{else ')) {
+          if (!simplifyHelpers || !hasNotHelper(node) || !hasNestedFixableHelper(node)) {
+            return;
+          }
+          context.report({
+            node: node.params[0],
+            messageId: 'negatedHelper',
+            fix: buildBlockFix(node, 'negatedHelper'),
+          });
+          return;
+        }
+
+        // Ignore `if ... else if ...` (chained) to avoid forcing negation
+        if (
+          node.inverse?.body?.length > 0 &&
+          node.inverse.body[0].type === 'GlimmerBlockStatement' &&
+          nodeIsIf &&
+          isIf(node.inverse.body[0])
+        ) {
+          return;
+        }
+      }
+
+      if (!hasNotHelper(node)) {
+        return;
+      }
+
+      const notExpr = node.params[0];
+      const hasFixableHelper = hasNestedFixableHelper(node);
+
+      // If it's `if (not (someHelper ...))` and we can't simplify the helper,
+      // don't suggest converting to `unless` (simple-unless rule would reject it)
+      if (
+        nodeIsIf &&
+        notExpr.params?.[0]?.type === 'GlimmerSubExpression' &&
+        (!simplifyHelpers || !hasFixableHelper)
+      ) {
+        return;
+      }
+
+      // (not a b c) with multiple params — can't simply remove negation
+      if (notExpr.params?.length > 1) {
+        return;
+      }
+
+      // Determine message
+      const isIfElseBlock = node.type === 'GlimmerBlockStatement' && node.inverse?.body?.length > 0;
+      const isIfElseInline = node.type !== 'GlimmerBlockStatement' && node.params?.length === 3;
+      const shouldFlip = isIfElseBlock || isIfElseInline;
+
+      let messageId;
+      if (hasFixableHelper && simplifyHelpers) {
+        messageId = 'negatedHelper';
+      } else if (shouldFlip && nodeIsIf) {
+        messageId = 'flipIf';
+      } else if (nodeIsUnless) {
+        messageId = 'useIf';
+      } else {
+        messageId = 'useUnless';
+      }
+
+      const isBlock = node.type === 'GlimmerBlockStatement';
+      context.report({
+        node: notExpr,
+        messageId,
+        fix: isBlock ? buildBlockFix(node, messageId) : buildInlineFix(node, messageId),
+      });
+    }
+
+    return {
+      GlimmerBlockStatement: checkNode,
+      GlimmerMustacheStatement: checkNode,
+      GlimmerSubExpression: checkNode,
+    };
+  },
+};

--- a/tests/lib/rules/template-no-negated-condition.js
+++ b/tests/lib/rules/template-no-negated-condition.js
@@ -1,0 +1,489 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/template-no-negated-condition');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('template-no-negated-condition', rule, {
+  valid: [
+    '<template>{{#if isValid}}Yes{{/if}}</template>',
+    '<template>{{#unless isInvalid}}Yes{{/unless}}</template>',
+    '<template>{{#if (eq value 1)}}Yes{{/if}}</template>',
+
+    '<template>{{#if condition}}<img>{{/if}}</template>',
+    '<template>{{#if (or c1 c2)}}{{/if}}</template>',
+    '<template>{{#if (not (or c1 c2))}}{{/if}}</template>',
+    '<template>{{#if (not c1 c2)}}{{/if}}</template>',
+    '<template>{{#if (not (not c1) c2)}}<img>{{/if}}</template>',
+    '<template>{{#if (not c1 (not c2))}}<img>{{/if}}</template>',
+
+    // simplifyHelpers: false config
+    {
+      code: '<template>{{#if (not (not c2))}}<img>{{/if}}</template>',
+      options: [{ simplifyHelpers: false }],
+    },
+    {
+      code: '<template>{{#if (not (eq c2))}}<img>{{/if}}</template>',
+      options: [{ simplifyHelpers: false }],
+    },
+
+    // if...else / if...else if patterns
+    '<template>{{#if condition}}<img>{{else}}<img>{{/if}}</template>',
+    '<template>{{#if (or c1 c2)}}<img>{{else}}<img>{{/if}}</template>',
+    '<template>{{#if condition}}<img>{{else if condition}}<img>{{/if}}</template>',
+    '<template>{{#if condition}}<img>{{else if (not condition2)}}<img>{{/if}}</template>',
+    '<template>{{#if (not condition)}}<img>{{else if (not condition2)}}<img>{{/if}}</template>',
+    '<template>{{#if condition}}<img>{{else if condition}}<img>{{else}}<img>{{/if}}</template>',
+    '<template>{{#if (not condition)}}<img>{{else if (not condition2)}}<img>{{else}}<img>{{/if}}</template>',
+
+    // unless variants
+    '<template>{{#unless (or c1 c2)}}<img>{{/unless}}</template>',
+    '<template>{{#unless condition}}<img>{{else}}<img>{{/unless}}</template>',
+    '<template>{{#unless condition}}<img>{{else if condition}}<img>{{/unless}}</template>',
+    '<template>{{#unless condition}}<img>{{else if condition}}<img>{{else}}<img>{{/unless}}</template>',
+
+    // MustacheStatement context (inline)
+    '<template><img class={{if condition "some-class"}}></template>',
+    '<template><img class={{if condition "some-class" "other-class"}}></template>',
+    '<template><img class={{unless condition "some-class"}}></template>',
+    '<template><img class={{if (not (or c1 c2)) "some-class"}}></template>',
+
+    // SubExpression context
+    '<template>{{input class=(if condition "some-class")}}</template>',
+    '<template>{{input class=(if condition "some-class" "other-class")}}</template>',
+    '<template>{{input class=(unless condition "some-class")}}</template>',
+    '<template>{{input class=(if (not (or c1 c2)) "some-class")}}</template>',
+  ],
+  invalid: [
+    {
+      code: '<template>{{#if (not isValid)}}No{{/if}}</template>',
+      output: '<template>{{#unless isValid}}No{{/unless}}</template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+
+    {
+      code: '<template>{{#if (not condition)}}<img>{{/if}}</template>',
+      output: '<template>{{#unless condition}}<img>{{/unless}}</template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+    {
+      code: '<template>{{#if (not (not c1 c2))}}<img>{{/if}}</template>',
+      output: '<template>{{#if (or c1 c2)}}<img>{{/if}}</template>',
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      code: '<template>{{#if (not condition)}}<img>{{else}}<input>{{/if}}</template>',
+      output: '<template>{{#if condition}}<input>{{else}}<img>{{/if}}</template>',
+      errors: [{ messageId: 'flipIf' }],
+    },
+    {
+      code: '<template>{{#unless (not condition)}}<img>{{/unless}}</template>',
+      output: '<template>{{#if condition}}<img>{{/if}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{#unless (not (not condition))}}<img>{{/unless}}</template>',
+      output: '<template>{{#unless condition}}<img>{{/unless}}</template>',
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      code: '<template>{{#unless (not condition)}}<img>{{else}}<input>{{/unless}}</template>',
+      output: '<template>{{#if condition}}<img>{{else}}<input>{{/if}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{#unless (not condition)}}<img>{{else if (not condition)}}<input>{{/unless}}</template>',
+      output:
+        '<template>{{#if condition}}<img>{{else if (not condition)}}<input>{{/if}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{#unless (not condition)}}<img>{{else if (not condition)}}<input>{{else}}<hr>{{/unless}}</template>',
+      output:
+        '<template>{{#if condition}}<img>{{else if (not condition)}}<input>{{else}}<hr>{{/if}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{#if condition}}{{else}}{{! some comment }}{{#if (not condition)}}<img>{{/if}}{{/if}}</template>',
+      output:
+        '<template>{{#if condition}}{{else}}{{! some comment }}{{#unless condition}}<img>{{/unless}}{{/if}}</template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+    {
+      code: '<template>{{#if condition}}{{else}}{{#if (not condition)}}<img>{{/if}}{{/if}}</template>',
+      output:
+        '<template>{{#if condition}}{{else}}{{#unless condition}}<img>{{/unless}}{{/if}}</template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+    {
+      code: '<template><img class={{if (not condition) "some-class"}}></template>',
+      output: '<template><img class={{unless condition "some-class"}}></template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+    {
+      code: '<template><img class={{if (not condition) "some-class" "other-class"}}></template>',
+      output: '<template><img class={{if condition "other-class" "some-class"}}></template>',
+      errors: [{ messageId: 'flipIf' }],
+    },
+    {
+      code: '<template><img class={{unless (not condition) "some-class"}}></template>',
+      output: '<template><img class={{if condition "some-class"}}></template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template><img class={{unless (not condition) "some-class" "other-class"}}></template>',
+      output: '<template><img class={{if condition "some-class" "other-class"}}></template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template><img class={{unless (not (not condition)) "some-class" "other-class"}}></template>',
+      output: '<template><img class={{unless condition "some-class" "other-class"}}></template>',
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      code: '<template>{{input class=(if (not condition) "some-class")}}</template>',
+      output: '<template>{{input class=(unless condition "some-class")}}</template>',
+      errors: [{ messageId: 'useUnless' }],
+    },
+    {
+      code: '<template>{{input class=(if (not condition) "some-class" "other-class")}}</template>',
+      output: '<template>{{input class=(if condition "other-class" "some-class")}}</template>',
+      errors: [{ messageId: 'flipIf' }],
+    },
+    {
+      code: '<template>{{input class=(unless (not condition) "some-class")}}</template>',
+      output: '<template>{{input class=(if condition "some-class")}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{input class=(unless (not condition) "some-class" "other-class")}}</template>',
+      output: '<template>{{input class=(if condition "some-class" "other-class")}}</template>',
+      errors: [{ messageId: 'useIf' }],
+    },
+    {
+      code: '<template>{{input class=(unless (not (not condition)) "some-class" "other-class")}}</template>',
+      output: '<template>{{input class=(unless condition "some-class" "other-class")}}</template>',
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+  ],
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+hbsRuleTester.run('template-no-negated-condition', rule, {
+  valid: [
+    '{{#if condition}}<img>{{/if}}',
+    '{{#if (or c1 c2)}}{{/if}}',
+    '{{#if (not (or c1 c2))}}{{/if}}',
+    '{{#if (not c1 c2)}}{{/if}}',
+    '{{#if (not (not c1) c2)}}<img>{{/if}}',
+    '{{#if (not c1 (not c2))}}<img>{{/if}}',
+    '{{#if condition}}<img>{{else}}<img>{{/if}}',
+    '{{#if (or c1 c2)}}<img>{{else}}<img>{{/if}}',
+    '{{#if condition}}<img>{{else if condition}}<img>{{/if}}',
+    '{{#if condition}}<img>{{else if (not condition2)}}<img>{{/if}}',
+    '{{#if (not condition)}}<img>{{else if (not condition2)}}<img>{{/if}}',
+    '{{#if condition}}<img>{{else if condition}}<img>{{else}}<img>{{/if}}',
+    '{{#if (not condition)}}<img>{{else if (not condition2)}}<img>{{else}}<img>{{/if}}',
+    '{{#unless condition}}<img>{{/unless}}',
+    '{{#unless (or c1 c2)}}<img>{{/unless}}',
+    '{{#unless (not c1 c2)}}<img>{{/unless}}',
+    '{{#unless condition}}<img>{{else}}<img>{{/unless}}',
+    '{{#unless (or c1 c2)}}<img>{{else}}<img>{{/unless}}',
+    '{{#unless condition}}<img>{{else if condition}}<img>{{/unless}}',
+    '{{#unless (or c1 c2)}}<img>{{else if (or c1 c2)}}<img>{{/unless}}',
+    '{{#unless condition}}<img>{{else if condition}}<img>{{else}}<img>{{/unless}}',
+    '{{#unless (or c1 c2)}}<img>{{else if (or c1 c2)}}<img>{{else}}<img>{{/unless}}',
+    '<img class={{if condition "some-class"}}>',
+    '<img class={{if (or c1 c2) "some-class"}}>',
+    '<img class={{if (not (or c1 c2)) "some-class"}}>',
+    '<img class={{if (not c1 c2) "some-class"}}>',
+    '<img class={{if condition "some-class" "other-class"}}>',
+    '<img class={{if (or c1 c2) "some-class" "other-class"}}>',
+    '<img class={{unless condition "some-class"}}>',
+    '<img class={{unless (or c1 c2) "some-class"}}>',
+    '<img class={{unless (not c1 c2) "some-class"}}>',
+    '<img class={{unless condition "some-class" "other-class"}}>',
+    '<img class={{unless (or c1 c2) "some-class" "other-class"}}>',
+    '{{input class=(if condition "some-class")}}',
+    '{{input class=(if (or c1 c2) "some-class")}}',
+    '{{input class=(if (not (or c1 c2)) "some-class")}}',
+    '{{input class=(if (not c1 c2) "some-class")}}',
+    '{{input class=(if condition "some-class" "other-class")}}',
+    '{{input class=(if (or c1 c2) "some-class" "other-class")}}',
+    '{{input class=(unless condition "some-class")}}',
+    '{{input class=(unless (or c1 c2) "some-class")}}',
+    '{{input class=(unless condition "some-class" "other-class")}}',
+    '{{input class=(unless (or c1 c2) "some-class" "other-class")}}',
+    // simplifyHelpers: false allows nested not/eq helpers without error.
+    {
+      code: '{{#if (not (not c2))}}<img>{{/if}}',
+      options: [{ simplifyHelpers: false }],
+    },
+    {
+      code: '{{#if (not (eq c2))}}<img>{{/if}}',
+      options: [{ simplifyHelpers: false }],
+    },
+    // simplifyHelpers: false — if with nested fixable helpers is valid.
+    {
+      code: '<img class={{if (not (gte c 10)) "some-class"}}>',
+      options: [{ simplifyHelpers: false }],
+    },
+    {
+      code: '{{input class=(if (not (lte c 10)) "some-class" "other-class")}}',
+      options: [{ simplifyHelpers: false }],
+    },
+  ],
+  invalid: [
+    {
+      code: '{{#if (not condition)}}<img>{{/if}}',
+      output: '{{#unless condition}}<img>{{/unless}}',
+      errors: [{ message: 'Change `if (not condition)` to `unless condition`.' }],
+    },
+    {
+      code: '{{#if (not (not condition))}}<img>{{/if}}',
+      output: '{{#if condition}}<img>{{/if}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{#if (not (not c1 c2))}}<img>{{/if}}',
+      output: '{{#if (or c1 c2)}}<img>{{/if}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{#if (not (eq c1 c2))}}<img>{{/if}}',
+      output: '{{#if (not-eq c1 c2)}}<img>{{/if}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{#if (not condition)}}<img>{{else}}<input>{{/if}}',
+      output: '{{#if condition}}<input>{{else}}<img>{{/if}}',
+      errors: [
+        {
+          message:
+            'Change `{{if (not condition)}} ... {{else}} ... {{/if}}` to `{{if condition}} ... {{else}} ... {{/if}}`.',
+        },
+      ],
+    },
+    {
+      code: '{{#unless (not condition)}}<img>{{/unless}}',
+      output: '{{#if condition}}<img>{{/if}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{#unless (not (not condition))}}<img>{{/unless}}',
+      output: '{{#unless condition}}<img>{{/unless}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{#unless (not condition)}}<img>{{else}}<input>{{/unless}}',
+      output: '{{#if condition}}<img>{{else}}<input>{{/if}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{#unless (not (not-eq c1 c2))}}<img>{{else}}<input>{{/unless}}',
+      output: '{{#unless (eq c1 c2)}}<img>{{else}}<input>{{/unless}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{#unless (not condition)}}<img>{{else if (not condition)}}<input>{{/unless}}',
+      output: '{{#if condition}}<img>{{else if (not condition)}}<input>{{/if}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{#unless (not (not condition))}}<img>{{else if (not (not condition))}}<input>{{/unless}}',
+      output: '{{#unless condition}}<img>{{else if (not (not condition))}}<input>{{/unless}}',
+      errors: [
+        { message: 'Simplify unnecessary negation of helper.' },
+        { message: 'Simplify unnecessary negation of helper.' },
+      ],
+    },
+    {
+      code: '{{#unless (not (gt c 10))}}<img>{{else if (not (lt c 5))}}<input>{{/unless}}',
+      output: '{{#unless (lte c 10)}}<img>{{else if (not (lt c 5))}}<input>{{/unless}}',
+      errors: [
+        { message: 'Simplify unnecessary negation of helper.' },
+        { message: 'Simplify unnecessary negation of helper.' },
+      ],
+    },
+    {
+      code: '{{#unless (not condition)}}<img>{{else if (not condition)}}<input>{{else}}<hr>{{/unless}}',
+      output: '{{#if condition}}<img>{{else if (not condition)}}<input>{{else}}<hr>{{/if}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{#unless (not condition)}}<img>{{else if (not (not c1 c2))}}<input>{{else}}<hr>{{/unless}}',
+      output: '{{#if condition}}<img>{{else if (not (not c1 c2))}}<input>{{else}}<hr>{{/if}}',
+      errors: [
+        { message: 'Change `unless (not condition)` to `if condition`.' },
+        { message: 'Simplify unnecessary negation of helper.' },
+      ],
+    },
+    {
+      code: '{{#if condition}}{{else}}{{! some comment }}{{#if (not condition)}}<img>{{/if}}{{/if}}',
+      output:
+        '{{#if condition}}{{else}}{{! some comment }}{{#unless condition}}<img>{{/unless}}{{/if}}',
+      errors: [{ message: 'Change `if (not condition)` to `unless condition`.' }],
+    },
+    {
+      code: '{{#if condition}}{{else}}{{#if (not condition)}}<img>{{/if}}{{/if}}',
+      output: '{{#if condition}}{{else}}{{#unless condition}}<img>{{/unless}}{{/if}}',
+      errors: [{ message: 'Change `if (not condition)` to `unless condition`.' }],
+    },
+    {
+      code: '<img class={{if (not condition) "some-class"}}>',
+      output: '<img class={{unless condition "some-class"}}>',
+      errors: [{ message: 'Change `if (not condition)` to `unless condition`.' }],
+    },
+    {
+      code: '<img class={{if (not (gte c 10)) "some-class"}}>',
+      output: '<img class={{if (lt c 10) "some-class"}}>',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '<img class={{if (not condition) "some-class" "other-class"}}>',
+      output: '<img class={{if condition "other-class" "some-class"}}>',
+      errors: [
+        {
+          message:
+            'Change `{{if (not condition)}} ... {{else}} ... {{/if}}` to `{{if condition}} ... {{else}} ... {{/if}}`.',
+        },
+      ],
+    },
+    {
+      code: '<img class={{if (not (not condition)) "some-class" "other-class"}}>',
+      output: '<img class={{if condition "some-class" "other-class"}}>',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '<img class={{unless (not condition) "some-class"}}>',
+      output: '<img class={{if condition "some-class"}}>',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '<img class={{unless (not condition) "some-class" "other-class"}}>',
+      output: '<img class={{if condition "some-class" "other-class"}}>',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '<img class={{unless (not (not condition)) "some-class" "other-class"}}>',
+      output: '<img class={{unless condition "some-class" "other-class"}}>',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{input class=(if (not condition) "some-class")}}',
+      output: '{{input class=(unless condition "some-class")}}',
+      errors: [{ message: 'Change `if (not condition)` to `unless condition`.' }],
+    },
+    {
+      code: '{{input class=(if (not condition) "some-class" "other-class")}}',
+      output: '{{input class=(if condition "other-class" "some-class")}}',
+      errors: [
+        {
+          message:
+            'Change `{{if (not condition)}} ... {{else}} ... {{/if}}` to `{{if condition}} ... {{else}} ... {{/if}}`.',
+        },
+      ],
+    },
+    {
+      code: '{{input class=(if (not (lte c 10)) "some-class" "other-class")}}',
+      output: '{{input class=(if (gt c 10) "some-class" "other-class")}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+    {
+      code: '{{input class=(unless (not condition) "some-class")}}',
+      output: '{{input class=(if condition "some-class")}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{input class=(unless (not condition) "some-class" "other-class")}}',
+      output: '{{input class=(if condition "some-class" "other-class")}}',
+      errors: [{ message: 'Change `unless (not condition)` to `if condition`.' }],
+    },
+    {
+      code: '{{input class=(unless (not (not condition)) "some-class" "other-class")}}',
+      output: '{{input class=(unless condition "some-class" "other-class")}}',
+      errors: [{ message: 'Simplify unnecessary negation of helper.' }],
+    },
+
+    // ******************************************
+    // simplifyHelpers: true (explicit) — BlockStatement
+    // ******************************************
+    {
+      // if (not (not ...)) with simplifyHelpers: true
+      code: '{{#if (not (not condition))}}<img>{{/if}}',
+      output: '{{#if condition}}<img>{{/if}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      // if (not (eq ...)) with simplifyHelpers: true
+      code: '{{#if (not (eq c1 c2))}}<img>{{/if}}',
+      output: '{{#if (not-eq c1 c2)}}<img>{{/if}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      // unless (not (not-eq ...)) else with simplifyHelpers: true
+      code: '{{#unless (not (not-eq c1 c2))}}<img>{{else}}<input>{{/unless}}',
+      output: '{{#unless (eq c1 c2)}}<img>{{else}}<input>{{/unless}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      // unless ... else if with fixable helpers — two errors with simplifyHelpers: true
+      code: '{{#unless (not (gt c 10))}}<img>{{else if (not (lt c 5))}}<input>{{/unless}}',
+      output: '{{#unless (lte c 10)}}<img>{{else if (not (lt c 5))}}<input>{{/unless}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }, { messageId: 'negatedHelper' }],
+    },
+    {
+      // unless ... else if ... else — two errors with simplifyHelpers: true
+      code: '{{#unless (not condition)}}<img>{{else if (not (not c1 c2))}}<input>{{else}}<hr>{{/unless}}',
+      output: '{{#if condition}}<img>{{else if (not (not c1 c2))}}<input>{{else}}<hr>{{/if}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'useIf' }, { messageId: 'negatedHelper' }],
+    },
+
+    // ******************************************
+    // simplifyHelpers: true (explicit) — MustacheStatement
+    // ******************************************
+    {
+      // if (not (gte ...)) with simplifyHelpers: true
+      code: '<img class={{if (not (gte c 10)) "some-class"}}>',
+      output: '<img class={{if (lt c 10) "some-class"}}>',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+    {
+      // if (not (not ...)) else with simplifyHelpers: true
+      code: '<img class={{if (not (not condition)) "some-class" "other-class"}}>',
+      output: '<img class={{if condition "some-class" "other-class"}}>',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+
+    // ******************************************
+    // simplifyHelpers: true (explicit) — SubExpression
+    // ******************************************
+    {
+      // if (not (lte ...)) else with simplifyHelpers: true
+      code: '{{input class=(if (not (lte c 10)) "some-class" "other-class")}}',
+      output: '{{input class=(if (gt c 10) "some-class" "other-class")}}',
+      options: [{ simplifyHelpers: true }],
+      errors: [{ messageId: 'negatedHelper' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Restores `template-no-negated-condition`, which was accidentally deleted in 133a16fc ("Delete rules that never existed or have overlap with other rules").

The rule **does** exist in ember-template-lint as [`no-negated-condition`](https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/rules/no-negated-condition.js) — so the deletion premise was wrong for this one. 

Note: `template-no-negated-condition` and `template-no-negated-comparison` are **different rules** with opposite goals:
- `template-no-negated-condition` — port of upstream; flags `{{#if (not condition)}}`, suggests `{{#unless condition}}` instead (autofix)
- `template-no-negated-comparison` — unrelated; flags negated comparison helpers like `(not-eq ...)`

## Changes

- Restores `lib/rules/template-no-negated-condition.js` (295 lines, verbatim from pre-deletion)
- Restores `tests/lib/rules/template-no-negated-condition.js` (489 lines)
- Restores `docs/rules/template-no-negated-condition.md`
- Re-adds the README table entry

## Test plan

- [x] All 8940 existing tests still pass (`254 test files`)
- [x] Rule is correctly loaded via `requireindex`