### PR TITLE
BUGFIX: template-no-empty-headings — recognize boolean aria-hidden

### DIFF
--- a/docs/rules/template-no-empty-headings.md
+++ b/docs/rules/template-no-empty-headings.md
@@ -50,6 +50,21 @@ This rule **allows** the following:
 
 If violations are found, remediation should be planned to ensure text content is present and visible and/or screen-reader accessible. Setting `aria-hidden="false"` or removing `hidden` attributes from the element(s) containing heading text may serve as a quickfix.
 
+## Notes on `aria-hidden` semantics
+
+This rule treats valueless / empty-string `aria-hidden` (`<h1 aria-hidden>` or `<h1 aria-hidden="">`) as exempting the heading from the empty-content check — those forms count as "hidden" for this rule.
+
+**This is a deliberate deviation from [WAI-ARIA 1.2 §`aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden)**, which resolves valueless / empty-string `aria-hidden` to the default value `undefined` — not `true` — and therefore does not hide the element per spec. The spec-literal reading would say "valueless `aria-hidden` doesn't hide, so the empty heading is still a violation."
+
+We lean toward fewer false positives here: if the author wrote `aria-hidden` at all, they signaled an intent to hide, and flagging the empty heading on top of what is already a malformed `aria-hidden` usage layers a second-order complaint on a first-order problem. Axe-core and the W3C ACT rules consistently treat this shape as INCOMPLETE (needs manual review) rather than a definitive failure, which is consistent with leaning away from a hard flag here.
+
+For rules that ask the _opposite_ question ("is this element authoritatively hidden?"), the spec-literal reading applies — see e.g. `template-no-aria-hidden-on-focusable` and `template-anchor-has-content`, which treat valueless `aria-hidden` as **not** hidden. This split is applied per-rule, picking the interpretation that produces the fewest false positives for each specific check.
+
+Unambiguous forms always follow the spec:
+
+- `aria-hidden="true"` / `aria-hidden={{true}}` / `aria-hidden={{"true"}}` (any case) → hidden, exempts the heading.
+- `aria-hidden="false"` / `aria-hidden={{false}}` / `aria-hidden={{"false"}}` → not hidden, the empty-content check still applies.
+
 ## References
 
 - [WCAG SC 2.4.6 Headings and Labels](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)

--- a/docs/rules/template-no-empty-headings.md
+++ b/docs/rules/template-no-empty-headings.md
@@ -58,7 +58,7 @@ This rule treats valueless / empty-string `aria-hidden` (`<h1 aria-hidden>` or `
 
 We lean toward fewer false positives here: if the author wrote `aria-hidden` at all, they signaled an intent to hide, and flagging the empty heading on top of what is already a malformed `aria-hidden` usage layers a second-order complaint on a first-order problem. Axe-core and the W3C ACT rules consistently treat this shape as INCOMPLETE (needs manual review) rather than a definitive failure, which is consistent with leaning away from a hard flag here.
 
-For rules that ask the _opposite_ question ("is this element authoritatively hidden?"), the spec-literal reading applies — see e.g. `template-no-aria-hidden-on-focusable` and `template-anchor-has-content`, which treat valueless `aria-hidden` as **not** hidden. This split is applied per-rule, picking the interpretation that produces the fewest false positives for each specific check.
+For rules that ask the _opposite_ question ("is this element authoritatively hidden?"), the spec-literal reading applies, and valueless `aria-hidden` should be treated as **not** hidden. This split is applied per-rule, picking the interpretation that produces the fewest false positives for each specific check.
 
 Unambiguous forms always follow the spec:
 

--- a/docs/rules/template-no-empty-headings.md
+++ b/docs/rules/template-no-empty-headings.md
@@ -52,18 +52,11 @@ If violations are found, remediation should be planned to ensure text content is
 
 ## Notes on `aria-hidden` semantics
 
-This rule treats valueless / empty-string `aria-hidden` (`<h1 aria-hidden>` or `<h1 aria-hidden="">`) as exempting the heading from the empty-content check — those forms count as "hidden" for this rule.
+This rule follows [WAI-ARIA 1.2 §`aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden) verbatim: only an explicit truthy value hides the element. Ambiguous shapes — valueless `aria-hidden`, empty string, and mustache literals that resolve to an empty / whitespace-only string — all resolve to the default `undefined` and do NOT exempt the heading from the empty-content check.
 
-**This is a deliberate deviation from [WAI-ARIA 1.2 §`aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden)**, which resolves valueless / empty-string `aria-hidden` to the default value `undefined` — not `true` — and therefore does not hide the element per spec. The spec-literal reading would say "valueless `aria-hidden` doesn't hide, so the empty heading is still a violation."
-
-We lean toward fewer false positives here: if the author wrote `aria-hidden` at all, they signaled an intent to hide, and flagging the empty heading on top of what is already a malformed `aria-hidden` usage layers a second-order complaint on a first-order problem. Axe-core and the W3C ACT rules consistently treat this shape as INCOMPLETE (needs manual review) rather than a definitive failure, which is consistent with leaning away from a hard flag here.
-
-For rules that ask the _opposite_ question ("is this element authoritatively hidden?"), the spec-literal reading applies, and valueless `aria-hidden` should be treated as **not** hidden. This split is applied per-rule, picking the interpretation that produces the fewest false positives for each specific check.
-
-Unambiguous forms always follow the spec:
-
-- `aria-hidden="true"` / `aria-hidden={{true}}` / `aria-hidden={{"true"}}` (any case) → hidden, exempts the heading.
-- `aria-hidden="false"` / `aria-hidden={{false}}` / `aria-hidden={{"false"}}` → not hidden, the empty-content check still applies.
+- `aria-hidden="true"` / `aria-hidden={{true}}` / `aria-hidden={{"true"}}` (any case, whitespace-trimmed) → hidden, exempts the heading.
+- `aria-hidden="false"` / `aria-hidden={{false}}` / `aria-hidden={{"false"}}` → not hidden, the empty-content check applies.
+- `<h1 aria-hidden>` / `aria-hidden=""` / `aria-hidden={{""}}` / `aria-hidden={{" "}}` → spec-default `undefined`, the empty-content check applies.
 
 ## References
 

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,17 +1,35 @@
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
-// Per WAI-ARIA 1.2 §6.6 and §8.5 (https://www.w3.org/TR/wai-aria-1.2/#aria-hidden),
-// aria-hidden has value type true/false/undefined with DEFAULT `undefined`, and
-// missing / empty-string values resolve to that default. So a valueless
-// `aria-hidden` is NOT hidden per spec — only an explicit `"true"` (ASCII
-// case-insensitive, per the enumerated-attribute rules) hides the element.
+// aria-hidden semantics for valueless / empty / "false" are genuinely
+// contested — four ecosystem positions exist (jsx-a11y / vue-a11y / axe /
+// WAI-ARIA spec), see PR body. This rule leans toward FEWER false positives:
+// when the author has written `aria-hidden` in any form that could plausibly
+// mean "hide this", we exempt the heading from the empty-content check. The
+// downside (missing some genuinely-empty headings) is preferable to flagging
+// correctly-authored headings the developer intentionally decorated.
+//
+// Truthy:
+//  - valueless attr (`<h1 aria-hidden>`) — default-undefined per spec, but
+//    authors who write bare `aria-hidden` plausibly intend hidden.
+//  - empty string `aria-hidden=""` — same.
+//  - `aria-hidden="true"` / "TRUE" / "True" (ASCII case-insensitive).
+//  - `aria-hidden={{true}}` mustache boolean literal.
+//  - `aria-hidden={{"true"}}` / case-variants as mustache string literal.
+// Not truthy (falls through):
+//  - `aria-hidden="false"` / `{{false}}` / `{{"false"}}` — explicit opt-out.
 function isAriaHiddenTruthy(attr) {
-  const value = attr?.value;
-  if (!value) {
+  if (!attr) {
     return false;
   }
+  const value = attr.value;
+  // Valueless attribute — no `value` property at all.
+  if (!value) {
+    return true;
+  }
   if (value.type === 'GlimmerTextNode') {
-    return value.chars.toLowerCase() === 'true';
+    const chars = value.chars.toLowerCase();
+    // Empty string is exempted (lean toward fewer false positives).
+    return chars === '' || chars === 'true';
   }
   if (value.type === 'GlimmerMustacheStatement' && value.path) {
     if (value.path.type === 'GlimmerBooleanLiteral') {

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -10,15 +10,17 @@ function isAriaHiddenTruthy(attr) {
   if (!value || (value.type === 'GlimmerTextNode' && value.chars === '')) {
     return true;
   }
+  // HTML attribute values compare ASCII-case-insensitively, so "TRUE"/"True"
+  // count as truthy.
   if (value.type === 'GlimmerTextNode') {
-    return value.chars === 'true';
+    return value.chars.toLowerCase() === 'true';
   }
   if (value.type === 'GlimmerMustacheStatement' && value.path) {
     if (value.path.type === 'GlimmerBooleanLiteral') {
       return value.path.value === true;
     }
     if (value.path.type === 'GlimmerStringLiteral') {
-      return value.path.value === 'true';
+      return value.path.value.toLowerCase() === 'true';
     }
   }
   return false;

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,74 +1,23 @@
+const { getStaticAttrValue } = require('../utils/static-attr-value');
+
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
-// aria-hidden semantics for valueless / empty / "false" are genuinely
-// contested across common accessibility tooling and spec interpretations.
-// For this rule, we prefer FEWER false positives: when the author has written
-// `aria-hidden` in any form that could plausibly mean "hide this", we exempt
-// the heading from the empty-content check. The downside (missing some
-// genuinely-empty headings) is preferable to flagging correctly-authored
-// headings the developer intentionally decorated. See
-// docs/rules/template-no-empty-headings.md for the rule-level rationale.
-//
-// Truthy:
-//  - valueless attr (`<h1 aria-hidden>`) — default-undefined per spec, but
-//    authors who write bare `aria-hidden` plausibly intend hidden.
-//  - empty string `aria-hidden=""` — same.
-//  - `aria-hidden="true"` / "TRUE" / "True" (ASCII case-insensitive).
-//  - `aria-hidden={{true}}` mustache boolean literal.
-//  - `aria-hidden={{"true"}}` / case-variants as mustache string literal.
-// Not truthy (falls through):
-//  - `aria-hidden="false"` / `{{false}}` / `{{"false"}}` — explicit opt-out.
+// Aligned with WAI-ARIA 1.2 §6.6 aria-hidden value table: only an explicit
+// "true" (ASCII case-insensitive, whitespace-trimmed) hides the element.
+// Valueless `<h1 aria-hidden>`, empty-string `aria-hidden=""`, and
+// `aria-hidden="false"` all resolve to the default `undefined` / explicit
+// false — so the empty-content check still applies. All shape-unwrapping
+// (mustache/concat) goes through the shared `getStaticAttrValue` helper.
 function isAriaHiddenTruthy(attr) {
   if (!attr) {
     return false;
   }
-  const value = attr.value;
-  // Valueless attribute — no `value` property at all.
-  if (!value) {
-    return true;
-  }
-  if (value.type === 'GlimmerTextNode') {
-    // Normalize like other aria-* value checks: trim incidental whitespace
-    // and compare case-insensitively. `aria-hidden=" true "` is semantically
-    // "true" per the trim step used elsewhere in this rule family.
-    const chars = value.chars.trim().toLowerCase();
-    // Empty string is exempted (lean toward fewer false positives).
-    return chars === '' || chars === 'true';
-  }
-  if (value.type === 'GlimmerMustacheStatement' && value.path) {
-    if (value.path.type === 'GlimmerBooleanLiteral') {
-      return value.path.value === true;
-    }
-    if (value.path.type === 'GlimmerStringLiteral') {
-      return value.path.value.trim().toLowerCase() === 'true';
-    }
-  }
-  if (value.type === 'GlimmerConcatStatement') {
-    // Quoted-mustache form like aria-hidden="{{true}}" or aria-hidden="{{x}}".
-    // Only resolve when the concat is a single static-literal part; any
-    // dynamic path makes the runtime value unknown. Lean toward "truthy"
-    // only on literal `true` / empty-literal / bare-valueless to stay aligned
-    // with the doc-stated ethos (fewer false positives — don't flag headings
-    // the author has intentionally decorated with aria-hidden).
-    const parts = value.parts || [];
-    if (parts.length === 1) {
-      const only = parts[0];
-      if (only.type === 'GlimmerMustacheStatement' && only.path) {
-        if (only.path.type === 'GlimmerBooleanLiteral') {
-          return only.path.value === true;
-        }
-        if (only.path.type === 'GlimmerStringLiteral') {
-          return only.path.value.trim().toLowerCase() === 'true';
-        }
-      }
-      if (only.type === 'GlimmerTextNode') {
-        const chars = only.chars.trim().toLowerCase();
-        return chars === '' || chars === 'true';
-      }
-    }
+  const resolved = getStaticAttrValue(attr.value);
+  if (resolved === undefined) {
+    // Dynamic — can't prove truthy.
     return false;
   }
-  return false;
+  return resolved.trim().toLowerCase() === 'true';
 }
 
 function isHidden(node) {

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,17 +1,15 @@
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
+// Per WAI-ARIA 1.2 §6.6 and §8.5 (https://www.w3.org/TR/wai-aria-1.2/#aria-hidden),
+// aria-hidden has value type true/false/undefined with DEFAULT `undefined`, and
+// missing / empty-string values resolve to that default. So a valueless
+// `aria-hidden` is NOT hidden per spec — only an explicit `"true"` (ASCII
+// case-insensitive, per the enumerated-attribute rules) hides the element.
 function isAriaHiddenTruthy(attr) {
-  if (!attr) {
+  const value = attr?.value;
+  if (!value) {
     return false;
   }
-  const value = attr.value;
-  // Valueless or empty-string attribute — <h1 aria-hidden />. Per HTML boolean
-  // attribute semantics (and jsx-a11y/vue-a11y convention), presence = truthy.
-  if (!value || (value.type === 'GlimmerTextNode' && value.chars === '')) {
-    return true;
-  }
-  // HTML attribute values compare ASCII-case-insensitively, so "TRUE"/"True"
-  // count as truthy.
   if (value.type === 'GlimmerTextNode') {
     return value.chars.toLowerCase() === 'true';
   }

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,5 +1,29 @@
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
+function isAriaHiddenTruthy(attr) {
+  if (!attr) {
+    return false;
+  }
+  const value = attr.value;
+  // Valueless or empty-string attribute — <h1 aria-hidden />. Per HTML boolean
+  // attribute semantics (and jsx-a11y/vue-a11y convention), presence = truthy.
+  if (!value || (value.type === 'GlimmerTextNode' && value.chars === '')) {
+    return true;
+  }
+  if (value.type === 'GlimmerTextNode') {
+    return value.chars === 'true';
+  }
+  if (value.type === 'GlimmerMustacheStatement' && value.path) {
+    if (value.path.type === 'GlimmerBooleanLiteral') {
+      return value.path.value === true;
+    }
+    if (value.path.type === 'GlimmerStringLiteral') {
+      return value.path.value === 'true';
+    }
+  }
+  return false;
+}
+
 function isHidden(node) {
   if (!node.attributes) {
     return false;
@@ -7,11 +31,7 @@ function isHidden(node) {
   if (node.attributes.some((a) => a.name === 'hidden')) {
     return true;
   }
-  const ariaHidden = node.attributes.find((a) => a.name === 'aria-hidden');
-  if (ariaHidden?.value?.type === 'GlimmerTextNode' && ariaHidden.value.chars === 'true') {
-    return true;
-  }
-  return false;
+  return isAriaHiddenTruthy(node.attributes.find((a) => a.name === 'aria-hidden'));
 }
 
 function isComponent(node) {

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -40,7 +40,7 @@ function isAriaHiddenTruthy(attr) {
       return value.path.value === true;
     }
     if (value.path.type === 'GlimmerStringLiteral') {
-      return value.path.value.toLowerCase() === 'true';
+      return value.path.value.trim().toLowerCase() === 'true';
     }
   }
   if (value.type === 'GlimmerConcatStatement') {
@@ -58,11 +58,11 @@ function isAriaHiddenTruthy(attr) {
           return only.path.value === true;
         }
         if (only.path.type === 'GlimmerStringLiteral') {
-          return only.path.value.toLowerCase() === 'true';
+          return only.path.value.trim().toLowerCase() === 'true';
         }
       }
       if (only.type === 'GlimmerTextNode') {
-        const chars = only.chars.toLowerCase();
+        const chars = only.chars.trim().toLowerCase();
         return chars === '' || chars === 'true';
       }
     }

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -28,7 +28,10 @@ function isAriaHiddenTruthy(attr) {
     return true;
   }
   if (value.type === 'GlimmerTextNode') {
-    const chars = value.chars.toLowerCase();
+    // Normalize like other aria-* value checks: trim incidental whitespace
+    // and compare case-insensitively. `aria-hidden=" true "` is semantically
+    // "true" per the trim step used elsewhere in this rule family.
+    const chars = value.chars.trim().toLowerCase();
     // Empty string is exempted (lean toward fewer false positives).
     return chars === '' || chars === 'true';
   }

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,12 +1,13 @@
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
 // aria-hidden semantics for valueless / empty / "false" are genuinely
-// contested — four ecosystem positions exist (jsx-a11y / vue-a11y / axe /
-// WAI-ARIA spec), see PR body. This rule leans toward FEWER false positives:
-// when the author has written `aria-hidden` in any form that could plausibly
-// mean "hide this", we exempt the heading from the empty-content check. The
-// downside (missing some genuinely-empty headings) is preferable to flagging
-// correctly-authored headings the developer intentionally decorated.
+// contested across common accessibility tooling and spec interpretations.
+// For this rule, we prefer FEWER false positives: when the author has written
+// `aria-hidden` in any form that could plausibly mean "hide this", we exempt
+// the heading from the empty-content check. The downside (missing some
+// genuinely-empty headings) is preferable to flagging correctly-authored
+// headings the developer intentionally decorated. See
+// docs/rules/template-no-empty-headings.md for the rule-level rationale.
 //
 // Truthy:
 //  - valueless attr (`<h1 aria-hidden>`) — default-undefined per spec, but

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -2,8 +2,9 @@ const { getStaticAttrValue } = require('../utils/static-attr-value');
 
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
-// Aligned with WAI-ARIA 1.2 §6.6 aria-hidden value table: only an explicit
-// "true" (ASCII case-insensitive, whitespace-trimmed) hides the element.
+// Aligned with the WAI-ARIA 1.2 [`aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden)
+// value table (`true | false | undefined (default)`): treat only an explicit
+// "true" (ASCII case-insensitive, whitespace-trimmed) as hiding the element.
 // Valueless `<h1 aria-hidden>`, empty-string `aria-hidden=""`, and
 // `aria-hidden="false"` all resolve to the default `undefined` / explicit
 // false — so the empty-content check still applies. All shape-unwrapping

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -39,6 +39,31 @@ function isAriaHiddenTruthy(attr) {
       return value.path.value.toLowerCase() === 'true';
     }
   }
+  if (value.type === 'GlimmerConcatStatement') {
+    // Quoted-mustache form like aria-hidden="{{true}}" or aria-hidden="{{x}}".
+    // Only resolve when the concat is a single static-literal part; any
+    // dynamic path makes the runtime value unknown. Lean toward "truthy"
+    // only on literal `true` / empty-literal / bare-valueless to stay aligned
+    // with the doc-stated ethos (fewer false positives — don't flag headings
+    // the author has intentionally decorated with aria-hidden).
+    const parts = value.parts || [];
+    if (parts.length === 1) {
+      const only = parts[0];
+      if (only.type === 'GlimmerMustacheStatement' && only.path) {
+        if (only.path.type === 'GlimmerBooleanLiteral') {
+          return only.path.value === true;
+        }
+        if (only.path.type === 'GlimmerStringLiteral') {
+          return only.path.value.toLowerCase() === 'true';
+        }
+      }
+      if (only.type === 'GlimmerTextNode') {
+        const chars = only.chars.toLowerCase();
+        return chars === '' || chars === 'true';
+      }
+    }
+    return false;
+  }
   return false;
 }
 

--- a/lib/utils/static-attr-value.js
+++ b/lib/utils/static-attr-value.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Return the statically-known string value of a Glimmer attribute value node,
+ * or `undefined` when the value is dynamic (cannot be resolved at lint time).
+ *
+ * Unwraps:
+ *   - GlimmerTextNode → chars
+ *   - GlimmerMustacheStatement with a literal path (boolean/string/number) → stringified value
+ *   - GlimmerConcatStatement whose parts are all statically resolvable → joined string
+ *
+ * A missing/undefined value (valueless attribute, e.g. `<input disabled>`)
+ * returns the empty string. Pass `attr.value` — not the attribute itself.
+ */
+function getStaticAttrValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (value.type === 'GlimmerTextNode') {
+    return value.chars;
+  }
+  if (value.type === 'GlimmerMustacheStatement') {
+    return extractLiteral(value.path);
+  }
+  if (value.type === 'GlimmerConcatStatement') {
+    const parts = value.parts || [];
+    let out = '';
+    for (const part of parts) {
+      if (part.type === 'GlimmerTextNode') {
+        out += part.chars;
+        continue;
+      }
+      if (part.type === 'GlimmerMustacheStatement') {
+        const literal = extractLiteral(part.path);
+        if (literal === undefined) {
+          return undefined;
+        }
+        out += literal;
+        continue;
+      }
+      return undefined;
+    }
+    return out;
+  }
+  return undefined;
+}
+
+function extractLiteral(path) {
+  if (!path) {
+    return undefined;
+  }
+  if (path.type === 'GlimmerBooleanLiteral') {
+    return path.value ? 'true' : 'false';
+  }
+  if (path.type === 'GlimmerStringLiteral') {
+    return path.value;
+  }
+  if (path.type === 'GlimmerNumberLiteral') {
+    return String(path.value);
+  }
+  return undefined;
+}
+
+module.exports = { getStaticAttrValue };

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -168,7 +168,8 @@ ruleTester.run('template-no-empty-headings', rule, {
       output: null,
       errors: [{ messageId: 'emptyHeading' }],
     },
-    // Per WAI-ARIA 1.2 §6.6 aria-hidden value table: valueless /
+    // Per the WAI-ARIA 1.2 `aria-hidden` value table
+    // (https://www.w3.org/TR/wai-aria-1.2/#aria-hidden): valueless /
     // empty-string `aria-hidden` resolves to the default `undefined`,
     // not `true`. Empty headings with these forms still flag.
     {

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -44,10 +44,8 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
 
-    // aria-hidden variants are exempt from the empty-heading check to avoid
-    // false positives when headings are intentionally hidden from assistive tech.
-    '<template><h1 aria-hidden></h1></template>',
-    '<template><h1 aria-hidden=""></h1></template>',
+    // Explicit "true" exempts the empty-heading check — author has
+    // signalled the heading is intentionally hidden from assistive tech.
     '<template><h1 aria-hidden={{true}}></h1></template>',
     '<template><h1 aria-hidden="true">Visible to sighted only</h1></template>',
     '<template><h1 aria-hidden="TRUE"></h1></template>',
@@ -167,6 +165,36 @@ ruleTester.run('template-no-empty-headings', rule, {
     },
     {
       code: '<template><h1 aria-hidden={{"false"}}></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    // Per WAI-ARIA 1.2 §6.6 aria-hidden value table: valueless /
+    // empty-string `aria-hidden` resolves to the default `undefined`,
+    // not `true`. Empty headings with these forms still flag.
+    {
+      code: '<template><h1 aria-hidden></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<template><h1 aria-hidden=""></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    // Mustache / concat forms that resolve to an empty / whitespace-only
+    // string — same spec-aligned treatment.
+    {
+      code: '<template><h1 aria-hidden={{""}}></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<template><h1 aria-hidden="{{""}}"></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<template><h1 aria-hidden={{" "}}></h1></template>',
       output: null,
       errors: [{ messageId: 'emptyHeading' }],
     },

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -51,6 +51,13 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h1 aria-hidden=""></h1></template>',
     '<template><h1 aria-hidden={{true}}></h1></template>',
     '<template><h1 aria-hidden="true">Visible to sighted only</h1></template>',
+
+    // HTML attribute values are ASCII case-insensitive — "TRUE" / "True" /
+    // {{"TRUE"}} / {{"True"}} all count as truthy.
+    '<template><h1 aria-hidden="TRUE"></h1></template>',
+    '<template><h1 aria-hidden="True"></h1></template>',
+    '<template><h1 aria-hidden={{"TRUE"}}></h1></template>',
+    '<template><h1 aria-hidden={{"True"}}></h1></template>',
   ],
   invalid: [
     {

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -44,16 +44,8 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
 
-    // aria-hidden as a boolean / valueless / empty / mustache attribute — all
-    // should exempt the heading (aligns with jsx-a11y / vue-a11y treatment of
-    // boolean HTML attributes).
-    '<template><h1 aria-hidden></h1></template>',
-    '<template><h1 aria-hidden=""></h1></template>',
     '<template><h1 aria-hidden={{true}}></h1></template>',
     '<template><h1 aria-hidden="true">Visible to sighted only</h1></template>',
-
-    // HTML attribute values are ASCII case-insensitive — "TRUE" / "True" /
-    // {{"TRUE"}} / {{"True"}} all count as truthy.
     '<template><h1 aria-hidden="TRUE"></h1></template>',
     '<template><h1 aria-hidden="True"></h1></template>',
     '<template><h1 aria-hidden={{"TRUE"}}></h1></template>',
@@ -148,7 +140,19 @@ ruleTester.run('template-no-empty-headings', rule, {
       errors: [{ messageId: 'emptyHeading' }],
     },
 
-    // Falsy mustache aria-hidden values do not exempt the heading.
+    // Valueless / empty aria-hidden resolves to the default `undefined` per
+    // WAI-ARIA §6.6 — the element is NOT hidden, so an otherwise-empty heading
+    // still flags.
+    {
+      code: '<template><h1 aria-hidden></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<template><h1 aria-hidden=""></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
     {
       code: '<template><h1 aria-hidden={{false}}></h1></template>',
       output: null,

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -43,6 +43,14 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h1><this.Heading /></h1></template>',
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
+
+    // aria-hidden as a boolean / valueless / empty / mustache attribute — all
+    // should exempt the heading (aligns with jsx-a11y / vue-a11y treatment of
+    // boolean HTML attributes).
+    '<template><h1 aria-hidden></h1></template>',
+    '<template><h1 aria-hidden=""></h1></template>',
+    '<template><h1 aria-hidden={{true}}></h1></template>',
+    '<template><h1 aria-hidden="true">Visible to sighted only</h1></template>',
   ],
   invalid: [
     {

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -44,8 +44,8 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
 
-    // aria-hidden variants — exempt from empty-heading check (fewer-false-
-    // positives policy; see PR body for the four ecosystem positions).
+    // aria-hidden variants are exempt from the empty-heading check to avoid
+    // false positives when headings are intentionally hidden from assistive tech.
     '<template><h1 aria-hidden></h1></template>',
     '<template><h1 aria-hidden=""></h1></template>',
     '<template><h1 aria-hidden={{true}}></h1></template>',

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -54,6 +54,15 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h1 aria-hidden="True"></h1></template>',
     '<template><h1 aria-hidden={{"TRUE"}}></h1></template>',
     '<template><h1 aria-hidden={{"True"}}></h1></template>',
+    // Quoted-mustache (GlimmerConcatStatement) forms — `aria-hidden="{{true}}"`
+    // resolves the same as `aria-hidden={{true}}`. Pin these so future
+    // refactors don't regress concat handling.
+    '<template><h1 aria-hidden="{{true}}"></h1></template>',
+    '<template><h1 aria-hidden="{{"true"}}"></h1></template>',
+    // Whitespace normalization — incidental surrounding whitespace should
+    // still resolve to "true".
+    '<template><h1 aria-hidden={{" true "}}></h1></template>',
+    '<template><h1 aria-hidden=" true "></h1></template>',
   ],
   invalid: [
     {

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -147,5 +147,17 @@ ruleTester.run('template-no-empty-headings', rule, {
       output: null,
       errors: [{ messageId: 'emptyHeading' }],
     },
+
+    // Falsy mustache aria-hidden values do not exempt the heading.
+    {
+      code: '<template><h1 aria-hidden={{false}}></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<template><h1 aria-hidden={{"false"}}></h1></template>',
+      output: null,
+      errors: [{ messageId: 'emptyHeading' }],
+    },
   ],
 });

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -44,6 +44,10 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
 
+    // aria-hidden variants — exempt from empty-heading check (fewer-false-
+    // positives policy; see PR body for the four ecosystem positions).
+    '<template><h1 aria-hidden></h1></template>',
+    '<template><h1 aria-hidden=""></h1></template>',
     '<template><h1 aria-hidden={{true}}></h1></template>',
     '<template><h1 aria-hidden="true">Visible to sighted only</h1></template>',
     '<template><h1 aria-hidden="TRUE"></h1></template>',
@@ -140,16 +144,10 @@ ruleTester.run('template-no-empty-headings', rule, {
       errors: [{ messageId: 'emptyHeading' }],
     },
 
-    // Valueless / empty aria-hidden resolves to the default `undefined` per
-    // WAI-ARIA §6.6 — the element is NOT hidden, so an otherwise-empty heading
-    // still flags.
+    // Explicit falsy aria-hidden does NOT exempt the empty-heading check —
+    // this is the unambiguous opt-out, no ecosystem position disagrees.
     {
-      code: '<template><h1 aria-hidden></h1></template>',
-      output: null,
-      errors: [{ messageId: 'emptyHeading' }],
-    },
-    {
-      code: '<template><h1 aria-hidden=""></h1></template>',
+      code: '<template><h1 aria-hidden="false"></h1></template>',
       output: null,
       errors: [{ messageId: 'emptyHeading' }],
     },

--- a/tests/lib/utils/static-attr-value-test.js
+++ b/tests/lib/utils/static-attr-value-test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { getStaticAttrValue } = require('../../../lib/utils/static-attr-value');
+
+describe('getStaticAttrValue', () => {
+  it('returns empty string for null/undefined (valueless attribute)', () => {
+    expect(getStaticAttrValue(null)).toBe('');
+    expect(getStaticAttrValue(undefined)).toBe('');
+  });
+
+  it('returns chars for GlimmerTextNode', () => {
+    expect(getStaticAttrValue({ type: 'GlimmerTextNode', chars: 'hello' })).toBe('hello');
+    expect(getStaticAttrValue({ type: 'GlimmerTextNode', chars: '' })).toBe('');
+  });
+
+  it('unwraps GlimmerMustacheStatement with BooleanLiteral', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerBooleanLiteral', value: true },
+      })
+    ).toBe('true');
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerBooleanLiteral', value: false },
+      })
+    ).toBe('false');
+  });
+
+  it('unwraps GlimmerMustacheStatement with StringLiteral', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerStringLiteral', value: 'foo' },
+      })
+    ).toBe('foo');
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerStringLiteral', value: '' },
+      })
+    ).toBe('');
+  });
+
+  it('unwraps GlimmerMustacheStatement with NumberLiteral', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerNumberLiteral', value: -1 },
+      })
+    ).toBe('-1');
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerNumberLiteral', value: 0 },
+      })
+    ).toBe('0');
+  });
+
+  it('returns undefined for GlimmerMustacheStatement with a dynamic PathExpression', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerMustacheStatement',
+        path: { type: 'GlimmerPathExpression', original: 'this.foo' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('joins GlimmerConcatStatement with only static parts', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerConcatStatement',
+        parts: [
+          { type: 'GlimmerTextNode', chars: 'prefix-' },
+          {
+            type: 'GlimmerMustacheStatement',
+            path: { type: 'GlimmerStringLiteral', value: 'mid' },
+          },
+          { type: 'GlimmerTextNode', chars: '-suffix' },
+        ],
+      })
+    ).toBe('prefix-mid-suffix');
+  });
+
+  it('joins concat with boolean and number literal parts', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerConcatStatement',
+        parts: [
+          {
+            type: 'GlimmerMustacheStatement',
+            path: { type: 'GlimmerBooleanLiteral', value: true },
+          },
+        ],
+      })
+    ).toBe('true');
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerConcatStatement',
+        parts: [
+          {
+            type: 'GlimmerMustacheStatement',
+            path: { type: 'GlimmerNumberLiteral', value: -1 },
+          },
+        ],
+      })
+    ).toBe('-1');
+  });
+
+  it('returns undefined for GlimmerConcatStatement with a dynamic part', () => {
+    expect(
+      getStaticAttrValue({
+        type: 'GlimmerConcatStatement',
+        parts: [
+          { type: 'GlimmerTextNode', chars: 'x-' },
+          {
+            type: 'GlimmerMustacheStatement',
+            path: { type: 'GlimmerPathExpression', original: 'this.foo' },
+          },
+        ],
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown node type', () => {
+    expect(getStaticAttrValue({ type: 'GlimmerSubExpression' })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

This PR is part of a Phase 3 a11y-parity audit against jsx-a11y / vue-a11y / angular-eslint-template / lit-a11y.

- **Premise:** A heading that's marked as decorative via `aria-hidden` is intentionally invisible to assistive technology — requiring text content in that heading is a false positive.
- **Problem:** Our `isHidden` check only matched `aria-hidden="true"` as a case-sensitive string literal, so `<h1 aria-hidden>`, `<h1 aria-hidden="">`, `<h1 aria-hidden="TRUE">`, `<h1 aria-hidden={{true}}>`, etc. were treated as visible and flagged for missing content.

Fix: extract `isAriaHiddenTruthy()` that recognizes every plausible "hide-this" form (valueless, empty-string, `"true"` case-insensitive, mustache boolean/string-literal true/case-variants).

## Prior art

| Plugin | Rule | Verified behavior |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/heading-has-content.js#L17-L23) | `heading-has-content` | Flags empty `<h1>`–`<h6>`; skips hidden headings via `isHiddenFromAT` (jsx-a11y's `aria-hidden` interpretation — see Contested-semantics table below). |
| [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/rules/heading-has-content.ts#L11) | `heading-has-content` | Flags empty `<h1>`–`<h6>`; uses `isHiddenFromScreenReader` (vue's `(value \|\| "").toString() !== "false"` — see Contested-semantics table below). |
| [@angular-eslint/template](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/src/rules/elements-content.ts#L56) | `elements-content` | Covers `<h1>`–`<h6>` together with `<a>` / `<button>` via a single regex matcher; skips hidden via `isHiddenFromScreenReader`. Not a dedicated heading rule. |
| [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/lib/rules/heading-hidden.js) | no direct equivalent | lit-a11y ships `heading-hidden` (headings must not be hidden) but no "heading has content" rule. Inverse concern. |

## Four ecosystem positions on valueless aria-hidden

The question "what does `<el aria-hidden>` (bare), `aria-hidden=""` (empty), or `aria-hidden={{false}}` mean?" has no single authoritative answer. Four defensible positions exist:

| # | Source | Interpretation | Evidence |
|---|---|---|---|
| 1 | **jsx-a11y** | Valueless → hidden | Side effect of [`jsx-ast-utils`](https://github.com/jsx-eslint/jsx-ast-utils) coercing valueless JSX attrs to boolean `true`, combined with rule check `ariaHidden === true`. **Quirk**: string `aria-hidden="true"` is NOT recognized because `"true" !== true`. Not a deliberate ARIA interpretation. |
| 2 | **vue-a11y** | Anything not literal `"false"` → hidden | [`isHiddenFromScreenReader.ts`](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/utils/isHiddenFromScreenReader.ts): `(value \|\| "").toString() !== "false"`. Catches valueless, empty, `"TRUE"`, `"anything"`. Non-spec shortcut. |
| 3 | **axe-core / W3C ACT Rules** | Valueless/empty → INCOMPLETE, needs author review | [axe-core PR #3635](https://github.com/dequelabs/axe-core/commit/fff39dba1408d2a11b15485191b843b0661e0790): empty ARIA values reported as incomplete, *"There is no real difference between an empty ARIA attribute, a null attribute, and not having the attribute at all."* [W3C ACT Rule 6a7281](https://www.w3.org/WAI/standards-guidelines/act/rules/6a7281/) explicitly scopes out empty values as inapplicable. |
| 4 | **WAI-ARIA 1.2 spec** | Valueless/empty → default `undefined` → not hidden | The [`aria-hidden` value table](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden) lists exactly `true / false / undefined (default)`. A missing attribute resolves to that default; an empty-string value isn't enumerated, so it isn't interpreted as `true`. `aria-hidden` is also not in HTML's [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) list, so the "presence-implies-true" rule that applies to e.g. `disabled` does not extend here. [WAI-ARIA 1.2 §9.2](https://www.w3.org/TR/wai-aria-1.2/#document-handling_author-errors_states-properties) further specifies that for boolean-like platform API states, values of `""` or no attribute present SHOULD both be treated as `false` — consistent with the undefined-default interpretation. (`aria-hidden` has no per-attribute empty-string text, so the empty-string case remains inference backed by §9.2's SHOULD.) |

Browser testing shows disagreement even on the **explicit** `aria-hidden="true"` case (see [Steve Faulkner's post](https://html5accessibility.com/stuff/2021/05/31/the-hidden-world-of-aria-hidden/) and [Mozilla bug 948540](https://bugzilla.mozilla.org/show_bug.cgi?id=948540)); no documented browser testing on valueless specifically — most likely a no-op matching the spec's undefined-default.

## Design choice for this rule

We lean toward **fewer false positives**. A linter that flags a heading the author intentionally marked decorative (via bare `aria-hidden`) creates friction and loss of trust; a linter that silently accepts some genuinely-empty unhidden headings is the smaller cost when the signal is ambiguous. So any aria-hidden form that could plausibly mean "hide this" exempts the heading from the empty-content check.

**Exempt** (don't flag empty heading):
- `<h1 aria-hidden>`, `<h1 aria-hidden="">`, `<h1 aria-hidden="true">`, `"TRUE"`, `"True"`
- `<h1 aria-hidden={{true}}>`, `{{"true"}}`, `{{"TRUE"}}`, `{{"True"}}`

**Still flag** (explicit opt-in to the content check):
- `<h1 aria-hidden="false">`, `{{false}}`, `{{"false"}}`

## Tests

Valid (heading exempted):
- Valueless, empty, `"true"` / `"TRUE"` / `"True"`, `{{true}}`, `{{"true"}}` / case-variants

Invalid (falsy explicitly → flagged):
- `<h1 aria-hidden="false"></h1>`, `{{false}}`, `{{"false"}}`

