### PR TITLE
feat: add template-valid-autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,14 +491,15 @@ To disable a rule for an entire `.gjs`/`.gts` file, use a regular ESLint file-le
 
 ### Possible Errors
 
-| Name                                                                                                                       | Description                                                       | 💼 | 🔧 | 💡 |
-| :------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------- | :- | :- | :- |
-| [template-no-extra-mut-helper-argument](docs/rules/template-no-extra-mut-helper-argument.md)                               | disallow passing more than one argument to the mut helper         | 📋 |    |    |
-| [template-no-jsx-attributes](docs/rules/template-no-jsx-attributes.md)                                                     | disallow JSX-style camelCase attributes                           |    | 🔧 |    |
-| [template-no-scope-outside-table-headings](docs/rules/template-no-scope-outside-table-headings.md)                         | disallow scope attribute outside th elements                      | 📋 |    |    |
-| [template-no-shadowed-elements](docs/rules/template-no-shadowed-elements.md)                                               | disallow ambiguity with block param names shadowing HTML elements | 📋 |    |    |
-| [template-no-unbalanced-curlies](docs/rules/template-no-unbalanced-curlies.md)                                             | disallow unbalanced mustache curlies                              | 📋 |    |    |
-| [template-no-unknown-arguments-for-builtin-components](docs/rules/template-no-unknown-arguments-for-builtin-components.md) | disallow unknown arguments for built-in components                | 📋 | 🔧 |    |
+| Name                                                                                                                       | Description                                                              | 💼 | 🔧 | 💡 |
+| :------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- | :- | :- | :- |
+| [template-no-extra-mut-helper-argument](docs/rules/template-no-extra-mut-helper-argument.md)                               | disallow passing more than one argument to the mut helper                | 📋 |    |    |
+| [template-no-jsx-attributes](docs/rules/template-no-jsx-attributes.md)                                                     | disallow JSX-style camelCase attributes                                  |    | 🔧 |    |
+| [template-no-scope-outside-table-headings](docs/rules/template-no-scope-outside-table-headings.md)                         | disallow scope attribute outside th elements                             | 📋 |    |    |
+| [template-no-shadowed-elements](docs/rules/template-no-shadowed-elements.md)                                               | disallow ambiguity with block param names shadowing HTML elements        | 📋 |    |    |
+| [template-no-unbalanced-curlies](docs/rules/template-no-unbalanced-curlies.md)                                             | disallow unbalanced mustache curlies                                     | 📋 |    |    |
+| [template-no-unknown-arguments-for-builtin-components](docs/rules/template-no-unknown-arguments-for-builtin-components.md) | disallow unknown arguments for built-in components                       | 📋 | 🔧 |    |
+| [template-valid-autocomplete](docs/rules/template-valid-autocomplete.md)                                                   | require autocomplete attribute values to match the HTML autofill grammar |    |    |    |
 
 ### Routes
 

--- a/docs/rules/template-valid-autocomplete.md
+++ b/docs/rules/template-valid-autocomplete.md
@@ -1,0 +1,71 @@
+# ember/template-valid-autocomplete
+
+<!-- end auto-generated rule header -->
+
+This rule validates the `autocomplete` attribute against the HTML living
+standard. Browsers ignore unknown tokens and mismatched combinations
+silently, so authoring mistakes become invisible at runtime — the user
+just doesn't get the suggestions they expect.
+
+The rule handles:
+
+- `<form autocomplete>` must be `"on"` or `"off"`.
+- `<input type="hidden">` cannot use the bare values `"on"` / `"off"`.
+- `<input type="checkbox | radio | file | submit | image | reset | button">`
+  cannot use `autocomplete` at all.
+- Token grammar: tokens must be a valid combination from the section / hint /
+  contact / field-name / webauthn set, in the right order.
+
+Dynamic values (`autocomplete={{this.acValue}}`) are skipped. Static empty
+(`autocomplete=""`) and whitespace-only values are flagged: on `<form>` as
+an invalid non-on/off value, on controls as a missing field name.
+
+**Not checked**: whether a field name's control group matches the input type
+(e.g. `"current-password"` on `<input type="text">`). The HTML spec describes
+these field-name-to-control-group mappings descriptively — it does not
+prohibit mismatched pairings with a MUST/MUST NOT. UA and password-manager
+behavior varies, so such a pairing is a grammar-valid author choice whose
+UA-visibility is a UX question, not a spec violation. `html-validate` flags
+it; we don't. `eslint-plugin-jsx-a11y` and `eslint-plugin-lit-a11y` also
+don't (they delegate to axe-core's `autocomplete-valid`, which omits the
+check) — that corroborates but does not drive the decision.
+
+## Token order
+
+An autocomplete attribute value can contain these tokens, in this order:
+
+1. Optional section name (`section-*` prefix).
+2. Optional `shipping` or `billing`.
+3. Optional contact modifier: `home`, `work`, `mobile`, `fax`, `pager`
+   (only for `tel-*` / `email` / `impp` field names).
+4. Exactly one field name.
+5. Optional `webauthn`.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<form autocomplete='yes'>
+  <input autocomplete='first-name' type='text' />
+  <input autocomplete='off street-address' type='text' />
+  <input autocomplete='home email family-name' type='text' />
+  <input autocomplete='section-a' type='text' />
+</form>
+```
+
+This rule **allows** the following:
+
+```hbs
+<form autocomplete='off'>
+  <input autocomplete='email' type='email' />
+  <input autocomplete='section-ship shipping street-address' type='text' />
+  <input autocomplete='work email' type='email' />
+  <input autocomplete='new-password webauthn' type='password' />
+</form>
+```
+
+## References
+
+- [HTML spec: autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill)
+- Adapted from [`html-validate`'s `valid-autocomplete`](https://html-validate.org/rules/valid-autocomplete.html) (MIT).

--- a/lib/rules/template-valid-autocomplete.js
+++ b/lib/rules/template-valid-autocomplete.js
@@ -197,8 +197,7 @@ module.exports = {
       contactMismatch: '`"{{contact}}"` cannot be combined with field name `"{{field}}"`',
       order: '`"{{second}}"` must appear before `"{{first}}"` in autocomplete',
       duplicateSection: 'autocomplete can contain at most one `section-*` token',
-      duplicateHint:
-        '`"shipping"` and `"billing"` are mutually exclusive and each may appear at most once',
+      duplicateHint: 'autocomplete can contain at most one hint token (`shipping` or `billing`)',
       duplicateContact:
         '`"{{token}}"` cannot be combined with another contact modifier — autocomplete allows at most one of `home`, `work`, `mobile`, `fax`, `pager`',
       duplicateWebauthn: '`"webauthn"` may appear at most once in autocomplete',
@@ -231,11 +230,12 @@ module.exports = {
       const onOffIdx = tokens.findIndex((t) => t === 'on' || t === 'off');
       if (onOffIdx !== -1) {
         const token = tokens[onOffIdx];
-        if (tokens.length > 1) {
-          report(attr, 'onOffCombine', { value: token });
-        }
         if (node.tag === 'input' && type === 'hidden') {
           report(attr, 'hiddenOnOff', { value: token });
+          return;
+        }
+        if (tokens.length > 1) {
+          report(attr, 'onOffCombine', { value: token });
         }
         return;
       }

--- a/lib/rules/template-valid-autocomplete.js
+++ b/lib/rules/template-valid-autocomplete.js
@@ -1,0 +1,332 @@
+'use strict';
+
+// Logic adapted from html-validate (MIT), Copyright 2017 David Sveningsson.
+//
+// Grammar-only validation. We check token identity, order, and combinations
+// that the HTML spec MUSTs (single field name, token order, contact-tokens
+// paired with contact-group field names, disallowed input types). We do NOT
+// port html-validate's field-name-to-input-type control-group cross-check
+// (e.g. flagging `current-password` on `type="text"`). Rationale: the HTML
+// spec describes the autofill field name control groups descriptively — it
+// does not prohibit mismatched pairings with a MUST/MUST NOT. UA and
+// password-manager behavior varies, so the combination is a grammar-valid
+// author choice whose UA-visibility is a UX question, not a spec violation.
+// Two peers (jsx-a11y, lit-a11y) also omit the check by delegating to
+// axe-core's `autocomplete-valid`, which corroborates the decision but is
+// not its justification.
+
+const FIELD_NAMES_NO_CONTACT = new Set([
+  'name',
+  'honorific-prefix',
+  'given-name',
+  'additional-name',
+  'family-name',
+  'honorific-suffix',
+  'nickname',
+  'username',
+  'new-password',
+  'current-password',
+  'one-time-code',
+  'organization-title',
+  'organization',
+  'street-address',
+  'address-line1',
+  'address-line2',
+  'address-line3',
+  'address-level4',
+  'address-level3',
+  'address-level2',
+  'address-level1',
+  'country',
+  'country-name',
+  'postal-code',
+  'cc-name',
+  'cc-given-name',
+  'cc-additional-name',
+  'cc-family-name',
+  'cc-number',
+  'cc-exp',
+  'cc-exp-month',
+  'cc-exp-year',
+  'cc-csc',
+  'cc-type',
+  'transaction-currency',
+  'transaction-amount',
+  'language',
+  'bday',
+  'bday-day',
+  'bday-month',
+  'bday-year',
+  'sex',
+  'url',
+  'photo',
+]);
+
+const FIELD_NAMES_WITH_CONTACT = new Set([
+  'tel',
+  'tel-country-code',
+  'tel-national',
+  'tel-area-code',
+  'tel-local',
+  'tel-local-prefix',
+  'tel-local-suffix',
+  'tel-extension',
+  'email',
+  'impp',
+]);
+
+const DISALLOWED_INPUT_TYPES = new Set([
+  'checkbox',
+  'radio',
+  'file',
+  'submit',
+  'image',
+  'reset',
+  'button',
+]);
+
+const EXPECTED_ORDER = ['section', 'hint', 'contact', 'field1', 'field2', 'webauthn'];
+const CONTACT_TOKENS = new Set(['home', 'work', 'mobile', 'fax', 'pager']);
+
+function classifyToken(token) {
+  // Per the HTML autofill spec, `section-*` requires at least one character
+  // after the hyphen (the identifier). Bare `section-` is not a valid token.
+  if (/^section-.+/.test(token)) {
+    return 'section';
+  }
+  if (token === 'shipping' || token === 'billing') {
+    return 'hint';
+  }
+  if (FIELD_NAMES_NO_CONTACT.has(token)) {
+    return 'field1';
+  }
+  if (FIELD_NAMES_WITH_CONTACT.has(token)) {
+    return 'field2';
+  }
+  if (CONTACT_TOKENS.has(token)) {
+    return 'contact';
+  }
+  if (token === 'webauthn') {
+    return 'webauthn';
+  }
+  return null;
+}
+
+function findAttr(node, name) {
+  return node.attributes?.find((a) => a.name === name);
+}
+
+function getStaticAttrString(node, name) {
+  const attr = findAttr(node, name);
+  if (!attr || !attr.value || attr.value.type !== 'GlimmerTextNode') {
+    return null;
+  }
+  return attr.value.chars;
+}
+
+function getInputType(node) {
+  const t = getStaticAttrString(node, 'type');
+  if (t === null) {
+    return node.tag === 'input' ? 'text' : null;
+  }
+  return t.toLowerCase();
+}
+
+function tokenize(value) {
+  return value
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+// Enforce multiplicity/mutual-exclusion rules per HTML §4.10.19.9. The
+// autofill grammar permits at most one token from each of:
+//   - `section-*` prefix
+//   - hint group (`shipping` XOR `billing` — both map to `kind: 'hint'`)
+//   - contact modifier (`home` | `work` | `mobile` | `fax` | `pager`)
+//   - `webauthn`
+// Returns `{ messageId, data }` on the first violation found, or `null`.
+function checkMultiplicity(order) {
+  const counts = { section: 0, hint: 0, contact: 0, webauthn: 0 };
+  const contactTokens = [];
+  for (const { tok, kind } of order) {
+    if (kind === 'section' || kind === 'hint' || kind === 'webauthn') {
+      counts[kind]++;
+    } else if (kind === 'contact') {
+      counts.contact++;
+      contactTokens.push(tok);
+    }
+  }
+  if (counts.section > 1) {
+    return { messageId: 'duplicateSection', data: {} };
+  }
+  if (counts.hint > 1) {
+    return { messageId: 'duplicateHint', data: {} };
+  }
+  if (counts.contact > 1) {
+    // Report the second contact token (authors usually fix the one that came
+    // "extra"; the first is the intended one).
+    return { messageId: 'duplicateContact', data: { token: contactTokens[1] } };
+  }
+  if (counts.webauthn > 1) {
+    return { messageId: 'duplicateWebauthn', data: {} };
+  }
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require autocomplete attribute values to match the HTML autofill grammar',
+      category: 'Possible Errors',
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-valid-autocomplete.md',
+      templateMode: 'both',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      formValue: '`<form autocomplete>` can only be `"on"` or `"off"` (got `"{{value}}"`)',
+      hiddenOnOff: '`<input type="hidden">` cannot use the autocomplete value `"{{value}}"`',
+      disallowedType: '`autocomplete` cannot be used on `<input type="{{type}}">`',
+      onOffCombine: '`"{{value}}"` cannot be combined with other autocomplete tokens',
+      invalidToken: '`"{{token}}"` is not a valid autocomplete token or field name',
+      missingField: '`autocomplete` attribute is missing a field name',
+      multipleFields: 'autocomplete attribute must contain exactly one field name',
+      contactMismatch: '`"{{contact}}"` cannot be combined with field name `"{{field}}"`',
+      order: '`"{{second}}"` must appear before `"{{first}}"` in autocomplete',
+      duplicateSection: 'autocomplete can contain at most one `section-*` token',
+      duplicateHint:
+        '`"shipping"` and `"billing"` are mutually exclusive and each may appear at most once',
+      duplicateContact:
+        '`"{{token}}"` cannot be combined with another contact modifier — autocomplete allows at most one of `home`, `work`, `mobile`, `fax`, `pager`',
+      duplicateWebauthn: '`"webauthn"` may appear at most once in autocomplete',
+    },
+  },
+
+  create(context) {
+    function report(attr, messageId, data) {
+      context.report({ node: attr, messageId, data });
+    }
+
+    function validateControl(node, attr, value) {
+      const type = getInputType(node) ?? 'text';
+
+      if (node.tag === 'input' && DISALLOWED_INPUT_TYPES.has(type)) {
+        report(attr, 'disallowedType', { type });
+        return;
+      }
+
+      const tokens = tokenize(value);
+      // Empty or whitespace-only autocomplete is an authoring mistake — the
+      // attribute communicates nothing and isn't a valid value per HTML
+      // §4.10.19. Flag via `missingField` since the remedy is to add a
+      // field name (or remove the attribute entirely).
+      if (tokens.length === 0) {
+        report(attr, 'missingField', {});
+        return;
+      }
+
+      const onOffIdx = tokens.findIndex((t) => t === 'on' || t === 'off');
+      if (onOffIdx !== -1) {
+        const token = tokens[onOffIdx];
+        if (tokens.length > 1) {
+          report(attr, 'onOffCombine', { value: token });
+        }
+        if (node.tag === 'input' && type === 'hidden') {
+          report(attr, 'hiddenOnOff', { value: token });
+        }
+        return;
+      }
+
+      const order = [];
+      for (const tok of tokens) {
+        const kind = classifyToken(tok);
+        if (!kind) {
+          report(attr, 'invalidToken', { token: tok });
+          return;
+        }
+        order.push({ tok, kind });
+      }
+
+      // Multiplicity constraints — each non-field token class may appear at
+      // most once, and `shipping`/`billing` are mutually exclusive.
+      const multiplicityError = checkMultiplicity(order);
+      if (multiplicityError) {
+        report(attr, multiplicityError.messageId, multiplicityError.data);
+        return;
+      }
+
+      // Field presence.
+      const fieldIndices = order
+        .map((o, i) => (o.kind === 'field1' || o.kind === 'field2' ? i : -1))
+        .filter((i) => i !== -1);
+
+      if (fieldIndices.length === 0) {
+        report(attr, 'missingField', {});
+        return;
+      }
+      if (fieldIndices.length > 1) {
+        report(attr, 'multipleFields', {});
+        return;
+      }
+
+      // Contact can only pair with field2.
+      const fieldIdx = fieldIndices[0];
+      const field = order[fieldIdx];
+      const contactIdx = order.findIndex((o) => o.kind === 'contact');
+      if (contactIdx !== -1 && field.kind === 'field1') {
+        report(attr, 'contactMismatch', { contact: order[contactIdx].tok, field: field.tok });
+        return;
+      }
+
+      // Order validation.
+      const expectedIdx = order.map((o) => EXPECTED_ORDER.indexOf(o.kind));
+      for (let i = 0; i < expectedIdx.length - 1; i++) {
+        if (expectedIdx[i] > expectedIdx[i + 1]) {
+          report(attr, 'order', { first: order[i].tok, second: order[i + 1].tok });
+          return;
+        }
+      }
+
+      // Deliberately NOT validating field-name-vs-input-type compatibility
+      // (e.g. `current-password` on `<input type="text">`). axe-core doesn't
+      // check this either, and the HTML autofill mapping has enough
+      // real-world variance that flagging here would over-trigger.
+    }
+
+    function validateForm(node, attr, value) {
+      const trimmed = value.trim().toLowerCase();
+      if (trimmed === 'on' || trimmed === 'off') {
+        return;
+      }
+      report(attr, 'formValue', { value: trimmed });
+    }
+
+    return {
+      GlimmerElementNode(node) {
+        const attr = findAttr(node, 'autocomplete');
+        if (!attr) {
+          return;
+        }
+        if (attr.value && attr.value.type !== 'GlimmerTextNode') {
+          return;
+        }
+        const value = attr.value ? attr.value.chars : '';
+        // Empty/whitespace values drop through to validateForm/validateControl
+        // — `<form autocomplete="">` flags as a non-on/off value, and
+        // `<input autocomplete="">` flags as a missing field name. Both are
+        // authoring mistakes the rule should surface.
+
+        if (node.tag === 'form') {
+          validateForm(node, attr, value);
+          return;
+        }
+        if (node.tag === 'input' || node.tag === 'textarea' || node.tag === 'select') {
+          validateControl(node, attr, value);
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/template-valid-autocomplete.js
+++ b/tests/lib/rules/template-valid-autocomplete.js
@@ -1,0 +1,211 @@
+const rule = require('../../../lib/rules/template-valid-autocomplete');
+const RuleTester = require('eslint').RuleTester;
+
+const validHbs = [
+  // form on/off.
+  '<form autocomplete="off"></form>',
+  '<form autocomplete="on"></form>',
+  '<form autocomplete="ON"></form>',
+  // control on/off.
+  '<input type="text" autocomplete="on" />',
+  '<input type="text" autocomplete="off" />',
+  // Basic field name.
+  '<input type="email" autocomplete="email" />',
+  '<input type="text" autocomplete="given-name" />',
+  '<input type="password" autocomplete="new-password" />',
+  '<input type="password" autocomplete="current-password" />',
+  // Full pattern: section + hint + field + webauthn.
+  '<input type="text" autocomplete="section-ship shipping address-line1" />',
+  '<input type="text" autocomplete="billing family-name" />',
+  '<input type="password" autocomplete="new-password webauthn" />',
+  // No control-group check: field name paired with an unrelated input type
+  // is NOT flagged. We defer to axe-core's behavior (grammar only).
+  '<input type="text" autocomplete="current-password" />',
+  '<input type="text" autocomplete="street-address" />',
+  '<input type="email" autocomplete="photo" />',
+  // Contact with field2.
+  '<input type="email" autocomplete="work email" />',
+  '<input type="tel" autocomplete="home tel" />',
+  // textarea / select.
+  '<textarea autocomplete="street-address"></textarea>',
+  '<select autocomplete="country"><option>NO</option></select>',
+  // Dynamic — skip.
+  '<input type="text" autocomplete={{this.ac}} />',
+  // Non-form-control — skip.
+  '<div autocomplete="anything"></div>',
+  // hidden with valid field.
+  '<input type="hidden" autocomplete="family-name" />',
+];
+
+const invalidHbs = [
+  // form: invalid value.
+  {
+    code: '<form autocomplete="yes"></form>',
+    errors: [{ message: '`<form autocomplete>` can only be `"on"` or `"off"` (got `"yes"`)' }],
+  },
+  // Empty autocomplete on form — invalid (not on/off).
+  {
+    code: '<form autocomplete=""></form>',
+    errors: [{ message: '`<form autocomplete>` can only be `"on"` or `"off"` (got `""`)' }],
+  },
+  // Empty autocomplete on a control — no field name, nothing to match.
+  {
+    code: '<input type="text" autocomplete="" />',
+    errors: [{ message: '`autocomplete` attribute is missing a field name' }],
+  },
+  // Whitespace-only counts the same.
+  {
+    code: '<input type="text" autocomplete="   " />',
+    errors: [{ message: '`autocomplete` attribute is missing a field name' }],
+  },
+  // Valueless attribute — treated as empty string, invalid.
+  {
+    code: '<input type="text" autocomplete />',
+    errors: [{ message: '`autocomplete` attribute is missing a field name' }],
+  },
+  {
+    code: '<form autocomplete></form>',
+    errors: [{ message: '`<form autocomplete>` can only be `"on"` or `"off"` (got `""`)' }],
+  },
+  // hidden: on/off forbidden.
+  {
+    code: '<input type="hidden" autocomplete="off" />',
+    errors: [{ message: '`<input type="hidden">` cannot use the autocomplete value `"off"`' }],
+  },
+  // Disallowed input types.
+  {
+    code: '<input type="checkbox" autocomplete="email" />',
+    errors: [{ message: '`autocomplete` cannot be used on `<input type="checkbox">`' }],
+  },
+  {
+    code: '<input type="submit" autocomplete="email" />',
+    errors: [{ message: '`autocomplete` cannot be used on `<input type="submit">`' }],
+  },
+  // Invalid token.
+  {
+    code: '<input type="text" autocomplete="first-name" />',
+    errors: [
+      {
+        message: '`"first-name"` is not a valid autocomplete token or field name',
+      },
+    ],
+  },
+  // on/off combined with other tokens.
+  {
+    code: '<input type="text" autocomplete="off street-address" />',
+    errors: [{ message: '`"off"` cannot be combined with other autocomplete tokens' }],
+  },
+  // Missing field.
+  {
+    code: '<input type="text" autocomplete="section-a" />',
+    errors: [{ message: '`autocomplete` attribute is missing a field name' }],
+  },
+  {
+    code: '<input type="text" autocomplete="shipping" />',
+    errors: [{ message: '`autocomplete` attribute is missing a field name' }],
+  },
+  // Multiple fields.
+  {
+    code: '<input type="email" autocomplete="home email family-name" />',
+    errors: [{ message: 'autocomplete attribute must contain exactly one field name' }],
+  },
+  // Contact with wrong field group.
+  {
+    code: '<input type="text" autocomplete="home family-name" />',
+    errors: [
+      {
+        message: '`"home"` cannot be combined with field name `"family-name"`',
+      },
+    ],
+  },
+  // Multiple contact modifiers — HTML §4.10.19.9 allows at most one.
+  {
+    code: '<input type="email" autocomplete="home work email" />',
+    errors: [
+      {
+        message:
+          '`"work"` cannot be combined with another contact modifier — autocomplete allows at most one of `home`, `work`, `mobile`, `fax`, `pager`',
+      },
+    ],
+  },
+  {
+    code: '<input type="tel" autocomplete="mobile pager tel" />',
+    errors: [
+      {
+        message:
+          '`"pager"` cannot be combined with another contact modifier — autocomplete allows at most one of `home`, `work`, `mobile`, `fax`, `pager`',
+      },
+    ],
+  },
+  // Same contact token repeated — still flagged (count > 1 regardless of
+  // whether it's the same or different token).
+  {
+    code: '<input type="tel" autocomplete="home home tel" />',
+    errors: [
+      {
+        message:
+          '`"home"` cannot be combined with another contact modifier — autocomplete allows at most one of `home`, `work`, `mobile`, `fax`, `pager`',
+      },
+    ],
+  },
+  // Order violation (webauthn before field).
+  {
+    code: '<input type="password" autocomplete="webauthn current-password" />',
+    errors: [
+      {
+        message: '`"current-password"` must appear before `"webauthn"` in autocomplete',
+      },
+    ],
+  },
+  // `section-` with empty identifier is not a valid token.
+  {
+    code: '<input type="text" autocomplete="section- given-name" />',
+    errors: [{ message: '`"section-"` is not a valid autocomplete token or field name' }],
+  },
+  // Multiplicity: at most one section-*.
+  {
+    code: '<input type="text" autocomplete="section-a section-b given-name" />',
+    errors: [{ message: 'autocomplete can contain at most one `section-*` token' }],
+  },
+  // Multiplicity: shipping and billing are mutually exclusive.
+  {
+    code: '<input type="text" autocomplete="shipping billing street-address" />',
+    errors: [
+      {
+        message:
+          '`"shipping"` and `"billing"` are mutually exclusive and each may appear at most once',
+      },
+    ],
+  },
+  // Multiplicity: webauthn at most once.
+  {
+    code: '<input type="email" autocomplete="webauthn webauthn email" />',
+    errors: [{ message: '`"webauthn"` may appear at most once in autocomplete' }],
+  },
+];
+
+const gjsValid = validHbs.map((code) => `<template>${code}</template>`);
+const gjsInvalid = invalidHbs.map(({ code, errors }) => ({
+  code: `<template>${code}</template>`,
+  errors,
+}));
+
+const gjsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+gjsRuleTester.run('template-valid-autocomplete', rule, {
+  valid: gjsValid,
+  invalid: gjsInvalid,
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+hbsRuleTester.run('template-valid-autocomplete', rule, {
+  valid: validHbs,
+  invalid: invalidHbs,
+});

--- a/tests/lib/rules/template-valid-autocomplete.js
+++ b/tests/lib/rules/template-valid-autocomplete.js
@@ -173,7 +173,7 @@ const invalidHbs = [
     errors: [
       {
         message:
-          '`"shipping"` and `"billing"` are mutually exclusive and each may appear at most once',
+          'autocomplete can contain at most one hint token (`shipping` or `billing`)',
       },
     ],
   },

--- a/tests/lib/rules/template-valid-autocomplete.js
+++ b/tests/lib/rules/template-valid-autocomplete.js
@@ -172,8 +172,7 @@ const invalidHbs = [
     code: '<input type="text" autocomplete="shipping billing street-address" />',
     errors: [
       {
-        message:
-          'autocomplete can contain at most one hint token (`shipping` or `billing`)',
+        message: 'autocomplete can contain at most one hint token (`shipping` or `billing`)',
       },
     ],
   },


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

See [html-validate `valid-autocomplete`](https://html-validate.org/rules/valid-autocomplete.html) for the peer rule. Logic adapted from html-validate (MIT), Copyright 2017 David Sveningsson.

Adds `template-valid-autocomplete`: validates the grammar of the `autocomplete` attribute on `<form>`, `<input>`, `<textarea>`, `<select>`. Token identity, order, and contact-with-field compatibility are checked. The field-name-to-control-group compatibility check (e.g. `current-password` on `type="text"`) is deliberately **not** implemented — see rationale below.

## Premise

[HTML spec §4.10.19.7 — autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) defines a restricted grammar for `autocomplete`: an optional `section-*`, an optional `shipping`/`billing`, an optional contact modifier (`home`/`work`/`mobile`/`fax`/`pager`), exactly one field name, and an optional `webauthn`. Browsers and password managers silently drop unknown tokens or mis-ordered combinations — authoring mistakes like `autocomplete="first-name"` (should be `given-name`) are invisible at runtime.

## Checks implemented

- `<form autocomplete>` accepts only `on` or `off`.
- `<input type="hidden">` cannot use `on`/`off`.
- `<input type="checkbox|radio|file|submit|image|reset|button">` cannot use `autocomplete` at all.
- Each token must be a valid section / hint / contact / field / webauthn token.
- Tokens must appear in the correct order.
- Contact modifiers (`home`/`work`/`mobile`/`fax`/`pager`) only pair with field names from the "with contact" list (`tel`, `email`, `impp`, etc.).
- Exactly one field name must be present.

## Deliberately omitted: field-name-to-control-group check

The spec's [autofill field name control group](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-field) table uses **descriptive** language for the mapping — "the control group for field name X is Y" — without a MUST/MUST NOT. `<input type="text" autocomplete="current-password">` is grammar-valid; UAs are likely to handle it inconsistently, but it is not a spec violation. Two peers (jsx-a11y, lit-a11y) happen to delegate to axe-core's `autocomplete-valid` virtual rule, which also omits this check.

## Flags

```hbs
<form autocomplete='yes'>...</form>                      {{! form: on/off only }}
<input type='hidden' autocomplete='off' />               {{! hidden forbids on/off }}
<input type='checkbox' autocomplete='email' />           {{! type forbids autocomplete }}
<input type='text' autocomplete='first-name' />          {{! "first-name" is not a valid field name; use "given-name" }}
<input type='text' autocomplete='off street-address' />  {{! on/off cannot combine with field tokens }}
<input type='text' autocomplete='section-a' />           {{! section without a field name }}
<input type='text' autocomplete='home family-name' />    {{! contact modifier + wrong field group }}
<input type='password' autocomplete='webauthn current-password' />  {{! wrong order }}
```

## Allows

```hbs
<form autocomplete='off'>
  <input type='email' autocomplete='email' />
  <input type='text' autocomplete='section-ship shipping address-line1' />
  <input type='email' autocomplete='work email' />
  <input type='password' autocomplete='new-password webauthn' />
</form>

{{! No control-group check — these are NOT flagged (matching axe-core) }}
<input type='text' autocomplete='current-password' />

{{! Dynamic value — skipped }}
<input type='text' autocomplete={{this.ac}} />
```

## Prior art

| Plugin | Equivalent | Behavior |
|---|---|---|
| [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/rules/autocomplete-valid.js) | `autocomplete-valid` | Delegates to axe-core's virtual rule — grammar only, no control-group check. |
| [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y/lib/rules/autocomplete-valid.js) | `autocomplete-valid` | Same as jsx-a11y (axe-core delegation). |
| vuejs-accessibility | — | No equivalent rule. |
| @angular-eslint/template | — | No equivalent rule. |
| [html-validate](https://html-validate.org/rules/valid-autocomplete.html) | `valid-autocomplete` | Full grammar + control-group cross-check. Token tables ported from here. |

Opt-in: not added to any preset config.