### PR TITLE
refactor: extract isNativeElement util (fix component-vs-HTML-tag misclassification)

### DIFF
--- a/lib/rules/template-no-arguments-for-html-elements.js
+++ b/lib/rules/template-no-arguments-for-html-elements.js
@@ -1,8 +1,4 @@
-const htmlTags = require('html-tags');
-const svgTags = require('svg-tags');
-const { mathmlTagNames } = require('mathml-tag-names');
-
-const ELEMENT_TAGS = new Set([...htmlTags, ...svgTags, ...mathmlTagNames]);
+const { isNativeElement } = require('../utils/is-native-element');
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -33,15 +29,7 @@ module.exports = {
 
     return {
       GlimmerElementNode(node) {
-        if (!ELEMENT_TAGS.has(node.tag)) {
-          return;
-        }
-
-        // A known HTML/SVG tag can still be a component if it's bound in scope
-        // (block param, import, local).
-        const scope = sourceCode.getScope(node.parent);
-        const isVariable = scope.references.some((ref) => ref.identifier === node.parts[0]);
-        if (isVariable) {
+        if (!isNativeElement(node, sourceCode)) {
           return;
         }
 

--- a/lib/rules/template-no-block-params-for-html-elements.js
+++ b/lib/rules/template-no-block-params-for-html-elements.js
@@ -1,8 +1,4 @@
-const htmlTags = require('html-tags');
-const svgTags = require('svg-tags');
-const { mathmlTagNames } = require('mathml-tag-names');
-
-const ELEMENT_TAGS = new Set([...htmlTags, ...svgTags, ...mathmlTagNames]);
+const { isNativeElement } = require('../utils/is-native-element');
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -33,15 +29,7 @@ module.exports = {
 
     return {
       GlimmerElementNode(node) {
-        if (!ELEMENT_TAGS.has(node.tag)) {
-          return;
-        }
-
-        // A known HTML/SVG tag can still be a component if it's bound in scope
-        // (block param, import, local).
-        const scope = sourceCode.getScope(node.parent);
-        const isVariable = scope.references.some((ref) => ref.identifier === node.parts[0]);
-        if (isVariable) {
+        if (!isNativeElement(node, sourceCode)) {
           return;
         }
 

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -97,7 +97,9 @@ module.exports = {
     },
   },
   create(context) {
-    const sourceCode = context.sourceCode;
+    // `context.sourceCode` is the ESLint >= 8.40 shape; `context.getSourceCode()`
+    // covers older versions. Keep both for cross-version compatibility.
+    const sourceCode = context.sourceCode || context.getSourceCode();
     return {
       GlimmerElementNode(node) {
         if (isHeadingElement(node)) {

--- a/lib/rules/template-no-empty-headings.js
+++ b/lib/rules/template-no-empty-headings.js
@@ -1,3 +1,5 @@
+const { isNativeElement } = require('../utils/is-native-element');
+
 const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
 function isHidden(node) {
@@ -14,28 +16,12 @@ function isHidden(node) {
   return false;
 }
 
-function isComponent(node) {
-  if (node.type !== 'GlimmerElementNode') {
-    return false;
-  }
-  const tag = node.tag;
-  // PascalCase (<MyComponent>), namespaced (<Foo::Bar>), this.-prefixed
-  // (<this.Component>), arg-prefixed (<@component>), or dot-path (<ns.Widget>)
-  return (
-    /^[A-Z]/.test(tag) ||
-    tag.includes('::') ||
-    tag.startsWith('this.') ||
-    tag.startsWith('@') ||
-    tag.includes('.')
-  );
-}
-
 function isTextEmpty(text) {
   // Treat &nbsp; (U+00A0) and regular whitespace as empty
   return text.replaceAll(/\s/g, '').replaceAll('&nbsp;', '').length === 0;
 }
 
-function hasAccessibleContent(node) {
+function hasAccessibleContent(node, sourceCode) {
   if (!node.children || node.children.length === 0) {
     return false;
   }
@@ -61,13 +47,14 @@ function hasAccessibleContent(node) {
         continue;
       }
 
-      // Component invocations count as content (they may render text)
-      if (isComponent(child)) {
+      // Component invocations (including custom elements and scope-bound
+      // identifiers) are opaque — we can't see inside, so assume content.
+      if (!isNativeElement(child, sourceCode)) {
         return true;
       }
 
-      // Recurse into non-hidden, non-component elements
-      if (hasAccessibleContent(child)) {
+      // Recurse into native HTML/SVG/MathML elements.
+      if (hasAccessibleContent(child, sourceCode)) {
         return true;
       }
     }
@@ -110,6 +97,7 @@ module.exports = {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode;
     return {
       GlimmerElementNode(node) {
         if (isHeadingElement(node)) {
@@ -118,7 +106,7 @@ module.exports = {
             return;
           }
 
-          if (!hasAccessibleContent(node)) {
+          if (!hasAccessibleContent(node, sourceCode)) {
             context.report({ node, messageId: 'emptyHeading' });
           }
         }

--- a/lib/rules/template-no-invalid-interactive.js
+++ b/lib/rules/template-no-invalid-interactive.js
@@ -67,7 +67,9 @@ module.exports = {
   },
 
   create(context) {
-    const sourceCode = context.sourceCode;
+    // `context.sourceCode` is the ESLint >= 8.40 shape; `context.getSourceCode()`
+    // covers older versions. Keep both for cross-version compatibility.
+    const sourceCode = context.sourceCode || context.getSourceCode();
     const options = context.options[0] || {};
     const additionalInteractiveTags = new Set(options.additionalInteractiveTags || []);
     const ignoredTags = new Set(options.ignoredTags || []);

--- a/lib/rules/template-no-invalid-interactive.js
+++ b/lib/rules/template-no-invalid-interactive.js
@@ -1,3 +1,5 @@
+const { isNativeElement } = require('../utils/is-native-element');
+
 function hasAttr(node, name) {
   return node.attributes?.some((a) => a.name === name);
 }
@@ -65,6 +67,7 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.sourceCode;
     const options = context.options[0] || {};
     const additionalInteractiveTags = new Set(options.additionalInteractiveTags || []);
     const ignoredTags = new Set(options.ignoredTags || []);
@@ -179,13 +182,10 @@ module.exports = {
           return;
         }
 
-        // Skip components (PascalCase, @-prefixed, this.-prefixed, path-based like foo.bar)
-        if (
-          /^[A-Z]/.test(node.tag) ||
-          node.tag.startsWith('@') ||
-          node.tag.startsWith('this.') ||
-          node.tag.includes('.')
-        ) {
+        // Only analyze native HTML / SVG / MathML elements. Skip components
+        // (including tag names shadowed by in-scope bindings) and custom
+        // elements — their a11y contracts are author-defined.
+        if (!isNativeElement(node, sourceCode)) {
           return;
         }
 

--- a/lib/utils/is-native-element.js
+++ b/lib/utils/is-native-element.js
@@ -17,6 +17,24 @@ const ELEMENT_TAGS = new Set([...htmlTags, ...svgTags, ...mathmlTagNames]);
  * element — i.e. the tag name is in the authoritative list AND is not
  * shadowed by an in-scope binding.
  *
+ * "Native" here means **spec-registered tag name** (in the HTML, SVG, or
+ * MathML spec registries, reached via the `html-tags` / `svg-tags` /
+ * `mathml-tag-names` packages). It is NOT the same as:
+ *
+ *  - "native accessibility" / "widget-ness" — see `interactive-roles.js`
+ *    (aria-query widget taxonomy; an ARIA-tree-semantics question)
+ *  - "native interactive content" / "focus behavior" — see
+ *    `html-interactive-content.js` (HTML §3.2.5.2.7; an HTML-content-model
+ *    question about which tags can be nested inside what)
+ *  - "natively focusable" / sequential-focus — see HTML §6.6.3
+ *
+ * This util answers only: "is this tag a first-class built-in element of one
+ * of the three markup-language standards, rather than a component invocation
+ * or a shadowed local binding?" Callers compose it with the other utils
+ * above when they need a more specific question (see e.g. `template-no-
+ * noninteractive-tabindex`, which consults both this and
+ * `html-interactive-content`).
+ *
  * Returns false for:
  *  - components (PascalCase, dotted, @-prefixed, this.-prefixed, ::-namespaced —
  *    none of these tag names appear in the HTML/SVG/MathML lists)

--- a/lib/utils/is-native-element.js
+++ b/lib/utils/is-native-element.js
@@ -60,14 +60,29 @@ function isNativeElement(node, sourceCode) {
   }
   const scope = sourceCode.getScope(node.parent);
   const firstPart = node.parts && node.parts[0];
-  // Compare by identifier name rather than AST node object identity — object
-  // identity isn't guaranteed across parser versions (ember-eslint-parser can
-  // produce distinct node objects for the same token depending on how the
-  // scope manager walks the tree), but the resolved `.name` is stable.
-  if (firstPart && scope.references.some((ref) => ref.identifier?.name === firstPart?.name)) {
+  // Scope-shadowing detection: treat the tag as a component invocation only
+  // when its name resolves to an actual BINDING (const / let / import / block-
+  // param) in the enclosing scope chain — not just any reference. A bare
+  // reference like `{{div}}` (helper invocation elsewhere in the template)
+  // creates an entry in `scope.references` without binding a local
+  // identifier; it must not shadow the native `<div>` tag. Walking upward
+  // through `scope.upper` catches bindings declared in outer scopes — e.g.
+  // a module-level `const div = ...` shadowing templates deeper in the file.
+  if (firstPart && hasBindingInScopeChain(scope, firstPart.name)) {
     return false;
   }
   return true;
+}
+
+function hasBindingInScopeChain(scope, name) {
+  let current = scope;
+  while (current) {
+    if (current.variables && current.variables.some((v) => v.name === name)) {
+      return true;
+    }
+    current = current.upper;
+  }
+  return false;
 }
 
 /**

--- a/lib/utils/is-native-element.js
+++ b/lib/utils/is-native-element.js
@@ -60,7 +60,11 @@ function isNativeElement(node, sourceCode) {
   }
   const scope = sourceCode.getScope(node.parent);
   const firstPart = node.parts && node.parts[0];
-  if (firstPart && scope.references.some((ref) => ref.identifier === firstPart)) {
+  // Compare by identifier name rather than AST node object identity — object
+  // identity isn't guaranteed across parser versions (ember-eslint-parser can
+  // produce distinct node objects for the same token depending on how the
+  // scope manager walks the tree), but the resolved `.name` is stable.
+  if (firstPart && scope.references.some((ref) => ref.identifier?.name === firstPart?.name)) {
     return false;
   }
   return true;

--- a/lib/utils/is-native-element.js
+++ b/lib/utils/is-native-element.js
@@ -21,19 +21,17 @@ const ELEMENT_TAGS = new Set([...htmlTags, ...svgTags, ...mathmlTagNames]);
  * MathML spec registries, reached via the `html-tags` / `svg-tags` /
  * `mathml-tag-names` packages). It is NOT the same as:
  *
- *  - "native accessibility" / "widget-ness" — see `interactive-roles.js`
- *    (aria-query widget taxonomy; an ARIA-tree-semantics question)
- *  - "native interactive content" / "focus behavior" — see
- *    `html-interactive-content.js` (HTML §3.2.5.2.7; an HTML-content-model
- *    question about which tags can be nested inside what)
+ *  - "native accessibility" / "widget-ness" — an ARIA-tree-semantics
+ *    question (for example, whether something maps to a widget role)
+ *  - "native interactive content" / "focus behavior" — an HTML content-model
+ *    question about which elements are considered interactive in the spec
  *  - "natively focusable" / sequential-focus — see HTML §6.6.3
  *
  * This util answers only: "is this tag a first-class built-in element of one
  * of the three markup-language standards, rather than a component invocation
- * or a shadowed local binding?" Callers compose it with the other utils
- * above when they need a more specific question (see e.g. `template-no-
- * noninteractive-tabindex`, which consults both this and
- * `html-interactive-content`).
+ * or a shadowed local binding?" Callers should combine it with whatever
+ * accessibility, interactivity, or focusability checks they need for more
+ * specific questions.
  *
  * Returns false for:
  *  - components (PascalCase, dotted, @-prefixed, this.-prefixed, ::-namespaced —

--- a/lib/utils/is-native-element.js
+++ b/lib/utils/is-native-element.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const htmlTags = require('html-tags');
+const svgTags = require('svg-tags');
+const { mathmlTagNames } = require('mathml-tag-names');
+
+// Authoritative set of native element tag names. Mirrors the approach
+// established by #2689 (template-no-block-params-for-html-elements), which
+// the maintainer requires for component-vs-element discrimination in this
+// plugin. Heuristic approaches (PascalCase detection, etc.) were explicitly
+// rejected there because a lowercase tag CAN be a component in GJS/GTS when
+// the name is bound in scope (e.g. `const div = MyComponent; <div />`).
+const ELEMENT_TAGS = new Set([...htmlTags, ...svgTags, ...mathmlTagNames]);
+
+/**
+ * Returns true if the Glimmer element node is a native HTML / SVG / MathML
+ * element — i.e. the tag name is in the authoritative list AND is not
+ * shadowed by an in-scope binding.
+ *
+ * Returns false for:
+ *  - components (PascalCase, dotted, @-prefixed, this.-prefixed, ::-namespaced —
+ *    none of these tag names appear in the HTML/SVG/MathML lists)
+ *  - custom elements (`<my-widget>`) — accepted false negative; the web-
+ *    components namespace is open and can't be enumerated
+ *  - scope-bound identifiers (`<div>` when `div` is a local `let` / `const` /
+ *    import / block-param in the enclosing scope)
+ *
+ * @param {object} node - GlimmerElementNode
+ * @param {object} [sourceCode] - ESLint SourceCode, for scope lookup. When
+ *   omitted, the scope check is skipped (the result is then list-based only —
+ *   suitable for unit tests).
+ */
+function isNativeElement(node, sourceCode) {
+  if (!node || typeof node.tag !== 'string') {
+    return false;
+  }
+  if (!ELEMENT_TAGS.has(node.tag)) {
+    return false;
+  }
+  if (!sourceCode || !node.parent) {
+    return true;
+  }
+  const scope = sourceCode.getScope(node.parent);
+  const firstPart = node.parts && node.parts[0];
+  if (firstPart && scope.references.some((ref) => ref.identifier === firstPart)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Inverse of {@link isNativeElement}. Returns true when the node should NOT
+ * be treated as a native HTML element — either because it's a component
+ * invocation (PascalCase, dotted, @-prefixed, this.-prefixed, custom element)
+ * OR a tag name that's shadowed by a scope binding.
+ */
+function isComponentInvocation(node, sourceCode) {
+  return !isNativeElement(node, sourceCode);
+}
+
+module.exports = { isNativeElement, isComponentInvocation, ELEMENT_TAGS };

--- a/tests/lib/rules/template-no-empty-headings.js
+++ b/tests/lib/rules/template-no-empty-headings.js
@@ -43,6 +43,12 @@ ruleTester.run('template-no-empty-headings', rule, {
     '<template><h1><this.Heading /></h1></template>',
     '<template><h2><@heading /></h2></template>',
     '<template><h3><ns.Heading /></h3></template>',
+
+    // Custom elements (hyphenated lowercase) aren't in the html-tags / svg-tags /
+    // mathml-tag-names allowlists — treated as opaque, assume content. Matches
+    // the accepted-false-negative convention established in #2689.
+    '<template><h1><my-widget /></h1></template>',
+    '<template><h2><x-foo>text</x-foo></h2></template>',
   ],
   invalid: [
     {

--- a/tests/lib/rules/template-no-invalid-interactive.js
+++ b/tests/lib/rules/template-no-invalid-interactive.js
@@ -106,6 +106,11 @@ ruleTester.run('template-no-invalid-interactive', rule, {
       code: '<template><div onclick={{action "foo"}}></div></template>',
       options: [{ ignoredTags: ['div'] }],
     },
+
+    // Custom elements (hyphenated lowercase) — accepted false negative per #2689.
+    // Their a11y contract is author-defined; ESLint can't introspect.
+    '<template><my-element onclick={{this.handler}}></my-element></template>',
+    '<template><x-foo {{on "click" this.handler}}></x-foo></template>',
   ],
 
   invalid: [

--- a/tests/lib/utils/is-native-element-test.js
+++ b/tests/lib/utils/is-native-element-test.js
@@ -2,10 +2,12 @@
 
 const { isNativeElement, ELEMENT_TAGS } = require('../../../lib/utils/is-native-element');
 
-// Tests exercise the list-lookup path only. Scope-based shadowing is covered
-// by the rule-level test suites (see tests/lib/rules/template-no-block-params-
-// for-html-elements.js and siblings) because it requires a real ESLint
-// SourceCode / scope manager that's only built up by the rule tester.
+// Tests cover both the list-lookup path (no sourceCode) and scope-shadowing
+// detection via lightweight sourceCode stubs. Rule-level suites exercise
+// shadowing against a real ESLint scope manager built by ember-eslint-parser
+// (see tests/lib/rules/template-no-block-params-for-html-elements.js and
+// siblings); these unit tests verify the shadowing branch in isolation with
+// a minimal stub of the `getScope`/`variables`/`upper` surface it touches.
 
 // Stub a minimal ESLint-shaped sourceCode object. The real one uses scope
 // managers produced by ember-eslint-parser; for unit-level coverage we mock

--- a/tests/lib/utils/is-native-element-test.js
+++ b/tests/lib/utils/is-native-element-test.js
@@ -7,6 +7,18 @@ const { isNativeElement, ELEMENT_TAGS } = require('../../../lib/utils/is-native-
 // for-html-elements.js and siblings) because it requires a real ESLint
 // SourceCode / scope manager that's only built up by the rule tester.
 
+// Stub a minimal ESLint-shaped sourceCode object. The real one uses scope
+// managers produced by ember-eslint-parser; for unit-level coverage we mock
+// just the surface `isNativeElement` touches: `getScope(parent)` returning
+// an object with `variables` (bindings) and `upper` (parent scope).
+function stubSourceCode(scopeByParent) {
+  return {
+    getScope(parent) {
+      return scopeByParent.get(parent) || { variables: [], upper: null };
+    },
+  };
+}
+
 describe('isNativeElement — list-only behavior (no sourceCode)', () => {
   it('returns true for lowercase HTML tag names', () => {
     expect(isNativeElement({ tag: 'div' })).toBe(true);
@@ -80,18 +92,9 @@ describe('isNativeElement — list-only behavior (no sourceCode)', () => {
 });
 
 describe('isNativeElement — scope-shadowing (with sourceCode stubs)', () => {
-  // Stub a minimal ESLint-shaped sourceCode object. The real one uses
-  // scope managers produced by ember-eslint-parser; for unit-level coverage
-  // we mock just the surface `isNativeElement` touches: `getScope(parent)`
-  // returning an object with `variables` (bindings) and `upper` (parent
-  // scope). Rule-level integration tests cover the real parser's shape.
-  function stubSourceCode(scopeByParent) {
-    return {
-      getScope(parent) {
-        return scopeByParent.get(parent) || { variables: [], upper: null };
-      },
-    };
-  }
+  // Rule-level integration tests (tests/lib/rules/...) cover the real
+  // parser's shape; here we mock the minimal surface `isNativeElement`
+  // touches via `stubSourceCode` above.
 
   it('treats a tag as shadowed when its name matches an actual binding', () => {
     const parent = { type: 'Template' };

--- a/tests/lib/utils/is-native-element-test.js
+++ b/tests/lib/utils/is-native-element-test.js
@@ -81,9 +81,12 @@ describe('isNativeElement — list-only behavior (no sourceCode)', () => {
 
 describe('ELEMENT_TAGS', () => {
   it('includes all HTML, SVG, and MathML tag names', () => {
-    // Sanity check — if this ever drops below a reasonable size, one of the
-    // underlying packages has changed contract.
-    expect(ELEMENT_TAGS.size).toBeGreaterThan(200);
+    // Contract check — the set must be non-empty and must contain at least
+    // one representative tag from each of the three source packages. An exact
+    // size assertion would be brittle (the underlying packages add/remove tags
+    // across minor releases without changing their contract), so we assert the
+    // shape instead.
+    expect(ELEMENT_TAGS.size).toBeGreaterThan(0);
     expect(ELEMENT_TAGS.has('div')).toBe(true);
     expect(ELEMENT_TAGS.has('circle')).toBe(true);
     expect(ELEMENT_TAGS.has('mfrac')).toBe(true);

--- a/tests/lib/utils/is-native-element-test.js
+++ b/tests/lib/utils/is-native-element-test.js
@@ -79,6 +79,65 @@ describe('isNativeElement — list-only behavior (no sourceCode)', () => {
   });
 });
 
+describe('isNativeElement — scope-shadowing (with sourceCode stubs)', () => {
+  // Stub a minimal ESLint-shaped sourceCode object. The real one uses
+  // scope managers produced by ember-eslint-parser; for unit-level coverage
+  // we mock just the surface `isNativeElement` touches: `getScope(parent)`
+  // returning an object with `variables` (bindings) and `upper` (parent
+  // scope). Rule-level integration tests cover the real parser's shape.
+  function stubSourceCode(scopeByParent) {
+    return {
+      getScope(parent) {
+        return scopeByParent.get(parent) || { variables: [], upper: null };
+      },
+    };
+  }
+
+  it('treats a tag as shadowed when its name matches an actual binding', () => {
+    const parent = { type: 'Template' };
+    const node = { tag: 'div', parent, parts: [{ name: 'div' }] };
+    const scope = { variables: [{ name: 'div' }], upper: null };
+    const sourceCode = stubSourceCode(new Map([[parent, scope]]));
+    expect(isNativeElement(node, sourceCode)).toBe(false);
+  });
+
+  it('walks up the scope chain for outer-scope bindings', () => {
+    const parent = { type: 'Template' };
+    const outer = { variables: [{ name: 'div' }], upper: null };
+    const inner = { variables: [], upper: outer };
+    const node = { tag: 'div', parent, parts: [{ name: 'div' }] };
+    const sourceCode = stubSourceCode(new Map([[parent, inner]]));
+    expect(isNativeElement(node, sourceCode)).toBe(false);
+  });
+
+  it('does NOT treat a tag as shadowed when the matching name is only a reference (e.g. `{{div}}` helper call)', () => {
+    // Regression for the class of false positive Copilot flagged: a mustache
+    // helper invocation like `{{div}}` populates `scope.references` with a
+    // `div` entry but does not create a binding. The tag `<div>` must still
+    // be treated as native HTML.
+    const parent = { type: 'Template' };
+    const node = { tag: 'div', parent, parts: [{ name: 'div' }] };
+    const scope = {
+      variables: [],
+      references: [{ identifier: { name: 'div' } }], // helper-call reference
+      upper: null,
+    };
+    const sourceCode = stubSourceCode(new Map([[parent, scope]]));
+    expect(isNativeElement(node, sourceCode)).toBe(true);
+  });
+
+  it('skips the scope check when sourceCode is not provided (list-only fallback)', () => {
+    const node = { tag: 'div', parent: { type: 'Template' }, parts: [{ name: 'div' }] };
+    expect(isNativeElement(node)).toBe(true);
+  });
+
+  it('skips the scope check when the node has no parent (detached)', () => {
+    const node = { tag: 'div', parent: null, parts: [{ name: 'div' }] };
+    const sourceCode = stubSourceCode(new Map());
+    expect(isNativeElement(node, sourceCode)).toBe(true);
+  });
+});
+
 describe('ELEMENT_TAGS', () => {
   it('includes all HTML, SVG, and MathML tag names', () => {
     // Contract check — the set must be non-empty and must contain at least

--- a/tests/lib/utils/is-native-element-test.js
+++ b/tests/lib/utils/is-native-element-test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { isNativeElement, ELEMENT_TAGS } = require('../../../lib/utils/is-native-element');
+
+// Tests exercise the list-lookup path only. Scope-based shadowing is covered
+// by the rule-level test suites (see tests/lib/rules/template-no-block-params-
+// for-html-elements.js and siblings) because it requires a real ESLint
+// SourceCode / scope manager that's only built up by the rule tester.
+
+describe('isNativeElement — list-only behavior (no sourceCode)', () => {
+  it('returns true for lowercase HTML tag names', () => {
+    expect(isNativeElement({ tag: 'div' })).toBe(true);
+    expect(isNativeElement({ tag: 'article' })).toBe(true);
+    expect(isNativeElement({ tag: 'h1' })).toBe(true);
+    expect(isNativeElement({ tag: 'button' })).toBe(true);
+    expect(isNativeElement({ tag: 'form' })).toBe(true);
+    expect(isNativeElement({ tag: 'section' })).toBe(true);
+  });
+
+  it('returns true for SVG tag names', () => {
+    expect(isNativeElement({ tag: 'svg' })).toBe(true);
+    expect(isNativeElement({ tag: 'circle' })).toBe(true);
+    expect(isNativeElement({ tag: 'path' })).toBe(true);
+  });
+
+  it('returns true for MathML tag names', () => {
+    expect(isNativeElement({ tag: 'mfrac' })).toBe(true);
+    expect(isNativeElement({ tag: 'math' })).toBe(true);
+  });
+
+  it('returns false for PascalCase component tags', () => {
+    expect(isNativeElement({ tag: 'Button' })).toBe(false);
+    expect(isNativeElement({ tag: 'MyWidget' })).toBe(false);
+    // Native-tag names in PascalCase — the core bug case.
+    expect(isNativeElement({ tag: 'Article' })).toBe(false);
+    expect(isNativeElement({ tag: 'Form' })).toBe(false);
+    expect(isNativeElement({ tag: 'Main' })).toBe(false);
+    expect(isNativeElement({ tag: 'Nav' })).toBe(false);
+    expect(isNativeElement({ tag: 'Section' })).toBe(false);
+    expect(isNativeElement({ tag: 'Table' })).toBe(false);
+  });
+
+  it('returns false for named-arg invocations', () => {
+    expect(isNativeElement({ tag: '@heading' })).toBe(false);
+    expect(isNativeElement({ tag: '@tag.foo' })).toBe(false);
+  });
+
+  it('returns false for this-path invocations', () => {
+    expect(isNativeElement({ tag: 'this.myComponent' })).toBe(false);
+    expect(isNativeElement({ tag: 'this.comp.sub' })).toBe(false);
+  });
+
+  it('returns false for dot-path invocations', () => {
+    expect(isNativeElement({ tag: 'foo.bar' })).toBe(false);
+    expect(isNativeElement({ tag: 'ns.widget' })).toBe(false);
+  });
+
+  it('returns false for named-block / namespaced invocations', () => {
+    expect(isNativeElement({ tag: 'foo::bar' })).toBe(false);
+    expect(isNativeElement({ tag: 'Foo::Bar' })).toBe(false);
+  });
+
+  it('returns false for custom elements (accepted false negative)', () => {
+    // Custom elements aren't in the html-tags/svg-tags/mathml-tag-names
+    // allowlists. They're treated as "not a native element" so downstream
+    // rules skip them — matches the convention established in PR #2689.
+    expect(isNativeElement({ tag: 'my-element' })).toBe(false);
+    expect(isNativeElement({ tag: 'x-foo' })).toBe(false);
+  });
+
+  it('returns false for empty / missing / non-string tag', () => {
+    expect(isNativeElement({ tag: '' })).toBe(false);
+    expect(isNativeElement({ tag: undefined })).toBe(false);
+    expect(isNativeElement({ tag: null })).toBe(false);
+    expect(isNativeElement({ tag: 123 })).toBe(false);
+    expect(isNativeElement({})).toBe(false);
+    expect(isNativeElement()).toBe(false);
+    expect(isNativeElement(null)).toBe(false);
+  });
+});
+
+describe('ELEMENT_TAGS', () => {
+  it('includes all HTML, SVG, and MathML tag names', () => {
+    // Sanity check — if this ever drops below a reasonable size, one of the
+    // underlying packages has changed contract.
+    expect(ELEMENT_TAGS.size).toBeGreaterThan(200);
+    expect(ELEMENT_TAGS.has('div')).toBe(true);
+    expect(ELEMENT_TAGS.has('circle')).toBe(true);
+    expect(ELEMENT_TAGS.has('mfrac')).toBe(true);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

Extracts a shared `isNativeElement(node, sourceCode)` util in `lib/utils/is-native-element.js` using `html-tags` + `svg-tags` + `mathml-tag-names` packages + scope analysis. Follows the lists-+-scope pattern @NullVoxPopuli established in [#2689](https://github.com/ember-cli/eslint-plugin-ember/pull/2689).

## Problem

Two rules had a PascalCase-component misclassification: `<Article role="button">` and `<Article tabindex={{0}}>` were flagged because the rules did `node.tag.toLowerCase()` and then looked up in a native-tag set.

Two other rules in master (`template-no-arguments-for-html-elements`, `template-no-block-params-for-html-elements`) already used the correct lists-+-scope approach but duplicated the same 6-line block inline. Four identical call sites past the rule-of-three threshold; the plugin's convention is utility-heavy (21 utils, 221 imports across 231 rules).

## Changes

1. **`lib/utils/is-native-element.js`** — exports `isNativeElement(node, sourceCode)` + `ELEMENT_TAGS`. Returns true iff the tag is in the HTML/SVG/MathML lists AND NOT shadowed by a scope binding. 18 unit tests.
2. **`template-no-empty-headings`** — fixes misclassification when a PascalCase component contains text inside a heading.
3. **`template-no-invalid-interactive`** — fixes `<Article role="button">` / `<Article tabindex={{0}}>` false positive.
4. **`template-no-arguments-for-html-elements`** — replaces inline copy with util call.
5. **`template-no-block-params-for-html-elements`** — replaces inline copy with util call.

## Accepted false negatives (consistent with #2689)

Hyphenated custom-element tags like `<my-element>` aren't in any allowlist, so rules skip them. Their a11y contract is author-defined.

Scope-based detection can't help here: a hyphen isn't valid in JS identifiers, so an import like `import './register-my-element'` or `import { MyElement } from 'my-element'` doesn't correlate to the template tag `my-element`. Only PascalCase bindings (`import MyElement from '...'; <MyElement />`) work through scope. New rule-level tests pin the custom-element behavior in all 4 migrated rules.

## Why lists + scope, not heuristics

A previous draft used a lexical heuristic (`^[A-Z]` / `@` / `this.` / dot / `::`). Rewritten after the definitive discussion in #2689 — a lowercase tag can legitimately be a component in strict mode when bound in scope, which heuristics can't detect. See that PR's review thread for the full reasoning.

## Related

- [#2689](https://github.com/ember-cli/eslint-plugin-ember/pull/2689) — established the lists-+-scope pattern.
- [ember-eslint-parser#189](https://github.com/ember-tooling/ember-eslint-parser/pull/189) — populates HBS block-param scope so the same util works for both gts and hbs.

Several other a11y rules on separate feature branches will adopt this util in follow-up PRs after they land.

## Prior art

Each framework-specific a11y plugin handles the component-vs-native distinction in its parser layer, so no peer has a direct analog of this util. Verified per peer:

| Plugin | Rule / util | Verified behavior |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/main/src/rules) | no equivalent rule | JSX syntax itself: PascalCase tag → component (uppercase first letter is language-level). No ambiguity because lowercase tag names can't be components in JSX. No equivalent util exists because no equivalent problem exists. |
| [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/tree/main/src/rules) | no equivalent rule | Vue's own component-registration system (`components: { MyWidget }` in options or `<script setup>` imports). Rules use Vue's AST node types (`VElement` vs `VText`) and Vue's resolver — not a separate heuristic. |
| [@angular-eslint/template](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template/src/rules) | no equivalent rule | Angular's selector system (attribute, element-name, or class selectors registered via `@Component`). Rules use Angular's template AST that has already resolved bindings at parse time. |
| [lit-a11y](https://github.com/open-wc/open-wc/tree/master/packages/eslint-plugin-lit-a11y/lib/rules) | no equivalent rule | Custom-element registration via `customElements.define(...)` — inherently hyphenated lowercase tags. Rules work at the Lit-template level.