### PR TITLE
BUGFIX: template-require-mandatory-role-attributes — lowercase role + split whitespace role lists

### DIFF
--- a/docs/rules/template-require-mandatory-role-attributes.md
+++ b/docs/rules/template-require-mandatory-role-attributes.md
@@ -52,7 +52,7 @@ Exempt pairings include (non-exhaustive):
 | `<input type="checkbox">` | `checkbox`, `switch` | native `checked` state                           |
 | `<input type="radio">`    | `radio`              | native `checked` state                           |
 | `<input type="range">`    | `slider`             | native `value` / `min` / `max`                   |
-| `<input type="number">`   | `spinbutton`         | native `value` (spinbutton has no required ARIA) |
+| `<input type="number">`   | `spinbutton`         | native `value` / `min` / `max` (spinbutton's required `aria-valuenow` is derived from the native `value`) |
 | `<input type="text">`     | `textbox`            | no required ARIA                                 |
 | `<input type="search">`   | `searchbox`          | no required ARIA                                 |
 

--- a/docs/rules/template-require-mandatory-role-attributes.md
+++ b/docs/rules/template-require-mandatory-role-attributes.md
@@ -47,14 +47,14 @@ When the role attribute explicitly declares a role that the native element alrea
 
 Exempt pairings include (non-exhaustive):
 
-| Element                   | Role                 | Required ARIA state supplied by                  |
-| ------------------------- | -------------------- | ------------------------------------------------ |
-| `<input type="checkbox">` | `checkbox`, `switch` | native `checked` state                           |
-| `<input type="radio">`    | `radio`              | native `checked` state                           |
-| `<input type="range">`    | `slider`             | native `value` / `min` / `max`                   |
+| Element                   | Role                 | Required ARIA state supplied by                                                                           |
+| ------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| `<input type="checkbox">` | `checkbox`, `switch` | native `checked` state                                                                                    |
+| `<input type="radio">`    | `radio`              | native `checked` state                                                                                    |
+| `<input type="range">`    | `slider`             | native `value` / `min` / `max`                                                                            |
 | `<input type="number">`   | `spinbutton`         | native `value` / `min` / `max` (spinbutton's required `aria-valuenow` is derived from the native `value`) |
-| `<input type="text">`     | `textbox`            | no required ARIA                                 |
-| `<input type="search">`   | `searchbox`          | no required ARIA                                 |
+| `<input type="text">`     | `textbox`            | no required ARIA                                                                                          |
+| `<input type="search">`   | `searchbox`          | no required ARIA                                                                                          |
 
 Undocumented pairings (e.g. `<input type="checkbox" role="menuitemcheckbox">` — axobject-query does not list this) remain flagged.
 

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -53,22 +53,30 @@ function getStaticAttrValue(node, name) {
   return undefined;
 }
 
-function getTagName(node) {
+// In classic Handlebars (.hbs) `{{input}}` globally resolves to Ember's
+// built-in input helper, which renders a native <input>. In strict-mode
+// GJS/GTS there is no corresponding lowercase `input` export from
+// `@ember/component` (only the PascalCase `<Input>` component), so
+// `{{input}}` in strict mode is always a user-bound identifier and cannot
+// be assumed to render a native <input>. Treating it as native there
+// would silently skip required-ARIA checks on arbitrary components.
+function isClassicHbsFilename(context) {
+  const filename = context.filename || context.getFilename?.() || '';
+  return !filename.endsWith('.gjs') && !filename.endsWith('.gts');
+}
+
+function getTagName(node, context) {
   if (node?.type === 'GlimmerElementNode') {
     // HTML tag names are case-insensitive; normalize so <INPUT>/<Input> match
     // the lowercase keys in AX_CONCEPTS_BY_TAG and the semantic-role maps.
     return node.tag?.toLowerCase();
   }
   if (node?.type === 'GlimmerMustacheStatement' && node.path?.original === 'input') {
-    // The classic `{{input}}` helper renders a native <input>.
-    //
-    // Caveat: in strict GJS/GTS mode, `{{input}}` is whatever was imported
-    // under the name `input` — it could be the classic helper (still renders
-    // native <input>) or some user-defined component. We assume the classic
-    // helper; the false-positive rate in practice is low because strict-mode
-    // authors rarely use `{{input}}` at all (idiomatic is <input> or
-    // <Input>), and when they do, it's almost always the imported built-in.
-    return 'input';
+    if (!context || isClassicHbsFilename(context)) {
+      return 'input';
+    }
+    // Strict-mode {{input}} — not the classic helper, can't claim native.
+    return null;
   }
   return null;
 }
@@ -111,8 +119,8 @@ function buildAxConceptsByTag() {
   return index;
 }
 
-function isSemanticRoleElement(node, role) {
-  const tag = getTagName(node);
+function isSemanticRoleElement(node, role, context) {
+  const tag = getTagName(node, context);
   if (!tag || typeof role !== 'string') {
     return false;
   }
@@ -153,14 +161,14 @@ function isSemanticRoleElement(node, role) {
 // type=checkbox role=switch>), the element is exempt: return { role, missing: null }.
 //
 // Diverges from jsx-a11y, which validates every recognised token.
-function getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node) {
+function getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node, context) {
   for (const role of roleTokens) {
     const roleDefinition = roles.get(role);
     if (!roleDefinition || roleDefinition.abstract) {
       continue;
     }
     // Semantic-role elements expose required ARIA state natively — skip.
-    if (isSemanticRoleElement(node, role)) {
+    if (isSemanticRoleElement(node, role, context)) {
       return { role, missing: null };
     }
     const requiredAttributes = Object.keys(roleDefinition.requiredProps);
@@ -227,7 +235,7 @@ module.exports = {
           .filter((attribute) => attribute.name?.startsWith('aria-'))
           .map((attribute) => attribute.name);
 
-        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node);
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node, context);
 
         if (result?.missing) {
           reportMissingAttributes(node, result.role, result.missing);
@@ -245,7 +253,7 @@ module.exports = {
           .filter((pair) => pair.key.startsWith('aria-'))
           .map((pair) => pair.key);
 
-        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node);
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node, context);
 
         if (result?.missing) {
           reportMissingAttributes(node, result.role, result.missing);

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -35,11 +35,7 @@ function splitRoleTokens(value) {
   if (!value) {
     return undefined;
   }
-  const tokens = value
-    .trim()
-    .toLowerCase()
-    .split(/\s+/u)
-    .filter(Boolean);
+  const tokens = value.trim().toLowerCase().split(/\s+/u).filter(Boolean);
   return tokens.length > 0 ? tokens : undefined;
 }
 

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -1,24 +1,35 @@
 const { roles } = require('aria-query');
 const { AXObjectRoles, elementAXObjects } = require('axobject-query');
 
-function getStaticRoleFromElement(node) {
+// ARIA role values are whitespace-separated tokens compared ASCII-case-insensitively.
+// Returns the list of normalised tokens, or undefined when the attribute is
+// missing or dynamic.
+function getStaticRolesFromElement(node) {
   const roleAttr = node.attributes?.find((attr) => attr.name === 'role');
 
   if (roleAttr?.value?.type === 'GlimmerTextNode') {
-    return roleAttr.value.chars || undefined;
+    return splitRoleTokens(roleAttr.value.chars);
   }
 
   return undefined;
 }
 
-function getStaticRoleFromMustache(node) {
+function getStaticRolesFromMustache(node) {
   const rolePair = node.hash?.pairs?.find((pair) => pair.key === 'role');
 
   if (rolePair?.value?.type === 'GlimmerStringLiteral') {
-    return rolePair.value.value;
+    return splitRoleTokens(rolePair.value.value);
   }
 
   return undefined;
+}
+
+function splitRoleTokens(value) {
+  if (!value) {
+    return undefined;
+  }
+  const tokens = value.trim().toLowerCase().split(/\s+/u).filter(Boolean);
+  return tokens.length > 0 ? tokens : undefined;
 }
 
 // Reads the static lowercase value of `name` from either a GlimmerElementNode
@@ -79,17 +90,17 @@ const AX_CONCEPTS_BY_TAG = buildAxConceptsByTag();
 function buildAxConceptsByTag() {
   const index = new Map();
   for (const [concept, axObjectNames] of elementAXObjects) {
-    const roles = new Set();
+    const conceptRoles = new Set();
     for (const axName of axObjectNames) {
       const axRoles = AXObjectRoles.get(axName);
       if (!axRoles) {
         continue;
       }
       for (const axRole of axRoles) {
-        roles.add(axRole.name);
+        conceptRoles.add(axRole.name);
       }
     }
-    const entry = { attributes: concept.attributes || [], roles };
+    const entry = { attributes: concept.attributes || [], roles: conceptRoles };
     if (!index.has(concept.name)) {
       index.set(concept.name, []);
     }
@@ -108,8 +119,8 @@ function isSemanticRoleElement(node, role) {
     return false;
   }
   const targetRole = role.toLowerCase();
-  for (const { attributes, roles } of entries) {
-    if (!roles.has(targetRole)) {
+  for (const { attributes, roles: conceptRoles } of entries) {
+    if (!conceptRoles.has(targetRole)) {
       continue;
     }
     const allMatch = attributes.every((cAttr) => {
@@ -129,26 +140,39 @@ function isSemanticRoleElement(node, role) {
   return false;
 }
 
-function getMissingRequiredAttributes(role, foundAriaAttributes, node) {
-  const roleDefinition = roles.get(role);
-
-  if (!roleDefinition) {
-    return null;
+// For an ARIA role-fallback list like "combobox listbox", check required
+// attributes against the FIRST recognised role (the primary) per ARIA 1.2
+// role-fallback semantics — a user agent picks the first role it recognises.
+// Abstract roles (widget, input, command, section, … — ARIA §5.3) are
+// ontology categories, not valid authoring roles, so UAs skip them too.
+//
+// When the primary role is a semantic-role element (axobject-query says the
+// native element provides the required ARIA state natively — e.g. <input
+// type=checkbox role=switch>), the element is exempt: return { role, missing: null }.
+//
+// Diverges from jsx-a11y, which validates every recognised token.
+function getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node) {
+  for (const role of roleTokens) {
+    const roleDefinition = roles.get(role);
+    if (!roleDefinition || roleDefinition.abstract) {
+      continue;
+    }
+    // Semantic-role elements expose required ARIA state natively — skip.
+    if (isSemanticRoleElement(node, role)) {
+      return { role, missing: null };
+    }
+    const requiredAttributes = Object.keys(roleDefinition.requiredProps);
+    const missingRequiredAttributes = requiredAttributes
+      .filter((requiredAttribute) => !foundAriaAttributes.includes(requiredAttribute))
+      // Sort for deterministic report order (aria-query's requiredProps
+      // iteration order is not guaranteed stable across versions).
+      .sort();
+    return {
+      role,
+      missing: missingRequiredAttributes.length > 0 ? missingRequiredAttributes : null,
+    };
   }
-
-  // If axobject-query classifies this {element, role} pair as a semantic role
-  // element, the native element provides all required ARIA state — skip the
-  // missing-attribute check entirely (matches jsx-a11y's approach).
-  if (isSemanticRoleElement(node, role)) {
-    return null;
-  }
-
-  const requiredAttributes = Object.keys(roleDefinition.requiredProps);
-  const missingRequiredAttributes = requiredAttributes.filter(
-    (requiredAttribute) => !foundAriaAttributes.includes(requiredAttribute)
-  );
-
-  return missingRequiredAttributes.length > 0 ? missingRequiredAttributes : null;
+  return null;
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -191,9 +215,9 @@ module.exports = {
 
     return {
       GlimmerElementNode(node) {
-        const role = getStaticRoleFromElement(node);
+        const roleTokens = getStaticRolesFromElement(node);
 
-        if (!role) {
+        if (!roleTokens) {
           return;
         }
 
@@ -201,21 +225,17 @@ module.exports = {
           .filter((attribute) => attribute.name?.startsWith('aria-'))
           .map((attribute) => attribute.name);
 
-        const missingRequiredAttributes = getMissingRequiredAttributes(
-          role,
-          foundAriaAttributes,
-          node
-        );
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node);
 
-        if (missingRequiredAttributes) {
-          reportMissingAttributes(node, role, missingRequiredAttributes);
+        if (result?.missing) {
+          reportMissingAttributes(node, result.role, result.missing);
         }
       },
 
       GlimmerMustacheStatement(node) {
-        const role = getStaticRoleFromMustache(node);
+        const roleTokens = getStaticRolesFromMustache(node);
 
-        if (!role) {
+        if (!roleTokens) {
           return;
         }
 
@@ -223,14 +243,10 @@ module.exports = {
           .filter((pair) => pair.key.startsWith('aria-'))
           .map((pair) => pair.key);
 
-        const missingRequiredAttributes = getMissingRequiredAttributes(
-          role,
-          foundAriaAttributes,
-          node
-        );
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node);
 
-        if (missingRequiredAttributes) {
-          reportMissingAttributes(node, role, missingRequiredAttributes);
+        if (result?.missing) {
+          reportMissingAttributes(node, result.role, result.missing);
         }
       },
     };

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -55,7 +55,9 @@ function getStaticAttrValue(node, name) {
 
 function getTagName(node) {
   if (node?.type === 'GlimmerElementNode') {
-    return node.tag;
+    // HTML tag names are case-insensitive; normalize so <INPUT>/<Input> match
+    // the lowercase keys in AX_CONCEPTS_BY_TAG and the semantic-role maps.
+    return node.tag?.toLowerCase();
   }
   if (node?.type === 'GlimmerMustacheStatement' && node.path?.original === 'input') {
     // The classic `{{input}}` helper renders a native <input>.

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -40,7 +40,9 @@ function splitRoleTokens(value) {
 }
 
 // For an ARIA role-fallback list like "combobox listbox", check required
-// attributes against the FIRST recognised role (the primary) — matches jsx-a11y.
+// attributes against the FIRST recognised role (the primary) per ARIA 1.2
+// role-fallback semantics — a user agent picks the first role it recognises.
+// Diverges from jsx-a11y, which validates every recognised token.
 function getMissingRequiredAttributes(roleTokens, foundAriaAttributes) {
   for (const role of roleTokens) {
     const roleDefinition = roles.get(role);

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -8,39 +8,59 @@ function createRequiredAttributeErrorMessage(attrs, role) {
   return `The attributes ${attrs.join(', ')} are required by the role ${role}`;
 }
 
-function getStaticRoleFromElement(node) {
+// ARIA role values are whitespace-separated tokens compared ASCII-case-insensitively.
+// Returns the list of normalised tokens, or undefined when the attribute is
+// missing or dynamic.
+function getStaticRolesFromElement(node) {
   const roleAttr = node.attributes?.find((attr) => attr.name === 'role');
 
   if (roleAttr?.value?.type === 'GlimmerTextNode') {
-    return roleAttr.value.chars || undefined;
+    return splitRoleTokens(roleAttr.value.chars);
   }
 
   return undefined;
 }
 
-function getStaticRoleFromMustache(node) {
+function getStaticRolesFromMustache(node) {
   const rolePair = node.hash?.pairs?.find((pair) => pair.key === 'role');
 
   if (rolePair?.value?.type === 'GlimmerStringLiteral') {
-    return rolePair.value.value;
+    return splitRoleTokens(rolePair.value.value);
   }
 
   return undefined;
 }
 
-function getMissingRequiredAttributes(role, foundAriaAttributes) {
-  const roleDefinition = roles.get(role);
-
-  if (!roleDefinition) {
-    return null;
+function splitRoleTokens(value) {
+  if (!value) {
+    return undefined;
   }
+  const tokens = value
+    .trim()
+    .toLowerCase()
+    .split(/\s+/u)
+    .filter(Boolean);
+  return tokens.length > 0 ? tokens : undefined;
+}
 
-  const requiredAttributes = Object.keys(roleDefinition.requiredProps);
-  const missingRequiredAttributes = requiredAttributes.filter(
-    (requiredAttribute) => !foundAriaAttributes.includes(requiredAttribute)
-  );
-
-  return missingRequiredAttributes.length > 0 ? missingRequiredAttributes : null;
+// For an ARIA role-fallback list like "combobox listbox", check required
+// attributes against the FIRST recognised role (the primary) — matches jsx-a11y.
+function getMissingRequiredAttributes(roleTokens, foundAriaAttributes) {
+  for (const role of roleTokens) {
+    const roleDefinition = roles.get(role);
+    if (!roleDefinition) {
+      continue;
+    }
+    const requiredAttributes = Object.keys(roleDefinition.requiredProps);
+    const missingRequiredAttributes = requiredAttributes.filter(
+      (requiredAttribute) => !foundAriaAttributes.includes(requiredAttribute)
+    );
+    return {
+      role,
+      missing: missingRequiredAttributes.length > 0 ? missingRequiredAttributes : null,
+    };
+  }
+  return null;
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -83,9 +103,9 @@ module.exports = {
 
     return {
       GlimmerElementNode(node) {
-        const role = getStaticRoleFromElement(node);
+        const roleTokens = getStaticRolesFromElement(node);
 
-        if (!role) {
+        if (!roleTokens) {
           return;
         }
 
@@ -93,17 +113,17 @@ module.exports = {
           .filter((attribute) => attribute.name?.startsWith('aria-'))
           .map((attribute) => attribute.name);
 
-        const missingRequiredAttributes = getMissingRequiredAttributes(role, foundAriaAttributes);
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes);
 
-        if (missingRequiredAttributes) {
-          reportMissingAttributes(node, role, missingRequiredAttributes);
+        if (result?.missing) {
+          reportMissingAttributes(node, result.role, result.missing);
         }
       },
 
       GlimmerMustacheStatement(node) {
-        const role = getStaticRoleFromMustache(node);
+        const roleTokens = getStaticRolesFromMustache(node);
 
-        if (!role) {
+        if (!roleTokens) {
           return;
         }
 
@@ -111,10 +131,10 @@ module.exports = {
           .filter((pair) => pair.key.startsWith('aria-'))
           .map((pair) => pair.key);
 
-        const missingRequiredAttributes = getMissingRequiredAttributes(role, foundAriaAttributes);
+        const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes);
 
-        if (missingRequiredAttributes) {
-          reportMissingAttributes(node, role, missingRequiredAttributes);
+        if (result?.missing) {
+          reportMissingAttributes(node, result.role, result.missing);
         }
       },
     };

--- a/tests/audit/role-has-required-aria/peer-parity.js
+++ b/tests/audit/role-has-required-aria/peer-parity.js
@@ -1,0 +1,204 @@
+// Audit fixture — peer-plugin parity for
+// `ember/template-require-mandatory-role-attributes`.
+//
+// Source files (context/ checkouts):
+//   - eslint-plugin-jsx-a11y-main/src/rules/role-has-required-aria-props.js
+//   - eslint-plugin-jsx-a11y-main/__tests__/src/rules/role-has-required-aria-props-test.js
+//   - eslint-plugin-vuejs-accessibility-main/src/rules/role-has-required-aria-props.ts
+//   - angular-eslint-main/packages/eslint-plugin-template/src/rules/role-has-required-aria.ts
+//   - angular-eslint-main/packages/eslint-plugin-template/tests/rules/role-has-required-aria/cases.ts
+//   - eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js
+//
+// These tests are NOT part of the main suite and do not run in CI. They encode
+// the CURRENT behavior of our rule. Each divergence from an upstream plugin is
+// annotated as "DIVERGENCE —".
+
+'use strict';
+
+const rule = require('../../../lib/rules/template-require-mandatory-role-attributes');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('audit:role-has-required-aria (gts)', rule, {
+  valid: [
+    // === Upstream parity (valid everywhere) ===
+    '<template><div /></template>',
+    '<template><div role="button" /></template>', // no required props
+    '<template><div role="heading" aria-level="2" /></template>',
+    '<template><span role="button">X</span></template>',
+    // checkbox with aria-checked — valid in all plugins.
+    '<template><div role="checkbox" aria-checked="false" /></template>',
+    // combobox with BOTH required props (jsx-a11y, vue, ours).
+    '<template><div role="combobox" aria-expanded="false" aria-controls="id" /></template>',
+    // scrollbar requires aria-valuenow, aria-valuemin, aria-valuemax, aria-controls, aria-orientation.
+    // slider similarly — we leave the all-present case off for brevity.
+
+    // Dynamic role — skipped by all.
+    '<template><div role={{this.role}} /></template>',
+
+    // Unknown role — jsx-a11y filters out unknown, we return null. Both allow.
+    '<template><div role="foobar" /></template>',
+
+    // === DIVERGENCE — <input type="checkbox" role="switch"> ===
+    // jsx-a11y: VALID via `isSemanticRoleElement` (semantic input[type=checkbox]
+    //   counts as already-declaring aria-checked via its `checked` state).
+    // vue-a11y: VALID via explicit carve-out in filterRequiredPropsExceptions.
+    // angular: VALID via isSemanticRoleElement.
+    // Our rule: INVALID — we treat every element generically and `switch` has
+    //   `aria-checked` as a required prop. Captured in invalid section below.
+
+    // === Partial parity — space-separated role tokens ===
+    // jsx-a11y + vue: split on whitespace, validate EACH recognised token.
+    // Our rule: splits on whitespace, validates only the FIRST recognised
+    //   token (ARIA 1.2 §4.1 role-fallback semantics — UA picks the first
+    //   recognised role). So `<div role="button combobox">` — which has
+    //   "button" as the first recognised token (no required attrs) —
+    //   remains valid for us but jsx-a11y would flag it for missing
+    //   combobox attrs.
+    '<template><div role="button combobox" /></template>',
+    // Both-token case where the first token HAS no required attrs: valid
+    //   for us, invalid for jsx-a11y.
+    '<template><div role="heading button" aria-level="2" /></template>',
+  ],
+
+  invalid: [
+    // === Upstream parity (invalid everywhere) ===
+    {
+      code: '<template><div role="slider" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="checkbox" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="combobox" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="scrollbar" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="heading" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="option" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+
+    // === Partial parity — partial attrs present, still missing one ===
+    // jsx-a11y flags `<div role="scrollbar" aria-valuemax aria-valuemin />`
+    //   (missing aria-controls/aria-orientation/aria-valuenow).
+    // Our rule: also flags — missing-attrs list non-empty. Parity.
+    {
+      code: '<template><div role="combobox" aria-controls="x" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+
+    // === Parity — case-insensitive role comparison ===
+    // jsx-a11y + vue + angular lowercase the role value before lookup.
+    // Our rule now does the same, so `<div role="COMBOBOX" />` → INVALID
+    //   (missing aria-expanded / aria-controls).
+    {
+      code: '<template><div role="COMBOBOX" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<template><div role="SLIDER" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+
+    // === Parity — whitespace-separated roles, first recognised validated ===
+    // `<div role="combobox listbox">` — both tokens are recognised roles
+    //   with required attrs. Per ARIA role-fallback semantics we validate
+    //   the first recognised token (combobox). jsx-a11y validates every
+    //   token; both plugins end up flagging this same code (though our
+    //   error names `combobox`, jsx-a11y may cite all missing attrs).
+    {
+      code: '<template><div role="combobox listbox" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+
+    // === DIVERGENCE — input[type=checkbox] role="switch" ===
+    // jsx-a11y / vue / angular: VALID (semantic exception).
+    // Our rule: INVALID (missing aria-checked). FALSE POSITIVE.
+    //   (This PR does not fix the semantic-input exception; separate
+    //   fix lives on fix/role-required-aria-checkbox-switch.)
+    {
+      code: '<template><input type="checkbox" role="switch" /></template>',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+  ],
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+hbsRuleTester.run('audit:role-has-required-aria (hbs)', rule, {
+  valid: [
+    '<div />',
+    '<div role="button" />',
+    '<div role="heading" aria-level="2" />',
+    '<div role="combobox" aria-expanded="false" aria-controls="id" />',
+    // Partial-parity: role-fallback validates only the first recognised
+    //   token. `<div role="button combobox">` is valid for us (first
+    //   recognised token "button" needs no attrs) but flagged by jsx-a11y.
+    '<div role="button combobox" />',
+    //   unknown role
+    '<div role="foobar" />',
+  ],
+  invalid: [
+    {
+      code: '<div role="slider" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<div role="checkbox" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    {
+      code: '<div role="heading" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    // Parity — case-insensitive comparison.
+    {
+      code: '<div role="COMBOBOX" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    // Parity — whitespace-separated roles, first recognised validated.
+    {
+      code: '<div role="combobox listbox" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+    // DIVERGENCE: semantic input exception — jsx-a11y/vue/angular say VALID.
+    {
+      code: '<input type="checkbox" role="switch" />',
+      output: null,
+      errors: [{ messageId: 'missingAttributes' }],
+    },
+  ],
+});

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -193,6 +193,30 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
         },
       ],
     },
+    // Strict-mode {{input}} is a scope binding, not Ember's classic helper
+    // (which doesn't exist as a strict-mode export from @ember/component).
+    // The semantic-role exemption must NOT apply — we can't prove the
+    // imported identifier renders a native <input>. Flag the missing ARIA.
+    {
+      code: '<template>{{input type="checkbox" role="switch"}}</template>',
+      filename: 'component.gjs',
+      output: null,
+      errors: [
+        {
+          message: 'The attribute aria-checked is required by the role switch',
+        },
+      ],
+    },
+    {
+      code: '<template>{{input type="range" role="slider"}}</template>',
+      filename: 'component.gts',
+      output: null,
+      errors: [
+        {
+          message: 'The attribute aria-valuenow is required by the role slider',
+        },
+      ],
+    },
   ],
 });
 

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -198,8 +198,8 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
     // The semantic-role exemption must NOT apply — we can't prove the
     // imported identifier renders a native <input>. Flag the missing ARIA.
     {
-      code: '<template>{{input type="checkbox" role="switch"}}</template>',
       filename: 'component.gjs',
+      code: '<template>{{input type="checkbox" role="switch"}}</template>',
       output: null,
       errors: [
         {
@@ -208,8 +208,8 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       ],
     },
     {
-      code: '<template>{{input type="range" role="slider"}}</template>',
       filename: 'component.gts',
+      code: '<template>{{input type="range" role="slider"}}</template>',
       output: null,
       errors: [
         {

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -74,6 +74,18 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       output: null,
       errors: [{ message: 'The attribute aria-selected is required by the role option' }],
     },
+    // Plain widget roles missing all required attrs — basic coverage that
+    // peer plugins (jsx-a11y / vue-a11y / angular-eslint) also flag.
+    {
+      code: '<template><div role="slider" /></template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-valuenow is required by the role slider' }],
+    },
+    {
+      code: '<template><div role="checkbox" /></template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-checked is required by the role checkbox' }],
+    },
     {
       code: '<template><CustomComponent role="checkbox" aria-required="true" /></template>',
       output: null,

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -45,16 +45,17 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
     '<template>{{input type="Checkbox" role="switch"}}</template>',
     '<template>{{input type="range" role="slider"}}</template>',
 
-    // Documented divergences from jsx-a11y / vue-a11y / angular-eslint:
-    // - Space-separated role tokens: peers split on whitespace and require
-    //   attrs for each token. We pass the whole string to aria-query, so
-    //   `role="combobox listbox"` lookup misses → no flag. (Case below.)
-    // - Case-folding role values: peers lowercase before lookup; we don't.
-    //   `role="COMBOBOX"` similarly misses lookup → no flag.
-    // - Unknown role: all plugins skip — parity, captured for completeness.
-    '<template><div role="combobox listbox" /></template>',
-    '<template><div role="COMBOBOX" /></template>',
-    '<template><div role="SLIDER" /></template>',
+    // Case-insensitive role matching — ARIA role tokens compare as ASCII-case-insensitive.
+    '<template><div role="COMBOBOX" aria-expanded="false" aria-controls="ctrl" /></template>',
+    // Role fallback list — primary role's required attributes are satisfied.
+    '<template><div role="combobox listbox" aria-expanded="false" aria-controls="ctrl" /></template>',
+    // Abstract roles (ARIA §5.3) are skipped per §4.1 fallback semantics —
+    // `widget` isn't an authoring role, so the UA walks past it to the next
+    // recognised token. Here `button` has no required attrs → valid.
+    '<template><div role="widget button" /></template>',
+    // Abstract role followed by a concrete role that IS satisfied.
+    '<template><div role="command slider" aria-valuenow="0" /></template>',
+    // Unknown roles are skipped — rule only checks required attrs for known roles.
     '<template><div role="foobar" /></template>',
   ],
 
@@ -159,6 +160,38 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       code: '<template><input type="radio" role="menuitemradio" /></template>',
       output: null,
       errors: [{ message: 'The attribute aria-checked is required by the role menuitemradio' }],
+    },
+    // Case-insensitivity surfaces previously-unflagged mistakes.
+    {
+      code: '<template><div role="COMBOBOX"></div></template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attributes aria-controls, aria-expanded are required by the role combobox',
+        },
+      ],
+    },
+    // Role-fallback list: when the primary role is missing required props, flag it.
+    {
+      code: '<template><div role="combobox listbox"></div></template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attributes aria-controls, aria-expanded are required by the role combobox',
+        },
+      ],
+    },
+    // Abstract role (`widget`) followed by a concrete role that's missing
+    // required attrs — UA skips the abstract, lands on `slider`, which
+    // requires aria-valuenow.
+    {
+      code: '<template><div role="widget slider"></div></template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attribute aria-valuenow is required by the role slider',
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -81,7 +81,7 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       errors: [{ message: 'The attribute aria-checked is required by the role checkbox' }],
     },
 
-    // Case-insensitivity surfaces previously-unflagged mistakes.
+    // Case-insensitive role matching — uppercase role missing required props is flagged.
     {
       code: '<template><div role="COMBOBOX"></div></template>',
       output: null,

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -25,6 +25,11 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
     '<template>{{foo-component role="button"}}</template>',
     '<template>{{foo-component role="unknown"}}</template>',
     '<template>{{foo-component role=role}}</template>',
+
+    // Case-insensitive role matching — ARIA role tokens compare as ASCII-case-insensitive.
+    '<template><div role="COMBOBOX" aria-expanded="false" aria-controls="ctrl" /></template>',
+    // Role fallback list — primary role's required attributes are satisfied.
+    '<template><div role="combobox listbox" aria-expanded="false" aria-controls="ctrl" /></template>',
   ],
 
   invalid: [
@@ -74,6 +79,27 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       code: '<template>{{foo role="checkbox"}}</template>',
       output: null,
       errors: [{ message: 'The attribute aria-checked is required by the role checkbox' }],
+    },
+
+    // Case-insensitivity surfaces previously-unflagged mistakes.
+    {
+      code: '<template><div role="COMBOBOX"></div></template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attributes aria-controls, aria-expanded are required by the role combobox',
+        },
+      ],
+    },
+    // Role-fallback list: when the primary role is missing required props, flag it.
+    {
+      code: '<template><div role="combobox listbox"></div></template>',
+      output: null,
+      errors: [
+        {
+          message: 'The attributes aria-controls, aria-expanded are required by the role combobox',
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -161,7 +161,7 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
       output: null,
       errors: [{ message: 'The attribute aria-checked is required by the role menuitemradio' }],
     },
-    // Case-insensitivity surfaces previously-unflagged mistakes.
+    // Case-insensitive role matching — uppercase role missing required props is flagged.
     {
       code: '<template><div role="COMBOBOX"></div></template>',
       output: null,


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

Two related fixes (shared root cause — both deal with role-token normalisation).

## 1. Case-insensitive role comparison

- **Premise:** ARIA role token comparison inherits case-insensitivity from HTML's enumerated-attribute rules — `role="COMBOBOX"` is the same token as `role="combobox"`. ([WAI-ARIA 1.2 §4.1](https://www.w3.org/TR/wai-aria-1.2/#introroles) explicitly defers case-sensitivity to the host language: *"Case-sensitivity of the comparison inherits from the case-sensitivity of the host language."*)
- **Problem:** `<div role="COMBOBOX">` was silently accepted — `roles.get("COMBOBOX")` returns undefined in `aria-query`, so the rule skipped the check entirely.

Fix: lowercase the role value before the lookup.

## 2. Whitespace-separated role fallback lists

- **Premise:** Per [WAI-ARIA 1.2 §4.1](https://www.w3.org/TR/wai-aria-1.2/#introroles), a `role` attribute may list multiple tokens and *"User agents MUST use the first token in the sequence of tokens in the role attribute value that matches the name of any non-abstract WAI-ARIA role."*
- **Problem:** `role="combobox listbox"` was treated as one opaque string. `aria-query` returned undefined, the rule skipped silently, and `<div role="combobox listbox">` without `aria-expanded` + `aria-controls` wasn't flagged.

Fix: split on whitespace, validate **the first recognised role** per ARIA §4.1's first-token semantics. This diverges from jsx-a11y and vue-a11y, which validate every recognised token — our approach is closer to the UA behavior the spec prescribes. Noted as a deliberate divergence.

Helpers renamed to plural forms (`getStaticRolesFromElement`, `getStaticRolesFromMustache`). `getMissingRequiredAttributes` now returns `{ role, missing }` so the reporter can cite the actually-checked role in the error message.

Four new tests cover both fixes (valid + invalid of each).

## Prior art

Verified each peer in source:

| Plugin | Rule | Verified behavior |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/role-has-required-aria-props.js#L63) | `role-has-required-aria-props` | `String(roleAttrValue).toLowerCase().split(' ')` → `.filter(recognised)` → `.forEach(validate)`. Validates EVERY recognised token. |
| [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/rules/role-has-required-aria-props.ts) | `role-has-required-aria-props` | `roleValue.toLowerCase().split(" ").forEach(role => { if (isAriaRoleDefinitionKey(role)) validate(role) })`. Same pattern. |
| [@angular-eslint/template](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/src/rules/role-has-required-aria.ts#L51-L55) | `role-has-required-aria` | Raw role string passed directly to `roles.get(role)`. No `.toLowerCase()`, no `.split()`. |
| [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/lib/rules/role-has-required-aria-attrs.js) | `role-has-required-aria-attrs` | Raw role string passed to `isAriaRole` / `roles.get`. No splitting, no lowercasing. |
