### PR TITLE
feat: re-export hbs parser and document HBS flat-config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,36 @@ export default [
 
 `template-lint-migration` mirrors the ember-template-lint `recommended` preset.
 
+### Linting `.hbs` files
+
+ESLint flat config only picks up `.hbs` files when a `files` glob names them. Add a dedicated block so they route to the Handlebars parser:
+
+```js
+// eslint.config.mjs
+import { hbsParser, plugin as emberPlugin } from 'eslint-plugin-ember/recommended';
+
+export default [
+  // ...other blocks...
+  {
+    files: ['app/**/*.hbs'],
+    languageOptions: { parser: hbsParser },
+    plugins: { ember: emberPlugin },
+    rules: {
+      'ember/template-no-bare-strings': 'error',
+      // ...other template rules...
+    },
+  },
+];
+```
+
+Make sure no earlier `@typescript-eslint/parser` block's `files` glob reaches `.hbs` — narrow it to `['**/*.{js,ts,gjs,gts}']` (or similar). Flat config merges rules across every matching block, so even if our HBS block overrides the parser, type-info rules from a matching TS block still layer on and fail with errors like:
+
+> Parsing error: `…` was not found by the project service because the extension for the file (`.hbs`) is non-standard.
+
+or
+
+> Error while loading rule `@typescript-eslint/await-thenable`: You have used a rule which requires type information.
+
 ### Replacing `template-lint-disable` comments
 
 Inline disable directives need to be rewritten to ESLint's syntax, prefixed with `ember/template-`. For now, only two scopes are supported: the next line, or the rest of the file. For example, replace:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -224,7 +224,7 @@ module.exports = [
       'import/default': 'off',
       'import/no-named-as-default': 'off',
       'import/no-named-as-default-member': 'off',
-      'import/no-unresalved': 'off',
+      'import/no-unresolved': 'off',
       'import/no-missing-import': 'off',
 
       // vite config format does not match regex

--- a/lib/recommended.mjs
+++ b/lib/recommended.mjs
@@ -3,9 +3,11 @@ import baseRules from './recommended-rules.js';
 import gjsRules from './recommended-rules-gjs.js';
 import gtsRules from './recommended-rules-gts.js';
 import emberParser from 'ember-eslint-parser';
+import emberHbsParser from 'ember-eslint-parser/hbs';
 
 export const plugin = emberPlugin;
 export const parser = emberParser;
+export const hbsParser = emberHbsParser;
 
 export const base = {
   name: 'ember:base',
@@ -57,6 +59,7 @@ export default {
   // Helpful utility exports
   plugin,
   parser,
+  hbsParser,
   // Recommended config sets
   configs: {
     base,


### PR DESCRIPTION
## Summary

- Re-exports `hbsParser` as a named export from `eslint-plugin-ember/recommended` (alongside the existing `parser` for gjs/gts). Lets consumers set up `.hbs` linting without adding `ember-eslint-parser` as a direct devDep.
- Adds a "Linting `.hbs` files" subsection under "Migrating from ember-template-lint" with a ready-to-paste flat-config block and a warning about the rule-merging pitfall when a typescript-eslint shared config's blocks (e.g. `recommendedTypeChecked`) don't set their own `files` and therefore match `.hbs` alongside everything else.

## Motivation

A user migrating from `ember-template-lint` hit:

> Parsing error: `…` was not found by the project service because the extension for the file (`.hbs`) is non-standard.

and later:

> Error while loading rule `@typescript-eslint/await-thenable`: You have used a rule which requires type information.

Both errors come from `@typescript-eslint/parser`'s project service being applied to `.hbs` files via a broad shared-config block. The README didn't document the HBS flat-config wiring, so this was left for each consumer to figure out. This PR closes that gap.

## Test plan

- [x] `npx vitest run tests/recommended.js tests/plugin-exports.js tests/config-setup.js` — all pass
- [x] `import { hbsParser } from 'eslint-plugin-ember/recommended'` resolves and exposes `parseForESLint`
- [x] `npx markdownlint README.md` clean