### PR TITLE
refactor(template-no-abstract-roles): source abstract-role list from aria-query

### DIFF
--- a/lib/rules/template-no-abstract-roles.js
+++ b/lib/rules/template-no-abstract-roles.js
@@ -1,17 +1,11 @@
-const PROHIBITED_ROLE_VALUES = new Set([
-  'command',
-  'composite',
-  'input',
-  'landmark',
-  'range',
-  'roletype',
-  'section',
-  'sectionhead',
-  'select',
-  'structure',
-  'widget',
-  'window',
-]);
+const { roles } = require('aria-query');
+
+// Abstract ARIA roles, sourced from aria-query. Abstract roles exist only for
+// taxonomy — authors should never set role="widget" / "landmark" / etc.
+// https://www.w3.org/TR/wai-aria-1.2/#abstract_roles
+const PROHIBITED_ROLE_VALUES = new Set(
+  [...roles.keys()].filter((role) => roles.get(role).abstract)
+);
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {


### PR DESCRIPTION
This PR is part of a broader a11y parity audit comparing our rules against jsx-a11y, vue-a11y, angular-eslint-template, and lit-a11y.

Replaces the hand-maintained list of 12 abstract ARIA roles with a derivation from `aria-query`:

```js
const { roles } = require('aria-query');
const PROHIBITED_ROLE_VALUES = new Set(
  [...roles.keys()].filter((role) => roles.get(role).abstract)
);
```

`aria-query` is already a dependency (used by several other rules). Future WAI-ARIA additions of abstract roles flow in automatically on aria-query upgrade instead of requiring a hand edit here.

## Before/after

Hand list (12 roles): `command`, `composite`, `input`, `landmark`, `range`, `roletype`, `section`, `sectionhead`, `select`, `structure`, `widget`, `window`.

`aria-query`'s `roles.keys().filter(r => roles.get(r).abstract)` yields the same 12. No behavioural change.

## Spec reference

- [WAI-ARIA 1.2 5.3.1 - Abstract Roles](https://www.w3.org/TR/wai-aria-1.2/#abstract_roles): "The following roles are used to support the WAI-ARIA Roles Model... They are not intended for use by user agents or authors."

Part of a cleanup campaign migrating hand-maintained lists in this plugin to authoritative sources where available. Related refactors migrate `aria-unsupported-elements` to aria-query's `dom.reserved` and `no-invalid-role` to aria-query's role set.