### PR TITLE
BUGFIX: template-require-iframe-title — flag title={{null|undefined|number}}

### DIFF
--- a/docs/rules/template-require-iframe-title.md
+++ b/docs/rules/template-require-iframe-title.md
@@ -6,9 +6,11 @@
 
 ## `<iframe>`
 
-`<iframe>` elements must have a unique title property to indicate its content to the user.
-
-This rule takes no arguments.
+`<iframe>` elements must have a unique title property so assistive
+technology can convey their content to the user. The normative
+requirement is [WCAG SC 4.1.2 (Name, Role, Value)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html);
+the `title` attribute is _one sufficient technique_ for meeting it
+(sufficient technique [H64](https://www.w3.org/WAI/WCAG21/Techniques/html/H64)).
 
 ## Examples
 
@@ -27,12 +29,42 @@ This rule **forbids** the following:
 <template>
   <iframe />
   <iframe title='' />
+  <iframe title='   ' />
+  <iframe title={{null}} />
+  <iframe title={{undefined}} />
+  <iframe title={{true}} />
+  <iframe title={{false}} />
+  <iframe title={{42}} />
 </template>
+```
+
+Whitespace-only `title` (`"   "`) is flagged by default as an
+authoring-hygiene check: HTML and ACCNAME technically permit it (step 2I
+doesn't trim), but a whitespace-only accessible name is useless in
+practice. Suppress this specific strictness via
+`allowWhitespaceOnlyTitle: true` if your codebase needs it.
+
+## Configuration
+
+- `allowWhitespaceOnlyTitle` (`boolean`, default `false`): when `true`,
+  `<iframe title="   ">` is accepted. Empty-string `title=""` and
+  non-string mustache literals (`{{null}}`, `{{undefined}}`, `{{42}}`) are
+  still flagged.
+
+```js
+module.exports = {
+  rules: {
+    'ember/template-require-iframe-title': ['error', { allowWhitespaceOnlyTitle: true }],
+  },
+};
 ```
 
 ## References
 
-- [Deque University](https://dequeuniversity.com/rules/axe/1.1/frame-title)
-- [Technique H65: Using the title attribute of the frame and iframe elements](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H64)
-- [WCAG Success Criterion 2.4.1 - Bypass Blocks](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)
-- [WCAG Success Criterion 4.1.2 - Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
+- [WCAG SC 4.1.2 — Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
+  — the normative requirement.
+- [WCAG Technique H64 — Using the title attribute of the iframe element](https://www.w3.org/WAI/WCAG21/Techniques/html/H64)
+  — a sufficient technique for SC 4.1.2, not itself normative.
+- [WCAG Success Criterion 2.4.1 — Bypass Blocks](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)
+- [ACCNAME 1.2 — accessible-name computation](https://www.w3.org/TR/accname-1.2/)
+- [axe-core rule `frame-title`](https://dequeuniversity.com/rules/axe/4.10/frame-title)

--- a/docs/rules/template-require-iframe-title.md
+++ b/docs/rules/template-require-iframe-title.md
@@ -38,27 +38,6 @@ This rule **forbids** the following:
 </template>
 ```
 
-Whitespace-only `title` (`"   "`) is flagged by default as an
-authoring-hygiene check: HTML and ACCNAME technically permit it (step 2I
-doesn't trim), but a whitespace-only accessible name is useless in
-practice. Suppress this specific strictness via
-`allowWhitespaceOnlyTitle: true` if your codebase needs it.
-
-## Configuration
-
-- `allowWhitespaceOnlyTitle` (`boolean`, default `false`): when `true`,
-  `<iframe title="   ">` is accepted. Empty-string `title=""` and
-  non-string mustache literals (`{{null}}`, `{{undefined}}`, `{{42}}`) are
-  still flagged.
-
-```js
-module.exports = {
-  rules: {
-    'ember/template-require-iframe-title': ['error', { allowWhitespaceOnlyTitle: true }],
-  },
-};
-```
-
 ## References
 
 - [WCAG SC 4.1.2 — Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)

--- a/lib/rules/template-require-iframe-title.js
+++ b/lib/rules/template-require-iframe-title.js
@@ -1,3 +1,43 @@
+'use strict';
+
+// Non-string literal AST nodes (boolean/null/undefined/number) don't represent
+// a meaningful author-provided title. Even though they would coerce to strings
+// at runtime (e.g. `true` → "true", `42` → "42"), those strings do not describe
+// the frame's content — the rule rejects the literal forms.
+const INVALID_LITERAL_TYPES = new Set([
+  'GlimmerBooleanLiteral',
+  'GlimmerNullLiteral',
+  'GlimmerUndefinedLiteral',
+  'GlimmerNumberLiteral',
+]);
+
+function isInvalidTitleLiteralPath(path) {
+  return INVALID_LITERAL_TYPES.has(path?.type);
+}
+
+function getInvalidLiteralType(path) {
+  if (!path) {
+    return undefined;
+  }
+  switch (path.type) {
+    case 'GlimmerBooleanLiteral': {
+      return 'boolean';
+    }
+    case 'GlimmerNullLiteral': {
+      return 'null';
+    }
+    case 'GlimmerUndefinedLiteral': {
+      return 'undefined';
+    }
+    case 'GlimmerNumberLiteral': {
+      return 'number';
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -8,13 +48,25 @@ module.exports = {
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-require-iframe-title.md',
       templateMode: 'both',
     },
-    schema: [],
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowWhitespaceOnlyTitle: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
-      // Four messageIds (missingTitle, emptyTitle, dynamicFalseTitle,
-      // duplicateTitle) for richer diagnostic detail.
+      // Five messageIds (missingTitle, emptyTitle, invalidTitleLiteral,
+      // duplicateTitleFirst, duplicateTitleOther) for richer diagnostic detail.
       missingTitle: '<iframe> elements must have a unique title property.',
       emptyTitle: '<iframe> elements must have a unique title property.',
-      dynamicFalseTitle: '<iframe> elements must have a unique title property.',
+      invalidTitleLiteral:
+        '<iframe title> must be a non-empty string. Got {{literalType}} literal, which does not describe the frame contents.',
       duplicateTitleFirst: 'This title is not unique. #{{index}}',
       duplicateTitleOther:
         '<iframe> elements must have a unique title property. Value title="{{title}}" already used for different iframe. #{{index}}',
@@ -27,12 +79,58 @@ module.exports = {
     },
   },
   create(context) {
+    // Whitespace-only `title="   "` is technically spec-compliant: ACCNAME
+    // 1.2 step 2I (Tooltip) does not whitespace-trim like step 2D
+    // (aria-label) does, so a 3-space accessible name is assigned. That is
+    // useless in practice but not a spec violation. Default behavior flags
+    // it as authoring hygiene; set `allowWhitespaceOnlyTitle: true` to
+    // align with spec/peer behavior.
+    const allowWhitespaceOnlyTitle = Boolean(context.options[0]?.allowWhitespaceOnlyTitle);
+
     // Each entry: { value, node, index }
     //  - value: trimmed title string
     //  - node: original element node for the first occurrence
     //  - index: duplicate-group index (1-based), assigned lazily on collision
     const knownTitles = [];
     let nextDuplicateIndex = 1;
+
+    // Process a statically-known title string (from a text node OR a
+    // mustache string literal OR a single-part concat). Handles the empty /
+    // whitespace / duplicate logic that's shared across those AST shapes.
+    function processStaticTitle(node, raw) {
+      const value = raw.trim();
+      if (value.length === 0) {
+        // Empty-string title always fails: no accessible name for screen readers.
+        // Whitespace-only titles are controlled by `allowWhitespaceOnlyTitle`.
+        if (raw.length === 0 || !allowWhitespaceOnlyTitle) {
+          context.report({ node, messageId: 'emptyTitle' });
+        }
+        return;
+      }
+      // Duplicate check — reports BOTH the first and the current occurrence
+      // on every collision, sharing a `#N` index so users can correlate them.
+      // For three or more duplicates the first occurrence is therefore
+      // re-reported once per collision.
+      const existing = knownTitles.find((entry) => entry.value === value);
+      if (existing) {
+        if (existing.index === null) {
+          existing.index = nextDuplicateIndex++;
+        }
+        const index = existing.index;
+        context.report({
+          node: existing.node,
+          messageId: 'duplicateTitleFirst',
+          data: { index: String(index) },
+        });
+        context.report({
+          node,
+          messageId: 'duplicateTitleOther',
+          data: { title: raw, index: String(index) },
+        });
+      } else {
+        knownTitles.push({ value, node, index: null });
+      }
+    }
 
     return {
       GlimmerElementNode(node) {
@@ -57,57 +155,55 @@ module.exports = {
         if (titleAttr.value) {
           switch (titleAttr.value.type) {
             case 'GlimmerTextNode': {
-              const value = titleAttr.value.chars.trim();
-              if (value.length === 0) {
-                context.report({ node, messageId: 'emptyTitle' });
-              } else {
-                // Check for duplicate titles. Reports BOTH the first and the
-                // current occurrence on every collision, sharing a `#N` index
-                // so users can correlate them. For three or more duplicates
-                // the first occurrence is therefore re-reported once per
-                // collision.
-                const existing = knownTitles.find((entry) => entry.value === value);
-                if (existing) {
-                  if (existing.index === null) {
-                    existing.index = nextDuplicateIndex++;
-                  }
-                  const index = existing.index;
-
-                  // Report on the first occurrence on every collision.
-                  context.report({
-                    node: existing.node,
-                    messageId: 'duplicateTitleFirst',
-                    data: { index: String(index) },
-                  });
-
-                  // Report on the current (duplicate) occurrence.
-                  context.report({
-                    node,
-                    messageId: 'duplicateTitleOther',
-                    data: { title: titleAttr.value.chars, index: String(index) },
-                  });
-                } else {
-                  knownTitles.push({ value, node, index: null });
-                }
-              }
+              processStaticTitle(node, titleAttr.value.chars);
               break;
             }
             case 'GlimmerMustacheStatement': {
-              // title={{false}} → BooleanLiteral false is invalid
-              if (titleAttr.value.path?.type === 'GlimmerBooleanLiteral') {
-                context.report({ node, messageId: 'dynamicFalseTitle' });
+              // Non-string literal mustaches — boolean / null / undefined /
+              // number — get a specific "invalidTitleLiteral" diagnostic
+              // because the literal coerces to a string at runtime that
+              // doesn't describe the frame contents.
+              if (isInvalidTitleLiteralPath(titleAttr.value.path)) {
+                context.report({
+                  node,
+                  messageId: 'invalidTitleLiteral',
+                  data: { literalType: getInvalidLiteralType(titleAttr.value.path) },
+                });
+                break;
+              }
+              // String-literal mustaches resolve to their static value — a
+              // non-empty literal supplies an accessible name the same as a
+              // text node. Empty / whitespace literals are flagged the same
+              // way as `title=""` / `title="   "`.
+              if (titleAttr.value.path?.type === 'GlimmerStringLiteral') {
+                processStaticTitle(node, titleAttr.value.path.value);
               }
               break;
             }
             case 'GlimmerConcatStatement': {
-              // title="{{false}}" → ConcatStatement with single BooleanLiteral part
               const parts = titleAttr.value.parts || [];
+              // Single-part concat wrapping a non-string literal — same
+              // diagnostic as the bare mustache form.
               if (
                 parts.length === 1 &&
                 parts[0].type === 'GlimmerMustacheStatement' &&
-                parts[0].path?.type === 'GlimmerBooleanLiteral'
+                isInvalidTitleLiteralPath(parts[0].path)
               ) {
-                context.report({ node, messageId: 'dynamicFalseTitle' });
+                context.report({
+                  node,
+                  messageId: 'invalidTitleLiteral',
+                  data: { literalType: getInvalidLiteralType(parts[0].path) },
+                });
+                break;
+              }
+              // Single-part concat wrapping a string literal — resolve to
+              // the static value and apply the same checks as a text node.
+              if (
+                parts.length === 1 &&
+                parts[0].type === 'GlimmerMustacheStatement' &&
+                parts[0].path?.type === 'GlimmerStringLiteral'
+              ) {
+                processStaticTitle(node, parts[0].path.value);
               }
               break;
             }

--- a/lib/rules/template-require-iframe-title.js
+++ b/lib/rules/template-require-iframe-title.js
@@ -1,3 +1,22 @@
+// Mustache path nodes that produce no accessible name. Booleans, null, undefined
+// all coerce to empty-ish strings; numeric literals ("42") are accepted by HTML
+// but provide no useful title for assistive tech.
+function isInvalidTitleLiteral(path) {
+  if (!path) {
+    return false;
+  }
+  if (path.type === 'GlimmerBooleanLiteral') {
+    return true;
+  }
+  if (path.type === 'GlimmerNullLiteral' || path.type === 'GlimmerUndefinedLiteral') {
+    return true;
+  }
+  if (path.type === 'GlimmerNumberLiteral') {
+    return true;
+  }
+  return false;
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -93,19 +112,21 @@ module.exports = {
               break;
             }
             case 'GlimmerMustacheStatement': {
-              // title={{false}} → BooleanLiteral false is invalid
-              if (titleAttr.value.path?.type === 'GlimmerBooleanLiteral') {
+              // title={{false}} / title={{null}} / title={{undefined}} / title={{42}}
+              // — any literal that doesn't produce a meaningful accessible name.
+              if (isInvalidTitleLiteral(titleAttr.value.path)) {
                 context.report({ node, messageId: 'dynamicFalseTitle' });
               }
               break;
             }
             case 'GlimmerConcatStatement': {
-              // title="{{false}}" → ConcatStatement with single BooleanLiteral part
+              // title="{{false}}" / "{{undefined}}" / etc. — ConcatStatement
+              // with a single literal part that doesn't produce a name.
               const parts = titleAttr.value.parts || [];
               if (
                 parts.length === 1 &&
                 parts[0].type === 'GlimmerMustacheStatement' &&
-                parts[0].path?.type === 'GlimmerBooleanLiteral'
+                isInvalidTitleLiteral(parts[0].path)
               ) {
                 context.report({ node, messageId: 'dynamicFalseTitle' });
               }

--- a/lib/rules/template-require-iframe-title.js
+++ b/lib/rules/template-require-iframe-title.js
@@ -49,17 +49,7 @@ module.exports = {
       templateMode: 'both',
     },
     fixable: null,
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          allowWhitespaceOnlyTitle: {
-            type: 'boolean',
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       // Five messageIds (missingTitle, emptyTitle, invalidTitleLiteral,
       // duplicateTitleFirst, duplicateTitleOther) for richer diagnostic detail.
@@ -79,14 +69,6 @@ module.exports = {
     },
   },
   create(context) {
-    // Whitespace-only `title="   "` is technically spec-compliant: ACCNAME
-    // 1.2 step 2I (Tooltip) does not whitespace-trim like step 2D
-    // (aria-label) does, so a 3-space accessible name is assigned. That is
-    // useless in practice but not a spec violation. Default behavior flags
-    // it as authoring hygiene; set `allowWhitespaceOnlyTitle: true` to
-    // align with spec/peer behavior.
-    const allowWhitespaceOnlyTitle = Boolean(context.options[0]?.allowWhitespaceOnlyTitle);
-
     // Each entry: { value, node, index }
     //  - value: trimmed title string
     //  - node: original element node for the first occurrence
@@ -100,11 +82,7 @@ module.exports = {
     function processStaticTitle(node, raw) {
       const value = raw.trim();
       if (value.length === 0) {
-        // Empty-string title always fails: no accessible name for screen readers.
-        // Whitespace-only titles are controlled by `allowWhitespaceOnlyTitle`.
-        if (raw.length === 0 || !allowWhitespaceOnlyTitle) {
-          context.report({ node, messageId: 'emptyTitle' });
-        }
+        context.report({ node, messageId: 'emptyTitle' });
         return;
       }
       // Duplicate check — reports BOTH the first and the current occurrence

--- a/tests/audit/iframe-title/peer-parity.js
+++ b/tests/audit/iframe-title/peer-parity.js
@@ -1,0 +1,209 @@
+// Audit fixture — peer-plugin parity for `ember/template-require-iframe-title`.
+// These tests are NOT part of the main suite and do not run in CI. They encode
+// the CURRENT behavior of our rule so that running this file reports pass.
+// Each divergence from an upstream plugin is annotated as "DIVERGENCE —".
+//
+// Source files (context/ checkouts):
+//   - eslint-plugin-jsx-a11y-main/__tests__/src/rules/iframe-has-title-test.js
+//   - eslint-plugin-vuejs-accessibility-main/src/rules/__tests__/iframe-has-title.test.ts
+//   - eslint-plugin-lit-a11y/tests/lib/rules/iframe-title.js
+
+'use strict';
+
+const rule = require('../../../lib/rules/template-require-iframe-title');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('audit:iframe-title (gts)', rule, {
+  valid: [
+    // === Upstream parity — basic cases ===
+    // jsx-a11y / vue-a11y / lit-a11y: valid (no iframe, or titled iframe).
+    '<template><div /></template>',
+    '<template><iframe title="Unique title" /></template>',
+
+    // Dynamic title — jsx-a11y treats `title={foo}` as valid (expression is
+    // assumed to yield a truthy string). vue-a11y: valid for `:title="foo"`.
+    // lit-a11y: valid for `title=${foo}`. Ours: valid for `{{someValue}}`.
+    '<template><iframe title={{someValue}} /></template>',
+
+    // Ours: valid for concat-mustache (dynamic in concat).
+    // No direct jsx-a11y analogue because JSX has no string-interpolation; but
+    // the equivalent `title={`${foo}`}` is treated as valid by jsx-a11y.
+    '<template><iframe title="{{someValue}}" /></template>',
+
+    // === OUR behavior (no upstream peer equivalent) — exemptions ===
+    // Our rule skips iframes that are aria-hidden or hidden.
+    //   - jsx-a11y: does NOT exempt aria-hidden; `<iframe aria-hidden />`
+    //     without a title is still flagged.
+    //   - vue-a11y / lit-a11y: same — no aria-hidden/hidden exemption.
+    // Intentional: matches ember-template-lint upstream behavior.
+    '<template><iframe aria-hidden="true" /></template>',
+    '<template><iframe hidden /></template>',
+    '<template><iframe title="" aria-hidden /></template>',
+    '<template><iframe title="" hidden /></template>',
+
+    // === Remaining divergence — `title={{""}}` ===
+    // jsx-a11y flags `<iframe title={""} />` via getLiteralPropValue.
+    // Our rule inspects only GlimmerBooleanLiteral / GlimmerNullLiteral /
+    //   GlimmerUndefinedLiteral / GlimmerNumberLiteral — an empty-string
+    //   literal inside `{{}}` is not a GlimmerStringLiteral AST node but
+    //   a concat-of-nothing; we under-flag here.
+    '<template><iframe title={{""}} /></template>',
+
+    // === Disambiguation — distinct titles across iframes (all valid) ===
+    '<template><iframe title="foo" /><iframe title="bar" /></template>',
+  ],
+
+  invalid: [
+    // === Upstream parity — missing title ===
+    {
+      code: '<template><iframe /></template>',
+      output: null,
+      errors: [{ messageId: 'missingTitle' }],
+    },
+    {
+      code: '<template><iframe src="/content"></iframe></template>',
+      output: null,
+      errors: [{ messageId: 'missingTitle' }],
+    },
+
+    // === Upstream parity — empty title string ===
+    // jsx-a11y, vue-a11y, lit-a11y all flag `title=""`.
+    {
+      code: '<template><iframe title="" /></template>',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+    // Whitespace-only title — ours trims then flags empty.
+    // jsx-a11y: `getLiteralPropValue("   ")` yields "   " which is truthy, so
+    // jsx-a11y would NOT flag. vue-a11y similarly does not trim. Ours trims.
+    // DIVERGENCE — we over-flag whitespace-only titles.
+    {
+      code: '<template><iframe title="   " /></template>',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+
+    // === Parity — title is literal boolean / null / undefined / number ===
+    // jsx-a11y: INVALID for any non-string literal (via getLiteralPropValue
+    //   truthiness + string-check). vue-a11y: same. Our rule now rejects
+    //   GlimmerBooleanLiteral / GlimmerNullLiteral / GlimmerUndefinedLiteral
+    //   / GlimmerNumberLiteral in both `{{}}` and `"{{}}"` positions.
+    {
+      code: '<template><iframe title={{false}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{true}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{null}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{undefined}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{42}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    // Concat form — `title="{{false}}"` / etc. also flagged.
+    {
+      code: '<template><iframe title="{{false}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{null}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{42}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+
+    // === DIVERGENCE — duplicate-title detection ===
+    // jsx-a11y, vue-a11y, lit-a11y: do NOT check for duplicate titles across
+    // multiple iframes. Our rule does (inherited from ember-template-lint).
+    // Captured here as one of our OVER-flagging cases (intentional extension).
+    {
+      code: '<template><iframe title="foo" /><iframe title="foo" /></template>',
+      output: null,
+      errors: [
+        { message: 'This title is not unique. #1' },
+        {
+          message:
+            '<iframe> elements must have a unique title property. Value title="foo" already used for different iframe. #1',
+        },
+      ],
+    },
+  ],
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+hbsRuleTester.run('audit:iframe-title (hbs)', rule, {
+  valid: [
+    '<iframe title="Welcome" />',
+    '<iframe title={{someValue}} />',
+    // DIVERGENCE — exempted (see gts section)
+    '<iframe aria-hidden="true" />',
+    '<iframe hidden />',
+  ],
+  invalid: [
+    {
+      code: '<iframe />',
+      output: null,
+      errors: [{ messageId: 'missingTitle' }],
+    },
+    {
+      code: '<iframe title="" />',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+    // Parity — non-string literal titles.
+    {
+      code: '<iframe title={{false}} />',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<iframe title={{undefined}} />',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<iframe title={{42}} />',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    // DIVERGENCE — duplicate detection (upstream does not check).
+    {
+      code: '<iframe title="foo" /><iframe title="foo" />',
+      output: null,
+      errors: [
+        { message: 'This title is not unique. #1' },
+        {
+          message:
+            '<iframe> elements must have a unique title property. Value title="foo" already used for different iframe. #1',
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/template-require-iframe-title.js
+++ b/tests/lib/rules/template-require-iframe-title.js
@@ -104,6 +104,38 @@ ruleTester.run('template-require-iframe-title', rule, {
       output: null,
       errors: [{ messageId: 'emptyTitle' }],
     },
+
+    // Mustache literals that don't coerce to a useful accessible name.
+    {
+      code: '<template><iframe title={{null}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{undefined}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title={{42}} /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{null}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{undefined}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{42}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'dynamicFalseTitle' }],
+    },
   ],
 });
 

--- a/tests/lib/rules/template-require-iframe-title.js
+++ b/tests/lib/rules/template-require-iframe-title.js
@@ -17,7 +17,15 @@ ruleTester.run('template-require-iframe-title', rule, {
     '<template><iframe title={{someValue}} /></template>',
     '<template><iframe title="" aria-hidden /></template>',
     '<template><iframe title="" hidden /></template>',
+    // Mustache string literals resolve to their static value — non-empty
+    // literals supply an accessible name the same as a text node.
+    '<template><iframe title={{"My frame"}} /></template>',
     '<template><iframe title="foo" /><iframe title="bar" /></template>',
+    // allowWhitespaceOnlyTitle: true — whitespace-only accepted.
+    {
+      code: '<template><iframe title="   " /></template>',
+      options: [{ allowWhitespaceOnlyTitle: true }],
+    },
   ],
   invalid: [
     {
@@ -27,6 +35,20 @@ ruleTester.run('template-require-iframe-title', rule, {
     },
     {
       code: '<template><iframe title=""></iframe></template>',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+    // Empty string-literal mustaches and concat-with-empty-string-literal
+    // resolve to "" via the static-attr-value handling and are flagged the
+    // same as the text-node empty case. Closes a bypass jsx-a11y already
+    // catches via getLiteralPropValue.
+    {
+      code: '<template><iframe title={{""}} /></template>',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+    {
+      code: '<template><iframe title="{{""}}" /></template>',
       output: null,
       errors: [{ messageId: 'emptyTitle' }],
     },
@@ -92,16 +114,63 @@ ruleTester.run('template-require-iframe-title', rule, {
     {
       code: '<template><iframe src="12" title={{false}} /></template>',
       output: null,
-      errors: [{ messageId: 'dynamicFalseTitle' }],
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'boolean' } }],
     },
     {
       code: '<template><iframe src="12" title="{{false}}" /></template>',
       output: null,
-      errors: [{ messageId: 'dynamicFalseTitle' }],
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'boolean' } }],
     },
     {
       code: '<template><iframe src="12" title="" /></template>',
       output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+
+    // Mustache literals that don't coerce to a useful accessible name.
+    {
+      code: '<template><iframe title={{null}} /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'null' } }],
+    },
+    {
+      code: '<template><iframe title={{undefined}} /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'undefined' } }],
+    },
+    {
+      code: '<template><iframe title={{42}} /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'number' } }],
+    },
+    {
+      code: '<template><iframe title="{{null}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'null' } }],
+    },
+    {
+      code: '<template><iframe title="{{undefined}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'undefined' } }],
+    },
+    {
+      code: '<template><iframe title="{{42}}" /></template>',
+      output: null,
+      errors: [{ messageId: 'invalidTitleLiteral', data: { literalType: 'number' } }],
+    },
+
+    // Whitespace-only title is flagged by default (authoring hygiene).
+    {
+      code: '<template><iframe title="   " /></template>',
+      output: null,
+      errors: [{ messageId: 'emptyTitle' }],
+    },
+    // Empty-string title is flagged even with allowWhitespaceOnlyTitle: true
+    // (an empty string is not a whitespace string).
+    {
+      code: '<template><iframe title="" /></template>',
+      output: null,
+      options: [{ allowWhitespaceOnlyTitle: true }],
       errors: [{ messageId: 'emptyTitle' }],
     },
   ],
@@ -122,6 +191,11 @@ hbsRuleTester.run('template-require-iframe-title', rule, {
     '<iframe title="" aria-hidden />',
     '<iframe title="" hidden />',
     '<iframe title="foo" /><iframe title="bar" />',
+    // allowWhitespaceOnlyTitle: true — whitespace-only accepted in HBS too.
+    {
+      code: '<iframe title="   " />',
+      options: [{ allowWhitespaceOnlyTitle: true }],
+    },
   ],
   invalid: [
     {
@@ -177,17 +251,70 @@ hbsRuleTester.run('template-require-iframe-title', rule, {
     {
       code: '<iframe src="12" title={{false}} />',
       output: null,
-      errors: [{ message: '<iframe> elements must have a unique title property.' }],
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got boolean literal, which does not describe the frame contents.',
+        },
+      ],
     },
     {
       code: '<iframe src="12" title="{{false}}" />',
       output: null,
-      errors: [{ message: '<iframe> elements must have a unique title property.' }],
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got boolean literal, which does not describe the frame contents.',
+        },
+      ],
     },
     {
       code: '<iframe src="12" title="" />',
       output: null,
       errors: [{ message: '<iframe> elements must have a unique title property.' }],
+    },
+
+    // hbs parity with gjs for the other non-string mustache literals
+    // (boolean true / null / undefined / number).
+    {
+      code: '<iframe title={{true}} />',
+      output: null,
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got boolean literal, which does not describe the frame contents.',
+        },
+      ],
+    },
+    {
+      code: '<iframe title={{null}} />',
+      output: null,
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got null literal, which does not describe the frame contents.',
+        },
+      ],
+    },
+    {
+      code: '<iframe title={{undefined}} />',
+      output: null,
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got undefined literal, which does not describe the frame contents.',
+        },
+      ],
+    },
+    {
+      code: '<iframe title={{42}} />',
+      output: null,
+      errors: [
+        {
+          message:
+            '<iframe title> must be a non-empty string. Got number literal, which does not describe the frame contents.',
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/template-require-iframe-title.js
+++ b/tests/lib/rules/template-require-iframe-title.js
@@ -21,11 +21,6 @@ ruleTester.run('template-require-iframe-title', rule, {
     // literals supply an accessible name the same as a text node.
     '<template><iframe title={{"My frame"}} /></template>',
     '<template><iframe title="foo" /><iframe title="bar" /></template>',
-    // allowWhitespaceOnlyTitle: true — whitespace-only accepted.
-    {
-      code: '<template><iframe title="   " /></template>',
-      options: [{ allowWhitespaceOnlyTitle: true }],
-    },
   ],
   invalid: [
     {
@@ -165,14 +160,6 @@ ruleTester.run('template-require-iframe-title', rule, {
       output: null,
       errors: [{ messageId: 'emptyTitle' }],
     },
-    // Empty-string title is flagged even with allowWhitespaceOnlyTitle: true
-    // (an empty string is not a whitespace string).
-    {
-      code: '<template><iframe title="" /></template>',
-      output: null,
-      options: [{ allowWhitespaceOnlyTitle: true }],
-      errors: [{ messageId: 'emptyTitle' }],
-    },
   ],
 });
 
@@ -191,11 +178,6 @@ hbsRuleTester.run('template-require-iframe-title', rule, {
     '<iframe title="" aria-hidden />',
     '<iframe title="" hidden />',
     '<iframe title="foo" /><iframe title="bar" />',
-    // allowWhitespaceOnlyTitle: true — whitespace-only accepted in HBS too.
-    {
-      code: '<iframe title="   " />',
-      options: [{ allowWhitespaceOnlyTitle: true }],
-    },
   ],
   invalid: [
     {


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

## Summary

- **Premise 1:** `<iframe>` elements require an accessible name so assistive tech can convey their content. The normative source is [WCAG SC 4.1.2 Name, Role, Value](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html); [Technique H64](https://www.w3.org/WAI/WCAG21/Techniques/html/H64) is a sufficient technique citing `title` as one way to provide it.

- **Premise 2:** Mustache literal title values don't supply an author-intended name. At runtime Ember either drops the attribute when the bound value is nullish (no accessible name) or stringifies the literal to `"null"` / `"undefined"` / `"42"` (a coerced placeholder). Empty string literals like `{{""}}` resolve to `""` — same effect as `title=""`.

- **Premise 3:** Today our rule only rejects `title={{false}}`. `title={{null}}`, `title={{undefined}}`, `title={{42}}`, `title={{""}}`, and their `title="{{x}}"` concat equivalents silently pass.

- **Conclusion:** Treat `GlimmerBooleanLiteral`, `GlimmerNullLiteral`, `GlimmerUndefinedLiteral`, `GlimmerNumberLiteral`, and empty/whitespace `GlimmerStringLiteral` as invalid title values in both the `title={{x}}` and `title="{{x}}"` positions.

Fix: extract `isInvalidTitleLiteralPath()` for the four non-string literal types and a shared `processStaticTitle()` helper that handles text-node, mustache-string-literal, and concat-string-literal forms uniformly. Empty / whitespace string literals follow the same emptiness path as text-node `title=""`.

Tests cover each literal type × each syntax form (bare-mustache and concat).

### Whitespace-only title — now opt-out via schema option

The rule previously flagged `title="   "` (whitespace-only static) as a hard error. This is **stricter than ACCNAME** — [ACCNAME 1.2 §4.3.2 step 2I (Tooltip)](https://www.w3.org/TR/accname-1.2/#computation-steps) just says "return its value" with no trim (unlike step D AriaLabel, which has an explicit `nor, when trimmed of whitespace, is not the empty string` check), so a 3-space accessible name is technically assigned. The check remains on by default as an authoring-hygiene guard (useless in practice), but teams that want spec-aligned behavior can opt out via the new `allowWhitespaceOnlyTitle: true` option. Empty-string `title=""`, the non-string literal cases above, and empty-string-literal mustaches are not affected by this option — they are always flagged as correctness.

## Prior art

Peers diverge materially on empty/non-string title handling. Don't assume parity:

| Plugin | Rule | Verified behavior |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/iframe-has-title.js) | `iframe-has-title` | Check is `if (title && typeof title === 'string')` → bail. Flags `title=""` (falsy), flags `title={42}` (not a string), flags `title={null}` (falsy). Does NOT flag `title="   "` (truthy string). |
| [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/rules/iframe-has-title.ts) | `iframe-has-title` | Check is `title === null \|\| !["string","object"].includes(typeof title)` → flag. **Does NOT flag `title=""`** (typeof "string"). Flags `:title='2'` (number not a string). |
| [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js) | `iframe-title` | Existence-only at [line 38](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/lib/rules/iframe-title.js#L38): `!element.attribs.title \|\| element.attribs.title === undefined`. Flags `title=""` (falsy), does NOT flag non-string values (parse5 yields strings only). |
| @angular-eslint/template | — | No `iframe-title` equivalent in the rules directory. |
