### PR TITLE
fix: ignore comment + whitespace nodes in template-no-yield-only

### DIFF
--- a/lib/rules/template-no-yield-only.js
+++ b/lib/rules/template-no-yield-only.js
@@ -1,3 +1,11 @@
+function isEmptyNode(node) {
+  return (
+    node.type === 'GlimmerMustacheCommentStatement' ||
+    node.type === 'GlimmerCommentStatement' ||
+    (node.type === 'GlimmerTextNode' && !node.chars.trim())
+  );
+}
+
 function isYieldOnly(node) {
   return (
     node.type === 'GlimmerMustacheStatement' &&
@@ -44,7 +52,8 @@ module.exports = {
             ? node.body[0].children
             : node.body;
 
-        if (templateNodes.length === 1 && isYieldOnly(templateNodes[0])) {
+        const nonEmptyNodes = templateNodes.filter((n) => !isEmptyNode(n));
+        if (nonEmptyNodes.length === 1 && isYieldOnly(nonEmptyNodes[0])) {
           isOnlyYield = true;
         }
       },

--- a/tests/lib/rules/template-no-yield-only.js
+++ b/tests/lib/rules/template-no-yield-only.js
@@ -30,6 +30,16 @@ const invalidHbs = [
     output: null,
     errors: [{ messageId: 'noYieldOnly' }],
   },
+  {
+    code: '{{!-- long-form comment --}}{{yield}}',
+    output: null,
+    errors: [{ messageId: 'noYieldOnly' }],
+  },
+  {
+    code: '<!-- html comment -->{{yield}}',
+    output: null,
+    errors: [{ messageId: 'noYieldOnly' }],
+  },
 ];
 
 function wrapTemplate(entry) {


### PR DESCRIPTION
Cowritten by claude:

## Summary

- `template-no-yield-only` flags yield-only templates via `templateNodes.length === 1 && isYieldOnly(templateNodes[0])`. That holds only while the parser strips template comments out of the body, which `ember-estree@0.4.2` happened to do.
- Upstream `ember-estree@0.4.3` ([NullVoxPopuli/ember-estree#31](https://github.com/NullVoxPopuli/ember-estree/pull/31)) started keeping `MustacheCommentStatement` nodes in the body (the native Glimmer AST shape). Under that parser a template like `<template>{{! x }}{{yield}}</template>` has a body of length 2 and is silently no longer flagged. This is the rule failure that blocks #2735's CI.
- Fix: filter comment + whitespace-only text nodes before the length check, via the same `isEmptyNode` helper that upstream `ember-template-lint` and the sibling rule `template-no-bare-yield.js` already use.

## Why fix it here rather than in the parser / estree

`ember-estree@0.4.3`'s change is the correct AST: it matches the pure-hbs parser (`ember-eslint-parser/hbs`) and the native Glimmer AST, both of which have always kept comment nodes in the template body. Re-hiding those nodes at the parser layer would re-introduce the bug that #2733 guards against (`{{! eslint-disable-* }}` directives would again be invisible to tooling that needs to see them). The semantic decision "should a comment-plus-yield template count as yield-only?" belongs to the rule.

## What this does not fix
Latent bug still remain after this PR (candidates for follow-up)                                                                                                                                              
  
  1. {{yield to="inverse"}} is still wrongly flagged. The initial #2596 commit had (!node.hash || !node.hash.pairs || node.hash.pairs.length === 0) guarding against this — the AI correctly called it "an           
  improvement" over upstream. The sync commit dropped it. A template whose only body is {{yield to="inverse"}} is not truly "yield-only" — it's explicitly delegating to the else / named <:inverse> block, which is
  the idiomatic way to do that. Upstream has this bug; we inherited it on the sync commit; we could diverge better.                                                                                                                                                                 
  
separate follow-up?                         
 

## Notes

- `template-no-bare-yield.js` and `template-no-yield-only.js` are near-duplicate ports of `ember-template-lint/lib/rules/no-yield-only.js`; only the former had kept pace with upstream's empty-node filter. This closes that drift.
- The filter is a no-op on the currently-pinned `ember-eslint-parser@0.10`, so this is safe to land independently of #2735 and paves the way for that PR's CI to go green once rebased.
- This also fixes a latent bug the rule had on 0.10: `<!-- html -->{{yield}}` was not being flagged as yield-only; now it is.

## Test plan

- [x] `pnpm test tests/lib/rules/template-no-yield-only.js` — 22 passed (18 original + 4 new assertions: `{{!-- long --}}{{yield}}` and `<!-- x -->{{yield}}` against both the gjs and hbs parsers)
- [x] `npx prettier --check` + `npx eslint` clean on both modified files
- [ ] CI green