### PR TITLE
refactor(template-require-presentational-children): source role list from aria-query

### DIFF
--- a/lib/rules/template-require-presentational-children.js
+++ b/lib/rules/template-require-presentational-children.js
@@ -1,21 +1,11 @@
-// Roles that require all descendants to be presentational
-// https://w3c.github.io/aria-practices/#children_presentational
-const ROLES_REQUIRING_PRESENTATIONAL_CHILDREN = new Set([
-  'button',
-  'checkbox',
-  'img',
-  'meter',
-  'menuitemcheckbox',
-  'menuitemradio',
-  'option',
-  'progressbar',
-  'radio',
-  'scrollbar',
-  'separator',
-  'slider',
-  'switch',
-  'tab',
-]);
+const { roles } = require('aria-query');
+
+// Roles where descendants are presentational per the ARIA "Children
+// Presentational" rule. Derived from aria-query (role.childrenPresentational).
+// https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational
+const ROLES_REQUIRING_PRESENTATIONAL_CHILDREN = new Set(
+  [...roles.keys()].filter((role) => roles.get(role).childrenPresentational)
+);
 
 // Tags that do not have semantic meaning
 const NON_SEMANTIC_TAGS = new Set([

--- a/tests/lib/rules/template-require-presentational-children.js
+++ b/tests/lib/rules/template-require-presentational-children.js
@@ -35,6 +35,12 @@ ruleTester.run('template-require-presentational-children', rule, {
       <title>Title here</title>
       <circle cx="10" cy="10" r="10"></circle>
     </svg></template>`,
+    // SKIPPED_TAGS: <svg> is always skipped, even when its role has childrenPresentational
+    // (graphics-symbol is such a role via Graphics-ARIA; this covers the new aria-query-derived set).
+    `<template>
+    <svg role="graphics-symbol">
+      <circle cx="10" cy="10" r="10"></circle>
+    </svg></template>`,
     `<template>
       <MyButton role="tab">
         <:default>Button text</:default>
@@ -77,6 +83,28 @@ ruleTester.run('template-require-presentational-children', rule, {
         },
       ],
     },
+    // doc-pagebreak: DPUB-ARIA role with childrenPresentational; now included via aria-query.
+    {
+      code: '<template><div role="doc-pagebreak"><h2>pg</h2></div></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            '<div> has a role of doc-pagebreak, it cannot have semantic descendants like <h2>',
+        },
+      ],
+    },
+    // graphics-symbol: Graphics-ARIA role with childrenPresentational; flags on non-svg host.
+    {
+      code: '<template><div role="graphics-symbol"><text>X</text></div></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            '<div> has a role of graphics-symbol, it cannot have semantic descendants like <text>',
+        },
+      ],
+    },
   ],
 });
 
@@ -107,6 +135,12 @@ hbsRuleTester.run('template-require-presentational-children', rule, {
     `
     <svg role="img">
       <title>Title here</title>
+      <circle cx="10" cy="10" r="10"></circle>
+    </svg>`,
+    // SKIPPED_TAGS: <svg> is always skipped, even when its role has childrenPresentational
+    // (graphics-symbol is such a role via Graphics-ARIA; this covers the new aria-query-derived set).
+    `
+    <svg role="graphics-symbol">
       <circle cx="10" cy="10" r="10"></circle>
     </svg>`,
     `
@@ -147,6 +181,28 @@ hbsRuleTester.run('template-require-presentational-children', rule, {
         },
         {
           message: '<div> has a role of button, it cannot have semantic descendants like <img>',
+        },
+      ],
+    },
+    // doc-pagebreak: DPUB-ARIA role with childrenPresentational; now included via aria-query.
+    {
+      code: '<div role="doc-pagebreak"><h2>pg</h2></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            '<div> has a role of doc-pagebreak, it cannot have semantic descendants like <h2>',
+        },
+      ],
+    },
+    // graphics-symbol: Graphics-ARIA role with childrenPresentational; flags on non-svg host.
+    {
+      code: '<div role="graphics-symbol"><text>X</text></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            '<div> has a role of graphics-symbol, it cannot have semantic descendants like <text>',
         },
       ],
     },

--- a/tests/lib/rules/template-require-presentational-children.js
+++ b/tests/lib/rules/template-require-presentational-children.js
@@ -35,8 +35,8 @@ ruleTester.run('template-require-presentational-children', rule, {
       <title>Title here</title>
       <circle cx="10" cy="10" r="10"></circle>
     </svg></template>`,
-    // SKIPPED_TAGS: <svg> is always skipped, even when its role has childrenPresentational
-    // (graphics-symbol is such a role via Graphics-ARIA; this covers the new aria-query-derived set).
+    // SKIPPED_TAGS: <svg> is always skipped, even when its role has
+    // childrenPresentational (e.g. graphics-symbol via Graphics-ARIA).
     `<template>
     <svg role="graphics-symbol">
       <circle cx="10" cy="10" r="10"></circle>
@@ -83,7 +83,7 @@ ruleTester.run('template-require-presentational-children', rule, {
         },
       ],
     },
-    // doc-pagebreak: DPUB-ARIA role with childrenPresentational; now included via aria-query.
+    // doc-pagebreak: DPUB-ARIA role with childrenPresentational.
     {
       code: '<template><div role="doc-pagebreak"><h2>pg</h2></div></template>',
       output: null,
@@ -137,8 +137,8 @@ hbsRuleTester.run('template-require-presentational-children', rule, {
       <title>Title here</title>
       <circle cx="10" cy="10" r="10"></circle>
     </svg>`,
-    // SKIPPED_TAGS: <svg> is always skipped, even when its role has childrenPresentational
-    // (graphics-symbol is such a role via Graphics-ARIA; this covers the new aria-query-derived set).
+    // SKIPPED_TAGS: <svg> is always skipped, even when its role has
+    // childrenPresentational (e.g. graphics-symbol via Graphics-ARIA).
     `
     <svg role="graphics-symbol">
       <circle cx="10" cy="10" r="10"></circle>
@@ -184,7 +184,7 @@ hbsRuleTester.run('template-require-presentational-children', rule, {
         },
       ],
     },
-    // doc-pagebreak: DPUB-ARIA role with childrenPresentational; now included via aria-query.
+    // doc-pagebreak: DPUB-ARIA role with childrenPresentational.
     {
       code: '<div role="doc-pagebreak"><h2>pg</h2></div>',
       output: null,


### PR DESCRIPTION
This PR is part of a broader a11y parity audit comparing our rules against jsx-a11y, vue-a11y, angular-eslint-template, and lit-a11y.

Replaces the hand-maintained list of 14 roles that require presentational children with a derivation from `aria-query`:

```js
const { roles } = require('aria-query');
const ROLES_REQUIRING_PRESENTATIONAL_CHILDREN = new Set(
  [...roles.keys()].filter((role) => roles.get(role).childrenPresentational)
);
```

## Before/after

| | Before | After |
|---|---|---|
| Roles covered | 14 (WAI-ARIA core) | 16 (adds `doc-pagebreak`, `graphics-symbol`) |

`aria-query`'s `childrenPresentational` flag is set on the 16 roles that the [WAI-ARIA 1.2 §5.2.9](https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational) + [DPUB-ARIA 1.1](https://www.w3.org/TR/dpub-aria-1.1/#doc-pagebreak) + [Graphics-ARIA 1.0](https://www.w3.org/TR/graphics-aria-1.0/#graphics-symbol) specs mark with the *Children Presentational* rule.

## Behavior expansion — DPUB / Graphics-ARIA

This PR adds two roles beyond WAI-ARIA core. Anyone using `role="doc-pagebreak"` or `role="graphics-symbol"` with semantic descendants will now see new warnings:

```hbs
{{! Previously silently accepted, now flagged: }}
<div role="doc-pagebreak"><h2>pg</h2></div>
<div role="graphics-symbol"><text>X</text></div>
```

These are correct per the specs — both roles are defined to have presentational children — but the expansion is worth flagging for projects that consume DPUB-ARIA or Graphics-ARIA.

## Follow-up note

`template-no-invalid-role` on master still carries a hand-maintained WAI-ARIA-only list — it will flag `role="doc-pagebreak"` as invalid. #2729 (currently open) addresses that: once merged, `template-no-invalid-role` will source its role set from aria-query too, and the two rules will agree on DPUB/Graphics-ARIA recognition.

## Spec reference

- [WAI-ARIA 1.2 §5.2.9 — Children Presentational](https://www.w3.org/TR/wai-aria-1.2/#childrenArePresentational)
- [DPUB-ARIA 1.1 — doc-pagebreak](https://www.w3.org/TR/dpub-aria-1.1/#doc-pagebreak) (W3C Recommendation 12 June 2025)
- [Graphics-ARIA 1.0 — graphics-symbol](https://www.w3.org/TR/graphics-aria-1.0/#graphics-symbol) (W3C Recommendation 02 October 2018)