### PR TITLE
fix: template-no-autofocus-attribute — value-aware + <dialog> exception

### DIFF
--- a/docs/rules/template-no-autofocus-attribute.md
+++ b/docs/rules/template-no-autofocus-attribute.md
@@ -40,13 +40,16 @@ Examples of **correct** code for this rule:
 </template>
 ```
 
-Explicit opt-out via a falsy value is allowed (parity with
-[`jsx-a11y/no-autofocus`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md)):
+Explicit opt-out via a mustache boolean `false` is allowed — this is the
+only form that statically guarantees no rendered `autofocus` attribute
+(Glimmer VM normalizes `{{false}}` to attribute removal). The string
+`autofocus="false"` is still flagged per HTML boolean-attribute semantics
+(any attribute presence, including the string `"false"`, enables autofocus).
 
 ```gjs
 <template>
-  <input autofocus="false" />
   <input autofocus={{false}} />
+  {{!-- element syntax: the mustache-boolean form --}}
 </template>
 ```
 

--- a/docs/rules/template-no-autofocus-attribute.md
+++ b/docs/rules/template-no-autofocus-attribute.md
@@ -40,6 +40,28 @@ Examples of **correct** code for this rule:
 </template>
 ```
 
+Explicit opt-out via a falsy value is allowed (parity with
+[`jsx-a11y/no-autofocus`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md)):
+
+```gjs
+<template>
+  <input autofocus="false" />
+  <input autofocus={{false}} />
+</template>
+```
+
+`<dialog>` and its descendants are exempt. A dialog is expected to focus its
+initial element on open, per
+[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog):
+
+```gjs
+<template>
+  <dialog>
+    <button autofocus>Close</button>
+  </dialog>
+</template>
+```
+
 ## When Not To Use It
 
 If you need to autofocus for specific accessibility or UX requirements and have thoroughly tested with assistive technologies, you may disable this rule for those specific cases.

--- a/docs/rules/template-no-autofocus-attribute.md
+++ b/docs/rules/template-no-autofocus-attribute.md
@@ -50,6 +50,9 @@ only form that statically guarantees no rendered `autofocus` attribute
 <template>
   <input autofocus={{false}} />
   {{!-- element syntax: the mustache-boolean form --}}
+
+  {{input autofocus=false}}
+  {{!-- mustache syntax: the hash-pair form --}}
 </template>
 ```
 

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -31,8 +31,9 @@ function isMustacheBooleanFalse(value) {
 }
 
 /**
- * Returns true when the given GlimmerElementNode is a `<dialog>` element
- * or is nested (at any depth) inside a `<dialog>` element. Per MDN,
+ * Returns true when the given node (a GlimmerElementNode OR a
+ * GlimmerMustacheStatement, e.g. `{{input autofocus=true}}`) is a `<dialog>`
+ * element or is nested (at any depth) inside a `<dialog>` element. Per MDN,
  * autofocus on (or within) a dialog is recommended because a dialog should
  * focus its initial element when opened.
  *

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -1,3 +1,64 @@
+/**
+ * Returns true when the attribute value is statically known to be falsy
+ * (i.e. the developer has written `autofocus="false"`, `autofocus={{false}}`,
+ * or `autofocus={{"false"}}`). These forms are aligned with jsx-a11y's
+ * `no-autofocus` rule, which reads the attribute value via `getPropValue` and
+ * skips reporting when the value is falsy (e.g. `<div autoFocus={false} />`).
+ *
+ * Valueless attributes (`<input autofocus>`) are TRUTHY per the HTML spec
+ * (boolean attribute present == "on") and must still be flagged.
+ */
+function isExplicitlyFalsy(value) {
+  if (!value) {
+    // No value property at all — treat as bare boolean attribute (truthy).
+    return false;
+  }
+
+  if (value.type === 'GlimmerTextNode') {
+    // `autofocus="false"` → chars === "false". Bare `autofocus` has chars === "".
+    return value.chars === 'false';
+  }
+
+  if (value.type === 'GlimmerMustacheStatement') {
+    const expr = value.path;
+    if (!expr) {
+      return false;
+    }
+    // `autofocus={{false}}` → BooleanLiteral(false).
+    if (expr.type === 'GlimmerBooleanLiteral' && expr.value === false) {
+      return true;
+    }
+    // `autofocus={{"false"}}` → StringLiteral("false").
+    if (expr.type === 'GlimmerStringLiteral' && expr.value === 'false') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Returns true when the given GlimmerElementNode is a `<dialog>` element
+ * or is nested (at any depth) inside a `<dialog>` element. Per MDN,
+ * autofocus on (or within) a dialog is recommended because a dialog should
+ * focus its initial element when opened.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
+ */
+function isInsideDialog(node) {
+  if (node.type === 'GlimmerElementNode' && node.tag === 'dialog') {
+    return true;
+  }
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (ancestor.type === 'GlimmerElementNode' && ancestor.tag === 'dialog') {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -27,25 +88,39 @@ module.exports = {
       GlimmerElementNode(node) {
         const autofocusAttr = node.attributes?.find((attr) => attr.name === 'autofocus');
 
-        if (autofocusAttr) {
-          context.report({
-            node: autofocusAttr,
-            messageId: 'noAutofocus',
-            fix(fixer) {
-              const sourceCode = context.sourceCode;
-              const text = sourceCode.getText();
-              const attrStart = autofocusAttr.range[0];
-              const attrEnd = autofocusAttr.range[1];
-
-              let removeStart = attrStart;
-              while (removeStart > 0 && /\s/.test(text[removeStart - 1])) {
-                removeStart--;
-              }
-
-              return fixer.removeRange([removeStart, attrEnd]);
-            },
-          });
+        if (!autofocusAttr) {
+          return;
         }
+
+        // jsx-a11y parity: `autofocus="false"` / `={{false}}` / `={{"false"}}`
+        // explicitly opt out and should not be flagged.
+        if (isExplicitlyFalsy(autofocusAttr.value)) {
+          return;
+        }
+
+        // MDN dialog exception: autofocus on a <dialog> or inside a <dialog>
+        // is recommended behavior, not an accessibility defect.
+        if (isInsideDialog(node)) {
+          return;
+        }
+
+        context.report({
+          node: autofocusAttr,
+          messageId: 'noAutofocus',
+          fix(fixer) {
+            const sourceCode = context.sourceCode;
+            const text = sourceCode.getText();
+            const attrStart = autofocusAttr.range[0];
+            const attrEnd = autofocusAttr.range[1];
+
+            let removeStart = attrStart;
+            while (removeStart > 0 && /\s/.test(text[removeStart - 1])) {
+              removeStart--;
+            }
+
+            return fixer.removeRange([removeStart, attrEnd]);
+          },
+        });
       },
 
       GlimmerMustacheStatement(node) {
@@ -53,12 +128,26 @@ module.exports = {
           return;
         }
         const autofocusPair = node.hash.pairs.find((pair) => pair.key === 'autofocus');
-        if (autofocusPair) {
-          context.report({
-            node: autofocusPair,
-            messageId: 'noAutofocus',
-          });
+        if (!autofocusPair) {
+          return;
         }
+
+        // Value-aware check for component/helper invocations such as
+        // `{{input autofocus=false}}` or `{{input autofocus="false"}}`.
+        const pairValue = autofocusPair.value;
+        if (pairValue) {
+          if (pairValue.type === 'GlimmerBooleanLiteral' && pairValue.value === false) {
+            return;
+          }
+          if (pairValue.type === 'GlimmerStringLiteral' && pairValue.value === 'false') {
+            return;
+          }
+        }
+
+        context.report({
+          node: autofocusPair,
+          messageId: 'noAutofocus',
+        });
       },
     };
   },

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -1,40 +1,25 @@
 /**
- * Returns true when the attribute value is statically known to be falsy
- * (i.e. the developer has written `autofocus="false"`, `autofocus={{false}}`,
- * or `autofocus={{"false"}}`). These forms are aligned with jsx-a11y's
- * `no-autofocus` rule, which reads the attribute value via `getPropValue` and
- * skips reporting when the value is falsy (e.g. `<div autoFocus={false} />`).
+ * `autofocus` is a boolean HTML attribute. Per the HTML spec, any presence
+ * (including `autofocus="false"`, `autofocus=""`, `autofocus="autofocus"`)
+ * means the element will auto-focus. Only the genuine absence of the
+ * attribute turns off auto-focus.
  *
- * Valueless attributes (`<input autofocus>`) are TRUTHY per the HTML spec
- * (boolean attribute present == "on") and must still be flagged.
+ * jsx-a11y's `no-autofocus` treats `autofocus={false}` / `autofocus="false"`
+ * as opt-outs — that is a peer-plugin convention that diverges from HTML
+ * boolean-attribute semantics. vue-a11y and lit-a11y are presence-based,
+ * consistent with the spec. We follow the spec.
+ *
+ * The only exception is a mustache boolean-literal `{{false}}` in element
+ * syntax — Glimmer authors writing `autofocus={{false}}` are expressing
+ * intent to omit the attribute conditionally. Treat that narrow literal
+ * case as opt-out (the rendered HTML will have no autofocus attr).
  */
-function isExplicitlyFalsy(value) {
-  if (!value) {
-    // No value property at all — treat as bare boolean attribute (truthy).
+function isMustacheBooleanFalse(value) {
+  if (value?.type !== 'GlimmerMustacheStatement') {
     return false;
   }
-
-  if (value.type === 'GlimmerTextNode') {
-    // `autofocus="false"` → chars === "false". Bare `autofocus` has chars === "".
-    return value.chars === 'false';
-  }
-
-  if (value.type === 'GlimmerMustacheStatement') {
-    const expr = value.path;
-    if (!expr) {
-      return false;
-    }
-    // `autofocus={{false}}` → BooleanLiteral(false).
-    if (expr.type === 'GlimmerBooleanLiteral' && expr.value === false) {
-      return true;
-    }
-    // `autofocus={{"false"}}` → StringLiteral("false").
-    if (expr.type === 'GlimmerStringLiteral' && expr.value === 'false') {
-      return true;
-    }
-  }
-
-  return false;
+  const expr = value.path;
+  return expr?.type === 'GlimmerBooleanLiteral' && expr.value === false;
 }
 
 /**
@@ -92,9 +77,10 @@ module.exports = {
           return;
         }
 
-        // jsx-a11y parity: `autofocus="false"` / `={{false}}` / `={{"false"}}`
-        // explicitly opt out and should not be flagged.
-        if (isExplicitlyFalsy(autofocusAttr.value)) {
+        // Mustache boolean-literal `autofocus={{false}}` renders no attribute
+        // at all — the only statically-known opt-out consistent with HTML
+        // boolean-attribute semantics.
+        if (isMustacheBooleanFalse(autofocusAttr.value)) {
           return;
         }
 
@@ -132,16 +118,14 @@ module.exports = {
           return;
         }
 
-        // Value-aware check for component/helper invocations such as
-        // `{{input autofocus=false}}` or `{{input autofocus="false"}}`.
+        // Mustache hash-pair `{{input autofocus=false}}` — boolean literal
+        // false at the hash-pair level is unambiguous and renders no attr.
+        // Note: `autofocus="false"` in mustache syntax IS still flagged — per
+        // HTML boolean-attribute semantics the string "false" is truthy; it
+        // is only jsx-a11y that carves that form out.
         const pairValue = autofocusPair.value;
-        if (pairValue) {
-          if (pairValue.type === 'GlimmerBooleanLiteral' && pairValue.value === false) {
-            return;
-          }
-          if (pairValue.type === 'GlimmerStringLiteral' && pairValue.value === 'false') {
-            return;
-          }
+        if (pairValue?.type === 'GlimmerBooleanLiteral' && pairValue.value === false) {
+          return;
         }
 
         context.report({

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -9,10 +9,11 @@
  * boolean-attribute semantics. vue-a11y and lit-a11y are presence-based,
  * consistent with the spec. We follow the spec.
  *
- * The only exception is a mustache boolean-literal `{{false}}` in element
- * syntax — Glimmer authors writing `autofocus={{false}}` are expressing
- * intent to omit the attribute conditionally. Treat that narrow literal
- * case as opt-out (the rendered HTML will have no autofocus attr).
+ * The only exception is a boolean-literal `false` — in element syntax
+ * written as `autofocus={{false}}`, and in mustache hash syntax written as
+ * `{{input autofocus=false}}`. Both forms express intent to omit the
+ * attribute conditionally, and the rendered HTML will have no autofocus
+ * attribute. Treat both literal-false cases as opt-out.
  *
  * Verified against Glimmer VM's attribute-normalization source:
  * glimmer-vm/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts —
@@ -132,6 +133,12 @@ module.exports = {
         // is only jsx-a11y that carves that form out.
         const pairValue = autofocusPair.value;
         if (pairValue?.type === 'GlimmerBooleanLiteral' && pairValue.value === false) {
+          return;
+        }
+
+        // MDN dialog exception: autofocus on a mustache component/helper
+        // nested inside a <dialog> is recommended behavior, not a defect.
+        if (isInsideDialog(node)) {
           return;
         }
 

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -39,6 +39,28 @@ function isMustacheBooleanFalse(value) {
  *
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
  */
+// Returns true for `{{input ...}}` and `{{component "input" ...}}` mustache
+// invocations — the only built-ins that deterministically render a native
+// <input> with forwarded attributes.
+function isNativeInputHelper(node) {
+  const path = node.path;
+  if (!path) {
+    return false;
+  }
+  // Direct invocation: `{{input ...}}`.
+  if (path.type === 'GlimmerPathExpression' && path.original === 'input') {
+    return true;
+  }
+  // Contextual component: `{{component "input" ...}}`.
+  if (path.type === 'GlimmerPathExpression' && path.original === 'component') {
+    const firstParam = node.params && node.params[0];
+    if (firstParam && firstParam.type === 'GlimmerStringLiteral' && firstParam.value === 'input') {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isInsideDialog(node) {
   if (node.type === 'GlimmerElementNode' && node.tag === 'dialog') {
     return true;
@@ -124,6 +146,25 @@ module.exports = {
         }
         const autofocusPair = node.hash.pairs.find((pair) => pair.key === 'autofocus');
         if (!autofocusPair) {
+          return;
+        }
+
+        // Narrow to helpers that deterministically render a native `autofocus`
+        // attribute. The rule's purpose is the HTML attribute; arbitrary
+        // components taking an `autofocus` prop are opaque — we can't tell
+        // statically whether that prop forwards to HTML or is used for
+        // something else.
+        //   - `{{input ...}}` — Ember's classic input helper renders a native
+        //     <input> with forwarded attributes.
+        //   - `{{component "input" ...}}` — contextual component resolution
+        //     points at the same helper.
+        //
+        // FUTURE: when type-aware linting lands (e.g., Glint integration or
+        // a template-type-check step), we can resolve custom components that
+        // forward `autofocus` to a native <input> and flag those too. For now
+        // we stay conservative to avoid false positives on unrelated helpers
+        // that happen to take an `autofocus` prop.
+        if (!isNativeInputHelper(node)) {
           return;
         }
 

--- a/lib/rules/template-no-autofocus-attribute.js
+++ b/lib/rules/template-no-autofocus-attribute.js
@@ -13,6 +13,13 @@
  * syntax — Glimmer authors writing `autofocus={{false}}` are expressing
  * intent to omit the attribute conditionally. Treat that narrow literal
  * case as opt-out (the rendered HTML will have no autofocus attr).
+ *
+ * Verified against Glimmer VM's attribute-normalization source:
+ * glimmer-vm/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts —
+ * `normalizeValue` returns `null` for `false | undefined | null`, and
+ * `SimpleDynamicAttribute.update()` calls `element.removeAttribute(name)`
+ * when the normalized value is null. So `autofocus={{false}}` renders
+ * with the attribute entirely absent from the DOM.
  */
 function isMustacheBooleanFalse(value) {
   if (value?.type !== 'GlimmerMustacheStatement') {

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -62,6 +62,14 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
         </div>
       </dialog>
     </template>`,
+
+    // Custom helpers / components taking an `autofocus` prop are opaque —
+    // we can't know whether the prop forwards to a native <input autofocus>
+    // or is used for something else. Narrow to {{input}} / {{component
+    // "input"}} which deterministically render native inputs.
+    `<template>{{my-wrapper autofocus=true}}</template>`,
+    `<template>{{some-component autofocus=true name="foo"}}</template>`,
+    `<template>{{component "some-other-helper" autofocus=true}}</template>`,
   ],
 
   invalid: [

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -22,21 +22,14 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
     `<template>
       <button>Click me</button>
     </template>`,
-    // Value-aware: explicit falsy values opt out (jsx-a11y parity).
-    `<template>
-      <input autofocus="false" />
-    </template>`,
+    // Mustache boolean-literal forms render NO attribute when the literal
+    // is false — these are the statically-known opt-outs that align with
+    // HTML boolean-attribute semantics.
     `<template>
       <input autofocus={{false}} />
     </template>`,
     `<template>
-      <input autofocus={{"false"}} />
-    </template>`,
-    `<template>
       {{input autofocus=false}}
-    </template>`,
-    `<template>
-      {{input autofocus="false"}}
     </template>`,
     // Dialog exception (MDN): autofocus on <dialog> is recommended.
     `<template>
@@ -231,6 +224,35 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
           type: 'GlimmerAttrNode',
         },
       ],
+    },
+
+    // Per HTML boolean-attribute semantics, the string "false" / mustache
+    // string "false" / hash-pair string "false" are all TRUTHY. Only the
+    // mustache boolean-literal {{false}} renders no attribute.
+    {
+      code: `<template>
+        <input autofocus="false" />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [{ messageId: 'noAutofocus', type: 'GlimmerAttrNode' }],
+    },
+    {
+      code: `<template>
+        <input autofocus={{"false"}} />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [{ messageId: 'noAutofocus', type: 'GlimmerAttrNode' }],
+    },
+    {
+      code: `<template>
+        {{input autofocus="false"}}
+      </template>`,
+      output: null,
+      errors: [{ messageId: 'noAutofocus' }],
     },
   ],
 });

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -67,9 +67,9 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
     // we can't know whether the prop forwards to a native <input autofocus>
     // or is used for something else. Narrow to {{input}} / {{component
     // "input"}} which deterministically render native inputs.
-    `<template>{{my-wrapper autofocus=true}}</template>`,
-    `<template>{{some-component autofocus=true name="foo"}}</template>`,
-    `<template>{{component "some-other-helper" autofocus=true}}</template>`,
+    '<template>{{my-wrapper autofocus=true}}</template>',
+    '<template>{{some-component autofocus=true name="foo"}}</template>',
+    '<template>{{component "some-other-helper" autofocus=true}}</template>',
   ],
 
   invalid: [

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -48,8 +48,8 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
         </div>
       </dialog>
     </template>`,
-    // Dialog exception also applies to the mustache form of the `<Input>`
-    // helper (`{{input autofocus=true}}`) — whether direct child or nested.
+    // Dialog exception also applies to the classic mustache form
+    // (`{{input autofocus=true}}`) — whether direct child or nested.
     `<template>
       <dialog>
         {{input autofocus=true}}

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -48,6 +48,20 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
         </div>
       </dialog>
     </template>`,
+    // Dialog exception also applies to the mustache form of the `<Input>`
+    // helper (`{{input autofocus=true}}`) — whether direct child or nested.
+    `<template>
+      <dialog>
+        {{input autofocus=true}}
+      </dialog>
+    </template>`,
+    `<template>
+      <dialog>
+        <div>
+          {{input autofocus=true}}
+        </div>
+      </dialog>
+    </template>`,
   ],
 
   invalid: [

--- a/tests/lib/rules/template-no-autofocus-attribute.js
+++ b/tests/lib/rules/template-no-autofocus-attribute.js
@@ -22,6 +22,39 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
     `<template>
       <button>Click me</button>
     </template>`,
+    // Value-aware: explicit falsy values opt out (jsx-a11y parity).
+    `<template>
+      <input autofocus="false" />
+    </template>`,
+    `<template>
+      <input autofocus={{false}} />
+    </template>`,
+    `<template>
+      <input autofocus={{"false"}} />
+    </template>`,
+    `<template>
+      {{input autofocus=false}}
+    </template>`,
+    `<template>
+      {{input autofocus="false"}}
+    </template>`,
+    // Dialog exception (MDN): autofocus on <dialog> is recommended.
+    `<template>
+      <dialog autofocus></dialog>
+    </template>`,
+    // Dialog descendants are also exempt (angular-eslint parity).
+    `<template>
+      <dialog>
+        <button autofocus>Close</button>
+      </dialog>
+    </template>`,
+    `<template>
+      <dialog>
+        <div>
+          <input autofocus />
+        </div>
+      </dialog>
+    </template>`,
   ],
 
   invalid: [
@@ -115,6 +148,82 @@ ruleTester.run('template-no-autofocus-attribute', rule, {
       </template>`,
       output: `<template>
         <input />
+      </template>`,
+      errors: [
+        {
+          messageId: 'noAutofocus',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    // Value-aware: truthy literals and any dynamic value still flag.
+    {
+      code: `<template>
+        <input autofocus="true" />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [
+        {
+          messageId: 'noAutofocus',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    {
+      code: `<template>
+        <input autofocus={{true}} />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [
+        {
+          messageId: 'noAutofocus',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    {
+      code: `<template>
+        <input autofocus={{"true"}} />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [
+        {
+          messageId: 'noAutofocus',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    {
+      code: `<template>
+        <input autofocus={{this.shouldFocus}} />
+      </template>`,
+      output: `<template>
+        <input />
+      </template>`,
+      errors: [
+        {
+          messageId: 'noAutofocus',
+          type: 'GlimmerAttrNode',
+        },
+      ],
+    },
+    // Dialog exception only applies within <dialog>; siblings elsewhere still flag.
+    {
+      code: `<template>
+        <section>
+          <button autofocus>Focus</button>
+        </section>
+      </template>`,
+      output: `<template>
+        <section>
+          <button>Focus</button>
+        </section>
       </template>`,
       errors: [
         {


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

## Premise

The Phase 3 audit on `audit/phase3/no-autofocus` (fixture B10 in `tests/audit/no-autofocus/peer-parity.js`) flagged two gaps in `template-no-autofocus-attribute`, tracked in PR #28 as G3 and G4:

- **G3** — The rule flagged `autofocus` on attribute presence only, so `autofocus={{false}}` (which renders no attribute at all in the final HTML) was reported even though the rendered element has no autofocus.
- **G4** — The rule flagged `autofocus` on any element, including `<dialog>` and its descendants. MDN's `<dialog>` reference describes autofocus-on-open as the recommended dialog behavior.

## Fix

### G3 — value-aware for mustache boolean-literal only

Per the HTML Living Standard on [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes), the presence of `autofocus` indicates TRUE regardless of value — `autofocus="false"` and `autofocus="autofocus"` are equally truthy. The only statically-known opt-out consistent with HTML boolean-attribute semantics is:

- `<input autofocus={{false}} />` — Glimmer renders no `autofocus` attribute when the mustache-literal evaluates to false.
- `{{input autofocus=false}}` — same at the hash-pair level.

Both are now exempted.

**Verification of the Glimmer rendering claim:** the attribute-omission behavior is authoritative per [Glimmer VM's `dynamic.ts`](https://github.com/glimmerjs/glimmer-vm/blob/main/packages/@glimmer/runtime/lib/vm/attributes/dynamic.ts): `normalizeValue` returns `null` for `false | undefined | null`, and `SimpleDynamicAttribute.update()` calls `element.removeAttribute(name)` when the normalized value is null. So `autofocus={{false}}` renders with no `autofocus` attribute in the DOM — not `autofocus="false"`.

**Not exempted** (flagged per spec):

- `autofocus="false"` — presence = truthy.
- `autofocus={{"false"}}` — renders as `autofocus="false"` = truthy.
- `{{input autofocus="false"}}` — same.
- Dynamic mustache expressions (helpers, path references) — can't be proved safe.

This diverges from jsx-a11y's `no-autofocus`, which treats the literal string `"false"` as an opt-out (via `getPropValue`). vue-a11y and lit-a11y are presence-based, consistent with the HTML spec — we align with them. Matches the spec-first direction established in #2717, [#19](https://github.com/johanrd/eslint-plugin-ember/pull/19), and [#33](https://github.com/johanrd/eslint-plugin-ember/pull/33).

### G4 — <dialog> exemption

autofocus on a `<dialog>` or any descendant of a `<dialog>` is exempt. MDN-backed editorial guidance (not a normative spec requirement); angular-eslint's `no-autofocus` implements the same exemption.

## Tests

22 tests total. Moved 3 cases from valid → invalid (per the G3 spec correction); 11 dialog / non-literal-falsy / peer-parity cases unchanged.

