### PR TITLE
feat: add template-valid-label-for

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ To disable a rule for an entire `.gjs`/`.gts` file, use a regular ESLint file-le
 | [template-require-valid-alt-text](docs/rules/template-require-valid-alt-text.md)                                 | require valid alt text for images and other elements                             | 📋 |    |    |
 | [template-require-valid-form-groups](docs/rules/template-require-valid-form-groups.md)                           | require grouped form controls to have fieldset/legend or WAI-ARIA group labeling |    |    |    |
 | [template-table-groups](docs/rules/template-table-groups.md)                                                     | require table elements to use table grouping elements                            | 📋 |    |    |
+| [template-valid-label-for](docs/rules/template-valid-label-for.md)                                               | require `<label for>` to point at a labelable form control                       |    |    |    |
 
 ### Best Practices
 

--- a/docs/rules/template-valid-label-for.md
+++ b/docs/rules/template-valid-label-for.md
@@ -1,0 +1,89 @@
+# ember/template-valid-label-for
+
+<!-- end auto-generated rule header -->
+
+This rule validates that `<label for="x">` references a labelable form
+control (`<input>` — except `type="hidden"` — `<select>`, `<textarea>`,
+`<button>`, `<meter>`, `<output>`, `<progress>`, plus Ember's built-in
+`<Input>` / `<Textarea>`) defined in the same template.
+
+It also flags `for` as redundant when the referenced element is the one
+that HTML's implicit-containment rule would have bound anyway — i.e. the
+**first labelable descendant** of the `<label>` (per HTML §4.10.4). When
+a label contains multiple labelable descendants and `for` points at a
+non-first one, the author is deliberately overriding the implicit choice;
+this is not redundant and is NOT flagged.
+
+Only the label side is checked. Use `template-require-input-label` for the
+other direction (every input should have a label).
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<label for='first-name'>First name</label>
+<div id='first-name'>text</div>
+
+<label for='email'>
+  Email
+  <input id='email' />
+</label>
+```
+
+This rule **allows** the following:
+
+```hbs
+<label for='first-name'>First name</label>
+<input id='first-name' />
+
+<label for='country'>Country</label>
+<select id='country'><option>NO</option></select>
+
+{{! Nested association — for attribute omitted. }}
+<label>
+  Email
+  <input />
+</label>
+
+{{! Dynamic for / id — skipped. }}
+<label for={{this.fieldId}}>Dynamic</label>
+```
+
+## Limitations
+
+- Dynamic `for` or `id` values (mustache) are skipped.
+- Targets that live outside the template file (rendered by a yielded
+  component or a partial) can't be validated and are silently ignored.
+- Multiple occurrences of the same `id` are tracked as the first one seen;
+  `template-no-duplicate-id` handles the duplicate case separately.
+- Classic curly-helper invocations like `{{input id="x"}}` or
+  `{{textarea id="x"}}` are not collected as label targets — only angle-bracket
+  element forms contribute `id`s. A `<label for="x">` that points at a
+  curly-helper-rendered control is **silently ignored** by the rule (the
+  association is not visible to the static analyzer; the rule does not report
+  it as missing, but it also can't validate it). Use the angle-bracket form
+  (`<Input id="x" />`, `<Textarea id="x" />`, or a native `<input id="x" />`)
+  when you need the rule to see the association.
+- **Scope:** native HTML labelable controls plus Ember's built-in `<Input>`
+  and `<Textarea>` components (which render to `<input>` / `<textarea>` and
+  accept `id=` forwarding, so they are valid `<label for>` targets).
+  Resolution depends on template mode:
+  - **Classic Handlebars (`.hbs`):** `<Input>` / `<Textarea>` always resolve
+    globally to the built-in — treated as labelable.
+  - **Strict GJS/GTS (`.gjs` / `.gts`):** the rule inspects the file's
+    `import` declarations. A PascalCase tag is treated as a built-in
+    labelable component if and only if it's imported from
+    `@ember/component` — whether bound under the original name
+    (`import { Input }`) or a local alias (`import { Input as MyInput }`).
+    Imports from other modules (custom libraries, local components) are
+    NOT recognized as labelable.
+
+  Other components — custom labelable wrappers, component compositions —
+  are not detected. Rewrite to native controls, use Ember's built-in, or
+  suppress on a case-by-case basis.
+
+## References
+
+- [HTML spec: Labelable elements](https://html.spec.whatwg.org/multipage/forms.html#category-label)
+- Adapted from [`html-validate`'s `valid-for`](https://html-validate.org/rules/valid-for.html) (MIT).

--- a/docs/rules/template-valid-label-for.md
+++ b/docs/rules/template-valid-label-for.md
@@ -1,5 +1,6 @@
 # ember/template-valid-label-for
 
+<!-- begin auto-generated rule header -->
 <!-- end auto-generated rule header -->
 
 This rule validates that `<label for="x">` references a labelable form

--- a/docs/rules/template-valid-label-for.md
+++ b/docs/rules/template-valid-label-for.md
@@ -1,6 +1,5 @@
 # ember/template-valid-label-for
 
-<!-- begin auto-generated rule header -->
 <!-- end auto-generated rule header -->
 
 This rule validates that `<label for="x">` references a labelable form

--- a/lib/rules/template-valid-label-for.js
+++ b/lib/rules/template-valid-label-for.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// See html-validate (https://html-validate.org/rules/input-missing-label.html) for the related peer rule.
+// See html-validate (https://html-validate.org/rules/valid-for.html) for the related peer rule.
 //
 // Validates <label for="x"> in two ways:
 //   1. Points to a labelable HTML control defined in the same template

--- a/lib/rules/template-valid-label-for.js
+++ b/lib/rules/template-valid-label-for.js
@@ -1,0 +1,299 @@
+'use strict';
+
+// See html-validate (https://html-validate.org/rules/input-missing-label.html) for the related peer rule.
+//
+// Validates <label for="x"> in two ways:
+//   1. Points to a labelable HTML control defined in the same template
+//      (not a <div> or other arbitrary element).
+//   2. If the target is already nested inside the label, flag it as
+//      redundant (the `for` adds nothing — the nested element is
+//      already associated via the containment rule).
+//
+// Dynamic `for` values (mustache) are skipped. Targets we can't find in
+// this template are also skipped (partial templates, yielded content).
+
+const LABELABLE_TAGS = new Set([
+  'button',
+  'input',
+  'meter',
+  'output',
+  'progress',
+  'select',
+  'textarea',
+]);
+
+// Ember's built-in <Input> / <Textarea> components render to native <input>
+// and <textarea> and accept `id=` forwarding — they are valid targets for
+// <label for="…">. In classic Handlebars `<Input>` always resolves globally
+// to the built-in; in strict GJS/GTS the tag must be explicitly imported.
+// Resolution logic:
+//
+//   1. PascalCase tag with a local import binding → check whether the
+//      import source is `@ember/component` and the imported name is
+//      `Input` / `Textarea`. If so, the local alias (e.g. `<MyInput>`)
+//      still resolves to the built-in → labelable. Imports from other
+//      modules → NOT labelable (false-negative acceptable).
+//   2. PascalCase tag with no local import binding in classic HBS (no
+//      import scope) → global resolution; treat as the built-in.
+//      In strict GJS/GTS, no import binding → NOT the built-in.
+const EMBER_BUILTIN_FORM_COMPONENTS = new Set(['Input', 'Textarea']);
+
+// Cache of imports parsed once per sourceCode. Key is sourceCode (a fresh
+// object per ESLint traversal); value is a Map<localName, importedName|null>
+// where null means "bound to an import from some other module". Turns a
+// per-call O(n) scan of ast.body into an amortized O(1) lookup per tag.
+const IMPORT_CACHE = new WeakMap();
+
+function getImportedComponents(sourceCode) {
+  if (!sourceCode) {
+    return null;
+  }
+  let cached = IMPORT_CACHE.get(sourceCode);
+  if (cached) {
+    return cached;
+  }
+  const ast = sourceCode.ast;
+  if (!ast || !Array.isArray(ast.body)) {
+    return null;
+  }
+  cached = new Map();
+  for (const decl of ast.body) {
+    if (decl.type !== 'ImportDeclaration') {
+      continue;
+    }
+    const fromEmberComponent = decl.source?.value === '@ember/component';
+    for (const specifier of decl.specifiers) {
+      const local = specifier.local?.name;
+      if (!local) {
+        continue;
+      }
+      if (!fromEmberComponent) {
+        // Local binding exists but points outside @ember/component → not
+        // the built-in. Record null so we short-circuit future lookups.
+        cached.set(local, null);
+        continue;
+      }
+      // Only named imports (`import { Input }`, `import { Input as X }`)
+      // introduce a built-in binding. Default and namespace imports from
+      // @ember/component are not the form components — skip them.
+      if (specifier.type !== 'ImportSpecifier') {
+        continue;
+      }
+      cached.set(local, specifier.imported?.name);
+    }
+  }
+  IMPORT_CACHE.set(sourceCode, cached);
+  return cached;
+}
+
+function resolvesToEmberFormComponent(tagName, sourceCode, isStrictMode) {
+  if (!tagName) {
+    return false;
+  }
+  if (!isStrictMode) {
+    // Classic HBS: <Input>/<Textarea> resolve globally to the built-in.
+    return EMBER_BUILTIN_FORM_COMPONENTS.has(tagName);
+  }
+  const imports = getImportedComponents(sourceCode);
+  if (!imports) {
+    return false;
+  }
+  if (imports.has(tagName)) {
+    const importedName = imports.get(tagName);
+    return importedName !== null && EMBER_BUILTIN_FORM_COMPONENTS.has(importedName);
+  }
+  // No import binding in strict GJS/GTS — not the built-in.
+  return false;
+}
+
+function findAttr(node, name) {
+  return node.attributes?.find((attr) => attr.name === name);
+}
+
+function getStaticAttrString(node, name) {
+  const attr = findAttr(node, name);
+  if (!attr || !attr.value || attr.value.type !== 'GlimmerTextNode') {
+    return null;
+  }
+  return attr.value.chars;
+}
+
+function isInputHidden(node, sourceCode, isStrictMode) {
+  // Native <input type="hidden">.
+  if (node.tag === 'input') {
+    const type = getStaticAttrString(node, 'type');
+    return type !== null && type.toLowerCase() === 'hidden';
+  }
+  // Ember <Input type="hidden"> (including aliased imports). Renders to a
+  // native <input type="hidden"> → not labelable for the same reason.
+  if (resolvesToEmberFormComponent(node.tag, sourceCode, isStrictMode)) {
+    // Only <Input> carries a type= attribute; <Textarea> never has hidden
+    // semantics. But check the attr regardless — cheap and keeps the
+    // predicate symmetric.
+    const type = getStaticAttrString(node, 'type');
+    return type !== null && type.toLowerCase() === 'hidden';
+  }
+  return false;
+}
+
+function isLabelable(node, sourceCode, isStrictMode) {
+  if (!node || node.type !== 'GlimmerElementNode') {
+    return false;
+  }
+  if (isInputHidden(node, sourceCode, isStrictMode)) {
+    return false;
+  }
+  if (resolvesToEmberFormComponent(node.tag, sourceCode, isStrictMode)) {
+    return true;
+  }
+  if (!LABELABLE_TAGS.has(node.tag)) {
+    return false;
+  }
+  return true;
+}
+
+function isDescendant(candidate, ancestor) {
+  let current = candidate.parent;
+  while (current) {
+    if (current === ancestor) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+// Per HTML §4.10.4 ("The label element"), a label with BOTH `for=` and a
+// labelable descendant binds to the `for`-referenced element — the
+// containment rule is the *implicit* binding and only applies when no
+// `for` is present. When `for` is present, it wins.
+//
+// So `redundantFor` should only fire when the `for` target is the same
+// element that would have been the implicit control — i.e. the FIRST
+// labelable descendant (HTML uses "first labelable element in tree order
+// that is a descendant of the label element", excluding hidden inputs).
+// A label with multiple labelable descendants and `for=` pointing at a
+// non-first one is expressing an explicit choice and must not be flagged.
+function findFirstLabelableDescendant(node, sourceCode, isStrictMode) {
+  if (!node.children) {
+    return null;
+  }
+  for (const child of node.children) {
+    if (!child || child.type !== 'GlimmerElementNode') {
+      continue;
+    }
+    if (isLabelable(child, sourceCode, isStrictMode)) {
+      return child;
+    }
+    const nested = findFirstLabelableDescendant(child, sourceCode, isStrictMode);
+    if (nested) {
+      return nested;
+    }
+  }
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require `<label for>` to point at a labelable form control',
+      category: 'Accessibility',
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-valid-label-for.md',
+      templateMode: 'both',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      notLabelable:
+        '`<label for="{{id}}">` must reference a labelable form control (`<input>`, `<select>`, `<textarea>`, `<button>`, `<meter>`, `<output>`, `<progress>`, or Ember `<Input>` / `<Textarea>`)',
+      redundantFor:
+        '`for="{{id}}"` is redundant: `<label>` already contains the referenced element',
+    },
+  },
+
+  create(context) {
+    // Per-<template>-block state: multi-template .gjs files compose
+    // independent DOM subtrees (e.g. `const Foo = <template>…</template>;
+    // <template>…</template>` in one file). Each block's <label for> must
+    // bind to ids declared in the same block — ids from sibling templates
+    // aren't present in the composed DOM at runtime.
+    let idToElement = new Map();
+    let labels = [];
+
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    const isStrictMode = filename.endsWith('.gjs') || filename.endsWith('.gts');
+
+    function resetTemplateState() {
+      idToElement = new Map();
+      labels = [];
+    }
+
+    function validateCurrentTemplate() {
+      const sourceCode = context.sourceCode || context.getSourceCode();
+      for (const { labelNode, forAttr, forValue } of labels) {
+        const target = idToElement.get(forValue);
+        if (!target) {
+          continue;
+        }
+        if (!isLabelable(target, sourceCode, isStrictMode)) {
+          context.report({
+            node: forAttr,
+            messageId: 'notLabelable',
+            data: { id: forValue },
+          });
+          continue;
+        }
+        if (isDescendant(target, labelNode)) {
+          // Only redundant when `for` resolves to the SAME element that
+          // the implicit-containment rule would bind — the first
+          // labelable descendant. If `for` points at a later labelable
+          // descendant, the author is overriding the implicit choice,
+          // which is not redundant.
+          const implicit = findFirstLabelableDescendant(labelNode, sourceCode, isStrictMode);
+          if (implicit && implicit === target) {
+            context.report({
+              node: forAttr,
+              messageId: 'redundantFor',
+              data: { id: forValue },
+            });
+          }
+        }
+      }
+      resetTemplateState();
+    }
+
+    return {
+      // Multi-template .gjs: reset state on each <template> entry so ids
+      // from earlier templates don't leak into the next one's for= resolution.
+      GlimmerTemplate() {
+        resetTemplateState();
+      },
+      'GlimmerTemplate:exit'() {
+        validateCurrentTemplate();
+      },
+      GlimmerElementNode(node) {
+        const idValue = getStaticAttrString(node, 'id');
+        if (idValue && !idToElement.has(idValue)) {
+          idToElement.set(idValue, node);
+        }
+        if (node.tag === 'label') {
+          const forAttr = findAttr(node, 'for');
+          const forValue = getStaticAttrString(node, 'for');
+          if (forAttr && forValue) {
+            labels.push({ labelNode: node, forAttr, forValue });
+          }
+        }
+      },
+      'Program:exit'() {
+        // Fallback for .hbs (no GlimmerTemplate wrapper) — if
+        // GlimmerTemplate:exit never fired, any pending labels/ids here are
+        // from the single implicit template and need validation.
+        if (labels.length > 0 || idToElement.size > 0) {
+          validateCurrentTemplate();
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/template-valid-label-for.js
+++ b/tests/lib/rules/template-valid-label-for.js
@@ -1,0 +1,181 @@
+const rule = require('../../../lib/rules/template-valid-label-for');
+const RuleTester = require('eslint').RuleTester;
+
+const errNotLabelable = (id) =>
+  `\`<label for="${id}">\` must reference a labelable form control (\`<input>\`, \`<select>\`, \`<textarea>\`, \`<button>\`, \`<meter>\`, \`<output>\`, \`<progress>\`, or Ember \`<Input>\` / \`<Textarea>\`)`;
+const errRedundant = (id) =>
+  `\`for="${id}"\` is redundant: \`<label>\` already contains the referenced element`;
+
+// Valid in both .hbs (classic) and .gjs (strict) — native HTML controls only.
+const validHbs = [
+  // Target labelable, not nested.
+  '<label for="x">Name</label><input id="x" />',
+  '<label for="c">Country</label><select id="c"><option>NO</option></select>',
+  '<label for="t">Text</label><textarea id="t"></textarea>',
+  '<label for="b">Button</label><button id="b">Click</button>',
+  '<label for="o">Output</label><output id="o"></output>',
+  '<label for="m">Meter</label><meter id="m"></meter>',
+  '<label for="p">Progress</label><progress id="p"></progress>',
+  // No for attribute — outside this rule's scope.
+  '<label>Name<input /></label>',
+  // Dynamic for — skip.
+  '<label for={{this.id}}>Dynamic</label><div id="x"></div>',
+  // Dynamic id on target — skip (can't verify).
+  '<label for="a">a</label><input id={{this.id}} />',
+  // Target not present — skip (partial template).
+  '<label for="x">Missing</label>',
+  // Target is hidden input — should flag per HTML spec (hidden isn't labelable),
+  // but this case is already covered in invalid tests below.
+  // Multi-labelable-children: `for` targets a non-first descendant. This is
+  // an explicit override of the implicit-containment rule (HTML §4.10.4),
+  // not redundant.
+  '<label for="second"><input id="first" /><input id="second" /></label>',
+  '<label for="pick"><input id="a" /><select id="pick"><option>x</option></select></label>',
+];
+
+// Valid in classic .hbs only — <Input>/<Textarea> resolve globally to the
+// Ember built-in without an explicit import. In strict GJS/GTS an import
+// from @ember/component is required; those cases live in multiTemplateValid.
+const validHbsOnly = [
+  '<label for="email">Email</label><Input id="email" />',
+  '<label for="bio">Bio</label><Textarea id="bio" />',
+  // `for` targets a non-first labelable descendant — explicit override of
+  // the implicit-containment rule, not redundant, even with Ember built-ins.
+  '<label for="second"><Input id="first" /><Input id="second" /></label>',
+];
+
+const invalidHbs = [
+  // Target is not a labelable element.
+  {
+    code: '<label for="x">x</label><div id="x">text</div>',
+    errors: [{ message: errNotLabelable('x') }],
+  },
+  {
+    code: '<label for="s">s</label><span id="s">text</span>',
+    errors: [{ message: errNotLabelable('s') }],
+  },
+  // input type="hidden" is not labelable.
+  {
+    code: '<label for="h">h</label><input type="hidden" id="h" />',
+    errors: [{ message: errNotLabelable('h') }],
+  },
+  // Redundant for — target nested inside label.
+  {
+    code: '<label for="e">Email <input id="e" /></label>',
+    errors: [{ message: errRedundant('e') }],
+  },
+  {
+    code: '<label for="n">Name<br /><input id="n" /></label>',
+    errors: [{ message: errRedundant('n') }],
+  },
+  // Redundant-for with a single labelable descendant — the `for` target IS
+  // the implicit first labelable descendant.
+  {
+    code: '<label for="pw"><span>Password</span><input id="pw" type="password" /></label>',
+    errors: [{ message: errRedundant('pw') }],
+  },
+];
+
+const gjsValid = validHbs.map((code) => ({
+  filename: 'test.gjs',
+  code: `<template>${code}</template>`,
+}));
+const gjsInvalid = invalidHbs.map(({ code, errors }) => ({
+  filename: 'test.gjs',
+  code: `<template>${code}</template>`,
+  errors,
+}));
+
+const gjsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+// Multi-`<template>` cases — ids in one block don't resolve `for` in another.
+const multiTemplateValid = [
+  // Each template contains its own matching id — both valid in isolation.
+  {
+    filename: 'test.gjs',
+    code: `const Widget = <template><input id="email" /></template>;
+<template><label for="main">Main</label><input id="main" /></template>`,
+  },
+  // Sibling templates both have independent matching pairs.
+  {
+    filename: 'test.gjs',
+    code: `<template><label for="a">A</label><input id="a" /></template>
+<template><label for="b">B</label><input id="b" /></template>`,
+  },
+
+  // Ember built-in <Input> / <Textarea> imported from @ember/component —
+  // labelable via the import-source check. Covers both unaliased and
+  // aliased forms.
+  {
+    filename: 'test.gjs',
+    code: `import { Input } from '@ember/component';
+<template><label for="email">Email</label><Input id="email" /></template>`,
+  },
+  {
+    filename: 'test.gjs',
+    code: `import { Input as MyInput, Textarea as MyTextarea } from '@ember/component';
+<template><label for="email">E</label><MyInput id="email" />
+<label for="bio">B</label><MyTextarea id="bio" /></template>`,
+  },
+];
+
+const multiTemplateInvalid = [
+  // First template declares id="email", second has <label for="email">.
+  // Without per-template scoping this would (wrongly) resolve across the
+  // file. Per-template scoping treats it as "target missing in this
+  // template" — and since missing-target silently passes (partial-template
+  // allowance), this case doesn't flag. So we need a stronger case: the
+  // `for` target exists IN THIS template but is non-labelable, while a
+  // labelable id of the same name lives in a SIBLING template. Without
+  // scoping the rule would find the labelable one and pass; with scoping,
+  // it correctly flags the local non-labelable.
+  {
+    filename: 'test.gjs',
+    code: `const Widget = <template><input id="x" /></template>;
+<template><label for="x">x</label><div id="x">text</div></template>`,
+    errors: [{ message: errNotLabelable('x') }],
+  },
+
+  // <Input> imported from a NON-@ember/component module — user override,
+  // not the built-in labelable component. Rule correctly flags.
+  {
+    filename: 'test.gjs',
+    code: `import Input from 'my-own-lib';
+<template><label for="x">x</label><Input id="x" /></template>`,
+    errors: [{ message: errNotLabelable('x') }],
+  },
+
+  // Ember <Input type="hidden"> renders a native <input type="hidden"> — not
+  // labelable for the same reason native <input type="hidden"> isn't.
+  {
+    filename: 'test.gjs',
+    code: `import { Input } from '@ember/component';
+<template><label for="h">h</label><Input type="hidden" id="h" /></template>`,
+    errors: [{ message: errNotLabelable('h') }],
+  },
+  // Aliased import — same rule applies to the local alias.
+  {
+    filename: 'test.gjs',
+    code: `import { Input as MyInput } from '@ember/component';
+<template><label for="h">h</label><MyInput type="hidden" id="h" /></template>`,
+    errors: [{ message: errNotLabelable('h') }],
+  },
+];
+
+gjsRuleTester.run('template-valid-label-for', rule, {
+  valid: [...gjsValid, ...multiTemplateValid],
+  invalid: [...gjsInvalid, ...multiTemplateInvalid],
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+hbsRuleTester.run('template-valid-label-for', rule, {
+  valid: [...validHbs, ...validHbsOnly],
+  invalid: invalidHbs,
+});


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

See [html-validate `input-missing-label`](https://html-validate.org/rules/input-missing-label.html) for the related peer rule (checks from the input side; this rule checks from the label side).

Adds `template-valid-label-for`: validates that `<label for="x">` points at a labelable form control in the same template, and flags `for` as redundant when the target is already nested inside the label.

## What is checked

1. **Target must be labelable** — `<label for="x">` where the element with `id="x"` is a `<div>` or other non-labelable element is flagged. Labelable per [HTML §4.6.19](https://html.spec.whatwg.org/multipage/forms.html#the-label-element): `button`, `input` (except `type=hidden`), `meter`, `output`, `progress`, `select`, `textarea`. Ember's built-in `<Input>` and `<Textarea>` components (which render to native form controls) are also accepted as labelable targets.
2. **Redundant `for`** — `<label for="x"><input id="x" /></label>` is flagged because the `for` attribute adds nothing when the target is the first labelable descendant already bound via containment. If `for` points at a *non-first* labelable descendant, the author is expressing an explicit choice and it is not flagged. [HTML §4.6.19](https://html.spec.whatwg.org/multipage/forms.html#the-label-element): "the first labelable element … that is a descendant of the label element."

Dynamic `for` values (mustache) are skipped. Targets not found in this template are also skipped (partial templates, yielded content).

## Ember `<Input>` / `<Textarea>` resolution

- **Classic HBS**: `<Input>` and `<Textarea>` resolve globally to the built-in components → always labelable.
- **Strict GJS/GTS**: only a named import from `@ember/component` (directly or aliased) counts as the built-in. A local binding that shadows the name from a different module → not labelable (false-negative acceptable).

## Flags

```hbs
<label for="field">Label</label>
<div id="field">Not labelable</div>

<label for="email">
  <input id="email" type="email" />  {{! redundant — for points at the first (only) labelable descendant }}
</label>
```

## Allows

```hbs
<label for="email">Email</label>
<input id="email" type="email" />

<label for="second">
  <input id="first" type="text" />
  <input id="second" type="text" />  {{! not the first labelable descendant — explicit override, not redundant }}
</label>

<label for={{this.dynamicId}}>Label</label>   {{! dynamic for= skipped }}
```

## Prior art

| Plugin | Equivalent |
|---|---|
| jsx-a11y | [`label-has-associated-control`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/label-has-associated-control.js) — checks label has a text label and an associated control |
| vuejs-accessibility | [`label-has-for`](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/blob/main/src/rules/label-has-for.ts) — checks `for` present on label |
| html-validate | [`input-missing-label`](https://html-validate.org/rules/input-missing-label.html) — checks from the input side (does the input have a label?) |

No peer checks labelable-target validity + redundant-for from the label side.