### PR TITLE
BUGFIX: false positive: interactive flow content inside <details>

### DIFF
--- a/lib/rules/template-no-nested-interactive.js
+++ b/lib/rules/template-no-nested-interactive.js
@@ -45,19 +45,23 @@ function isMenuItemNode(node) {
   return getTextAttr(node, 'role') === 'menuitem';
 }
 
-function isSummaryFirstChildOfDetails(summaryNode, parentEntry) {
-  if (summaryNode.tag !== 'summary' || parentEntry.tag !== 'details') {
+function isAllowedDetailsChild(childNode, parentEntry) {
+  if (parentEntry.tag !== 'details') {
     return false;
   }
-  const parentNode = parentEntry.node;
-  const children = parentNode.children || [];
+  // Non-<summary> children are flow content in the disclosed panel — allowed.
+  // <summary> is only allowed as the first non-whitespace child of <details>.
+  if (childNode.tag !== 'summary') {
+    return true;
+  }
+  const children = parentEntry.node.children || [];
   const firstNonWhitespace = children.find((child) => {
     if (child.type === 'GlimmerTextNode') {
       return child.chars.trim().length > 0;
     }
     return true;
   });
-  return firstNonWhitespace === summaryNode;
+  return firstNonWhitespace === childNode;
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -208,8 +212,8 @@ module.exports = {
               });
             }
             parentEntry.interactiveChildCount++;
-          } else if (isSummaryFirstChildOfDetails(node, parentEntry)) {
-            // <summary> as first non-whitespace child of <details> is allowed
+          } else if (isAllowedDetailsChild(node, parentEntry)) {
+            // flow content in the disclosed panel, or <summary> as first child
           } else if (isMenuItemNode(parentEntry.node) && isMenuItemNode(node)) {
             // Nested menuitem nodes are valid (menu/sub-menu pattern)
           } else {

--- a/tests/lib/rules/template-no-nested-interactive.js
+++ b/tests/lib/rules/template-no-nested-interactive.js
@@ -61,6 +61,8 @@ ruleTester.run('template-no-nested-interactive', rule, {
     },
     '<template><details><summary>Details</summary>Something small enough to escape casual notice.</details></template>',
     '<template><details> <summary>Details</summary>Something small enough to escape casual notice.</details></template>',
+    '<template><details><summary>Advanced</summary><label for="x">Field</label><input id="x" /></details></template>',
+    '<template><details><summary>More</summary><div><button type="button">Action</button></div></details></template>',
     `<template>
     <ul role="menubar" aria-label="functions" id="appmenu">
       <li role="menuitem" aria-haspopup="true">
@@ -249,6 +251,8 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
     '<label><input></label>',
     '<details><summary>Details</summary>Something small enough to escape casual notice.</details>',
     '<details> <summary>Details</summary>Something small enough to escape casual notice.</details>',
+    '<details><summary>Advanced</summary><label for="x">Field</label><input id="x" /></details>',
+    '<details><summary>More</summary><div><button type="button">Action</button></div></details>',
     `
     <ul role="menubar" aria-label="functions" id="appmenu">
       <li role="menuitem" aria-haspopup="true">


### PR DESCRIPTION
- **Premise 1:** The [permitted content of `<details>` is "one `<summary>` element, followed by flow content"](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element) — see the [spec's own example](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element) mixing `<input>` and `<label>` as siblings of `<summary>`.
- **Premise 2:** [Flow content](https://html.spec.whatwg.org/multipage/dom.html#flow-content) includes `<label>`, `<input>`, `<button>`, `<form>`.
- **Conclusion:** Interactive content as a sibling of `<summary>` inside `<details>` is spec-conformant and should not be flagged.

Narrow fix: `<details>` stays in the interactive set, so the rule still flags:

- `<details>` inside another interactive element (e.g. `<button><details/></button>`)
- `<summary>` when it is **not** the first non-whitespace child of `<details>`

Only the case of "interactive element in the disclosed panel (sibling of `<summary>`)" is exempted — `<details>`'s own children other than `<summary>` no longer see `<details>` as an interactive ancestor.

Upstream `ember-template-lint@7.9.3` has the same false positive; fixing here is pragmatic since `ember-template-lint` is being de-emphasized.