### PR TITLE
BUGFIX: template-require-media-caption — compare kind="captions" case-insensitively

### DIFF
--- a/lib/rules/template-require-media-caption.js
+++ b/lib/rules/template-require-media-caption.js
@@ -74,7 +74,7 @@ module.exports = {
           }
 
           if (kindAttr.value?.type === 'GlimmerTextNode') {
-            return kindAttr.value.chars === 'captions';
+            return kindAttr.value.chars.toLowerCase() === 'captions';
           }
 
           return false;

--- a/tests/lib/rules/template-require-media-caption.js
+++ b/tests/lib/rules/template-require-media-caption.js
@@ -31,6 +31,10 @@ ruleTester.run('template-require-media-caption', rule, {
     </template>`,
 
     '<template><video><track kind="captions" /></video></template>',
+    // HTML enumerated attribute values are case-insensitive, so "Captions" is
+    // the same as "captions" for the track element. Matches jsx-a11y/vue-a11y.
+    '<template><video><track kind="Captions" /></video></template>',
+    '<template><video><track kind="CAPTIONS" /></video></template>',
     '<template><audio muted="true"></audio></template>',
     '<template><video muted></video></template>',
     '<template><audio muted={{this.muted}}></audio></template>',


### PR DESCRIPTION
This PR is part of a Phase 3 a11y-parity audit against jsx-a11y / vue-a11y / angular-eslint-template / lit-a11y.

- **Premise:** [HTML enumerated attribute values are ASCII case-insensitive](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attributes) — `kind="Captions"` is equivalent to `kind="captions"`.
- **Problem:** Our rule compared `kindAttr.value.chars === 'captions'` literally, flagging `<track kind="Captions">` as missing a captions track.

Fix: lowercase the value before comparison.

Two new valid tests: `<track kind="Captions">`, `<track kind="CAPTIONS">`.

## Prior art

| Plugin | Rule | Reference |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/media-has-caption.js) | `media-has-caption` | Lowercases via `String.prototype.toLowerCase()` before comparison. Valid test `<audio><track kind="Captions" /></audio>` at `__tests__/src/rules/media-has-caption-test.js:50`. |
| [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/rules/media-has-caption.ts) | `media-has-caption` | Same. Valid test `<audio><track kind='Captions' /></audio>` at `src/rules/__tests__/media-has-caption.test.ts:17`. |