### PR TITLE
BUGFIX: accept tabindex="-1" in template-require-aria-activedescendant-tabindex

### DIFF
--- a/docs/rules/template-require-aria-activedescendant-tabindex.md
+++ b/docs/rules/template-require-aria-activedescendant-tabindex.md
@@ -6,11 +6,11 @@
 
 <!-- end auto-generated rule header -->
 
-This rule requires all non-interactive HTML elements using the `aria-activedescendant` attribute to declare a `tabindex` of zero.
+This rule requires non-interactive HTML elements using the `aria-activedescendant` attribute to declare a `tabindex` of `0` or `-1`.
 
 The `aria-activedescendant` attribute identifies the active descendant element of a composite widget, textbox, group, or application with document focus. This attribute is placed on the container element of the input control, and its value is set to the ID of the active child element. This allows screen readers to communicate information about the currently active element as if it has focus, while actual focus of the DOM remains on the container element.
 
-Elements with `aria-activedescendant` must have a `tabindex` of zero in order to support keyboard navigation. Besides interactive elements, which are inherently keyboard-focusable, elements using the `aria-activedescendant` attribute must declare a `tabIndex` of zero with the `tabIndex` attribute.
+Elements with `aria-activedescendant` must be focusable to support keyboard navigation. `tabindex="0"` puts the element in the natural tab order; `tabindex="-1"` makes it focusable programmatically (e.g. via roving focus) but skips it in the tab order. Both are valid patterns for composite widgets — see the [W3C APG — Managing focus in composites using aria-activedescendant](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant).
 
 ## Examples
 
@@ -19,8 +19,8 @@ This rule **forbids** the following:
 ```gjs
 <template>
   <div aria-activedescendant='some-id'></div>
-  <div aria-activedescendant='some-id' tabindex='-1'></div>
-  <input aria-activedescendant={{some-id}} tabindex='-1' />
+  <div aria-activedescendant='some-id' tabindex='-2'></div>
+  <input aria-activedescendant={{some-id}} tabindex='-100' />
 </template>
 ```
 
@@ -32,9 +32,11 @@ This rule **allows** the following:
   <CustomComponent aria-activedescendant={{some-id}} />
   <CustomComponent aria-activedescendant={{some-id}} tabindex={{0}} />
   <div aria-activedescendant='some-id' tabindex='0'></div>
+  <div aria-activedescendant='some-id' tabindex='-1'></div>
   <input />
   <input aria-activedescendant={{some-id}} />
   <input aria-activedescendant={{some-id}} tabindex={{0}} />
+  <input aria-activedescendant={{some-id}} tabindex={{-1}} />
 </template>
 ```
 

--- a/lib/rules/template-require-aria-activedescendant-tabindex.js
+++ b/lib/rules/template-require-aria-activedescendant-tabindex.js
@@ -91,7 +91,7 @@ module.exports = {
 
         const tabindexValue = getTabindexNumericValue(tabindexAttr);
 
-        if (!Number.isFinite(tabindexValue) || tabindexValue < 0) {
+        if (!Number.isFinite(tabindexValue) || tabindexValue < -1) {
           context.report({
             node,
             messageId: 'missingTabindex',

--- a/tests/lib/rules/template-require-aria-activedescendant-tabindex.js
+++ b/tests/lib/rules/template-require-aria-activedescendant-tabindex.js
@@ -13,6 +13,12 @@ const validHbs = [
   '<CustomComponent aria-activedescendant="choice1" />',
   '<CustomComponent aria-activedescendant="option1" tabIndex="-1" />',
   '<CustomComponent aria-activedescendant={{foo}} tabindex={{bar}} />',
+  // tabindex="-1" is focusable-but-not-tabbable — the canonical pattern for
+  // composite widgets that manage focus via roving focus / aria-activedescendant.
+  // See W3C APG — https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant
+  '<div aria-activedescendant="option0" tabindex="-1"></div>',
+  '<div aria-activedescendant={{foo}} tabindex={{-1}}></div>',
+  '<button aria-activedescendant="x" tabindex="-1"></button>',
 ];
 
 const invalidHbs = [
@@ -27,11 +33,6 @@ const invalidHbs = [
     errors: [{ message: ERROR_MESSAGE }],
   },
   {
-    code: '<div aria-activedescendant={{foo}} tabindex={{-1}}></div>',
-    output: '<div aria-activedescendant={{foo}} tabindex="0"></div>',
-    errors: [{ message: ERROR_MESSAGE }],
-  },
-  {
     code: '<div aria-activedescendant="fixme" tabindex=-100></div>',
     output: '<div aria-activedescendant="fixme" tabindex="0"></div>',
     errors: [{ message: ERROR_MESSAGE }],
@@ -39,11 +40,6 @@ const invalidHbs = [
   {
     code: '<a aria-activedescendant="x"></a>',
     output: '<a aria-activedescendant="x" tabindex="0"></a>',
-    errors: [{ message: ERROR_MESSAGE }],
-  },
-  {
-    code: '<button aria-activedescendant="x" tabindex="-1"></button>',
-    output: '<button aria-activedescendant="x" tabindex="0"></button>',
     errors: [{ message: ERROR_MESSAGE }],
   },
 ];


### PR DESCRIPTION
- **Premise 1:** [`tabindex="0"` puts an element in the natural tab order; `tabindex="-1"` makes it programmatically focusable but skipped by Tab](https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute).
- **Premise 2:** The [W3C APG guidance for composites using `aria-activedescendant`](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_activedescendant) explicitly treats both values as valid — `-1` is the canonical choice for widgets managed via roving focus.
- **Conclusion:** `tabindex="-1"` on an element with `aria-activedescendant` should not be flagged. The current rule does flag it and autofixes to `tabindex="0"`, silently moving the element into the tab order.

Fix: extend the accepted range from `>= 0` to `>= -1`. Matches `eslint-plugin-jsx-a11y` (`aria-activedescendant-has-tabindex.js`: `if (tabIndex >= -1) return;`) and `eslint-plugin-lit-a11y`.

Three test cases moved from `invalid` to `valid`; rule doc updated to describe the new accepted range.

Upstream `ember-template-lint@7.9.3` has the same false positive.