### PR TITLE
feat: add template-no-duplicate-form-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ To disable a rule for an entire `.gjs`/`.gts` file, use a regular ESLint file-le
 
 | Name                                                                                                                       | Description                                                       | 💼 | 🔧 | 💡 |
 | :------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------- | :- | :- | :- |
+| [template-no-duplicate-form-names](docs/rules/template-no-duplicate-form-names.md)                                         | disallow duplicate form control names within the same form        |    |    |    |
 | [template-no-extra-mut-helper-argument](docs/rules/template-no-extra-mut-helper-argument.md)                               | disallow passing more than one argument to the mut helper         | 📋 |    |    |
 | [template-no-jsx-attributes](docs/rules/template-no-jsx-attributes.md)                                                     | disallow JSX-style camelCase attributes                           |    | 🔧 |    |
 | [template-no-scope-outside-table-headings](docs/rules/template-no-scope-outside-table-headings.md)                         | disallow scope attribute outside th elements                      | 📋 |    |    |

--- a/docs/rules/template-no-duplicate-form-names.md
+++ b/docs/rules/template-no-duplicate-form-names.md
@@ -1,0 +1,82 @@
+# ember/template-no-duplicate-form-names
+
+<!-- end auto-generated rule header -->
+
+This rule disallows two form controls sharing the same `name` attribute
+within the same `<form>` (or within the template root, if no `<form>`
+wraps the controls).
+
+Duplicate names break form serialization: both values are emitted into
+the entry list, and server-side code that expects a single value typically
+reads only one — often not the one the author intended.
+
+Three categories are exempt from the duplicate check:
+
+- **Non-submitting controls** (`<input type="button">`, `<input type="reset">`,
+  `<button type="button">`, `<button type="reset">`) are skipped entirely.
+  Per [HTML §4.10.21.4](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set)
+  they do not contribute to the form data, so their `name` can't collide
+  with anything.
+- **Radio groups** (`<input type="radio">`) share a `name` with same-type
+  siblings to express mutual exclusion — exactly one contributes per
+  submission.
+- **Submit-like controls** may share a `name` across any mix of
+  `<input type="submit">`, `<input type="image">`, and `<button>` (bare
+  `<button>` defaults to `type="submit"` per HTML §4.10.9). Only one
+  submit-like control contributes to the form-data entry list per
+  submission — the one the user activated — so same-name is unambiguous.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<form>
+  <input name='email' />
+  <input name='email' />
+</form>
+
+<form>
+  <input type='text' name='field' />
+  <textarea name='field'></textarea>
+</form>
+```
+
+This rule **allows** the following:
+
+```hbs
+<form>
+  <input type='radio' name='color' value='red' />
+  <input type='radio' name='color' value='blue' />
+  <input type='submit' name='action' value='save' />
+  <input type='submit' name='action' value='publish' />
+</form>
+```
+
+Controls with the HTML `disabled` attribute are ignored — per
+[HTML §4.10.21.4](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set)
+they do not contribute to the form-data entry list and cannot collide.
+
+Controls with the HTML `hidden` attribute are **not** exempt: `hidden`
+affects rendering, not form submission. A `hidden` control still submits
+its `name`/`value`, so a duplicate name involving a hidden control is a
+real collision.
+
+## Limitations
+
+- Controls associated with a form via the `form="id"` attribute (rather than
+  by nesting inside a `<form>` element) are not tracked by this rule. Only
+  controls that are descendants of a `<form>` element are scoped to that form.
+- `name` values via mustache (`name={{this.fieldName}}`) are skipped — we
+  cannot know the value at lint time.
+- The `name[]` PHP-style array pattern is treated as an ordinary name; if
+  you declare two `name="x[]"` controls in the same form this rule will
+  still flag them. Support for array brackets may be added later.
+- The `<input type="hidden">` + `<input type="checkbox">` default-value
+  pattern (which is permitted in HTML) is not recognized — the pair will
+  be flagged if you use it. Rename the hidden input if you hit this.
+
+## References
+
+- [HTML spec: Form submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm)
+- Adapted from [`html-validate`'s `form-dup-name`](https://html-validate.org/rules/form-dup-name.html) (MIT).

--- a/lib/rules/template-no-duplicate-form-names.js
+++ b/lib/rules/template-no-duplicate-form-names.js
@@ -173,7 +173,6 @@ function findEnclosingFormOrRoot(node) {
 
 const { getBranchPath, areMutuallyExclusive } = require('../utils/control-flow');
 
-
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {

--- a/lib/rules/template-no-duplicate-form-names.js
+++ b/lib/rules/template-no-duplicate-form-names.js
@@ -18,7 +18,7 @@
 //     selected at a time);
 //   - submit-like controls: at most one submit-like control contributes per
 //     submission, so any mix of <input type=submit>, <input type=image>, and
-//     <button [type=submit]> can share a name.
+//     <button> (bare or type=submit) can share a name.
 // Derived from aria-query's button-role mapping; see `getShareCategory` below.
 
 const { elementRoles } = require('aria-query');
@@ -137,12 +137,14 @@ function getControlType(node) {
     if (t.kind === 'static') {
       return BUTTON_TYPES.has(t.value.toLowerCase()) ? t.value.toLowerCase() : 'submit';
     }
-    if (t.kind === 'absent') {
+    if (t.kind === 'absent' || t.kind === 'empty') {
+      // No type attribute, or valueless `<button type />` — both default to
+      // 'submit' per HTML §4.10.9 (invalid/missing type → submit state).
       return 'submit';
     }
-    // Dynamic or empty type (mustache / concat / valueless) — the runtime
-    // value is unknown. Return a sentinel so the caller can skip duplicate-
-    // name checks for this node rather than baking in a wrong default.
+    // Dynamic type (mustache / concat) — runtime value is unknown. Return a
+    // sentinel so the caller can skip duplicate-name checks for this node
+    // rather than guessing the wrong default.
     return 'unknown';
   }
   if (node.tag === 'input') {

--- a/lib/rules/template-no-duplicate-form-names.js
+++ b/lib/rules/template-no-duplicate-form-names.js
@@ -173,37 +173,6 @@ function findEnclosingFormOrRoot(node) {
 
 const { getBranchPath, areMutuallyExclusive } = require('../utils/control-flow');
 
-// Per HTML spec (§4.10.21.4 "Constructing the entry list"), only `disabled`
-// controls are skipped when building the form-data entry list. `hidden`
-// does NOT affect submission — a hidden control still contributes its name
-// and value. Duplicate-name collisions can therefore happen even when one
-// of the controls is `hidden`.
-//
-// `disabled={{false}}` (boolean-literal mustache) is carved out: Glimmer VM
-// normalizes boolean `false` to attribute removal at runtime (see
-// `SimpleDynamicAttribute.update` → `removeAttribute`), so the rendered DOM
-// has no `disabled` attribute and the control IS enabled. Matches the same
-// carve-out in `template-no-autofocus-attribute`. Other falsy-looking forms
-// — `disabled="false"` (static string), `disabled={{"false"}}` (string-
-// literal mustache) — still mean disabled per HTML boolean-attribute
-// semantics: presence = disabled regardless of value content.
-function isDisabled(node) {
-  const attr = findAttr(node, 'disabled');
-  if (!attr) {
-    return false;
-  }
-  const value = attr.value;
-  if (
-    value &&
-    value.type === 'GlimmerMustacheStatement' &&
-    value.path &&
-    value.path.type === 'GlimmerBooleanLiteral' &&
-    value.path.value === false
-  ) {
-    return false;
-  }
-  return true;
-}
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -245,9 +214,6 @@ module.exports = {
     return {
       GlimmerElementNode(node) {
         if (!FORM_CONTROL_TAGS.has(node.tag)) {
-          return;
-        }
-        if (isDisabled(node)) {
           return;
         }
         const nameInfo = getStaticAttrValue(node, 'name');

--- a/lib/rules/template-no-duplicate-form-names.js
+++ b/lib/rules/template-no-duplicate-form-names.js
@@ -1,0 +1,308 @@
+'use strict';
+
+// See html-validate (https://html-validate.org/rules/form-dup-name.html) for the peer rule concept.
+//
+// Simplifications vs. upstream for v1: we don't support `name[]` array syntax,
+// the <input type="hidden"> + <input type="checkbox"> default-value pattern,
+// or the full form-associated element registry. Scope is <input>/<select>/
+// <textarea>/<button>/<output>.
+//
+// Types that do not contribute to the form-data entry list (per HTML spec
+// §4.10.21.4) are skipped entirely — no name collision is possible because
+// they never submit. This covers <input type="button"|"reset"> and
+// <button type="button"|"reset">.
+//
+// Types whose duplicate-name pattern is legitimate are tracked but allowed to
+// share a name within their "share category":
+//   - radio group: multiple <input type=radio> share a name by design (one
+//     selected at a time);
+//   - submit-like controls: at most one submit-like control contributes per
+//     submission, so any mix of <input type=submit>, <input type=image>, and
+//     <button [type=submit]> can share a name.
+// Derived from aria-query's button-role mapping; see `getShareCategory` below.
+
+const { elementRoles } = require('aria-query');
+
+const FORM_CONTROL_TAGS = new Set(['input', 'select', 'textarea', 'button', 'output']);
+const NON_SUBMITTING_TYPES = new Set(['button', 'reset']);
+
+// Submit-like <input> types — derived from aria-query's `button`-role mapping
+// (input[type=submit|image|button|reset] all map to role=button), minus the
+// non-submitting types. At most ONE submit-like control contributes to the
+// form-data entry list per submission (the one the user clicks), so any mix
+// of these can legitimately share a name.
+//
+// "Radio group" semantics are orthogonal: multiple <input type=radio> share a
+// name because selection is mutually exclusive, and exactly one contributes
+// its value. So radios get their own category.
+const SUBMIT_LIKE_INPUT_TYPES = buildSubmitLikeInputTypes();
+
+function buildSubmitLikeInputTypes() {
+  const result = new Set();
+  for (const [schema, rolesSet] of elementRoles) {
+    if (schema.name !== 'input') {
+      continue;
+    }
+    if (!rolesSet.includes('button')) {
+      continue;
+    }
+    const typeAttr = (schema.attributes || []).find((a) => a.name === 'type');
+    if (!typeAttr || typeof typeAttr.value !== 'string') {
+      continue;
+    }
+    if (NON_SUBMITTING_TYPES.has(typeAttr.value)) {
+      continue;
+    }
+    result.add(typeAttr.value);
+  }
+  return result;
+}
+
+// Returns the "share category" for a control type: entries with the same
+// non-null category can legitimately share a name.
+//   - 'radio': radio-group semantics (one selected at a time)
+//   - 'submit-like': submit-control semantics (one triggers submission)
+//   - null: not shareable; any same-name collision is a real duplicate
+function getShareCategory(tag, type) {
+  if (tag === 'input' && type === 'radio') {
+    return 'radio';
+  }
+  if (tag === 'button') {
+    // Bare <button> defaults to type=submit; <button type=submit> too.
+    if (type === 'submit') {
+      return 'submit-like';
+    }
+    return null;
+  }
+  if (tag === 'input' && SUBMIT_LIKE_INPUT_TYPES.has(type)) {
+    return 'submit-like';
+  }
+  return null;
+}
+
+function findAttr(node, name) {
+  return node.attributes?.find((attr) => attr.name === name);
+}
+
+function getStaticAttrValue(node, name) {
+  const attr = findAttr(node, name);
+  if (!attr || !attr.value) {
+    return { kind: attr ? 'empty' : 'absent', value: '' };
+  }
+  if (attr.value.type === 'GlimmerTextNode') {
+    return { kind: 'static', value: attr.value.chars };
+  }
+  if (attr.value.type === 'GlimmerMustacheStatement' && attr.value.path) {
+    if (attr.value.path.type === 'GlimmerStringLiteral') {
+      return { kind: 'static', value: attr.value.path.value };
+    }
+    if (attr.value.path.type === 'GlimmerBooleanLiteral') {
+      return { kind: 'static', value: String(attr.value.path.value) };
+    }
+  }
+  return { kind: 'dynamic', value: '' };
+}
+
+// HTML §4.10.18 — `<button>` and `<input>` with missing/invalid/unknown type
+// fall back to the default state ('submit' for <button>, 'text' for <input>).
+const BUTTON_TYPES = new Set(['submit', 'reset', 'button']);
+const INPUT_TYPES = new Set([
+  'hidden',
+  'text',
+  'search',
+  'tel',
+  'url',
+  'email',
+  'password',
+  'date',
+  'month',
+  'week',
+  'time',
+  'datetime-local',
+  'number',
+  'range',
+  'color',
+  'checkbox',
+  'radio',
+  'file',
+  'submit',
+  'image',
+  'reset',
+  'button',
+]);
+
+function getControlType(node) {
+  if (node.tag === 'button') {
+    const t = getStaticAttrValue(node, 'type');
+    if (t.kind === 'static') {
+      return BUTTON_TYPES.has(t.value.toLowerCase()) ? t.value.toLowerCase() : 'submit';
+    }
+    if (t.kind === 'absent') {
+      return 'submit';
+    }
+    // Dynamic or empty type (mustache / concat / valueless) — the runtime
+    // value is unknown. Return a sentinel so the caller can skip duplicate-
+    // name checks for this node rather than baking in a wrong default.
+    return 'unknown';
+  }
+  if (node.tag === 'input') {
+    const t = getStaticAttrValue(node, 'type');
+    if (t.kind === 'static') {
+      return INPUT_TYPES.has(t.value.toLowerCase()) ? t.value.toLowerCase() : 'text';
+    }
+    if (t.kind === 'absent' || t.kind === 'empty') {
+      return 'text';
+    }
+    return 'unknown';
+  }
+  return node.tag;
+}
+
+function findEnclosingFormOrRoot(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'GlimmerElementNode' && current.tag === 'form') {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+const { getBranchPath, areMutuallyExclusive } = require('../utils/control-flow');
+
+// Per HTML spec (§4.10.21.4 "Constructing the entry list"), only `disabled`
+// controls are skipped when building the form-data entry list. `hidden`
+// does NOT affect submission — a hidden control still contributes its name
+// and value. Duplicate-name collisions can therefore happen even when one
+// of the controls is `hidden`.
+//
+// `disabled={{false}}` (boolean-literal mustache) is carved out: Glimmer VM
+// normalizes boolean `false` to attribute removal at runtime (see
+// `SimpleDynamicAttribute.update` → `removeAttribute`), so the rendered DOM
+// has no `disabled` attribute and the control IS enabled. Matches the same
+// carve-out in `template-no-autofocus-attribute`. Other falsy-looking forms
+// — `disabled="false"` (static string), `disabled={{"false"}}` (string-
+// literal mustache) — still mean disabled per HTML boolean-attribute
+// semantics: presence = disabled regardless of value content.
+function isDisabled(node) {
+  const attr = findAttr(node, 'disabled');
+  if (!attr) {
+    return false;
+  }
+  const value = attr.value;
+  if (
+    value &&
+    value.type === 'GlimmerMustacheStatement' &&
+    value.path &&
+    value.path.type === 'GlimmerBooleanLiteral' &&
+    value.path.value === false
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow duplicate form control names within the same form',
+      category: 'Possible Errors',
+      url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-duplicate-form-names.md',
+      templateMode: 'both',
+    },
+    schema: [],
+    messages: {
+      duplicate: 'Duplicate form control `name="{{name}}"` within the same form',
+    },
+  },
+
+  create(context) {
+    // Per-form: Map<name, entries[]>. Each entry records { type, path } so we
+    // can pairwise compare against subsequent occurrences — mutually exclusive
+    // branches (different `program`/`inverse` subtrees of the same
+    // `{{#if}}`/`{{#unless}}`) never both render, so their same-name
+    // "collision" is a false positive.
+    const nameMapByForm = new WeakMap();
+    const rootMap = new Map();
+
+    function getMapForForm(formNode) {
+      if (!formNode) {
+        return rootMap;
+      }
+      let map = nameMapByForm.get(formNode);
+      if (!map) {
+        map = new Map();
+        nameMapByForm.set(formNode, map);
+      }
+      return map;
+    }
+
+    return {
+      GlimmerElementNode(node) {
+        if (!FORM_CONTROL_TAGS.has(node.tag)) {
+          return;
+        }
+        if (isDisabled(node)) {
+          return;
+        }
+        const nameInfo = getStaticAttrValue(node, 'name');
+        if (nameInfo.kind !== 'static' || nameInfo.value === '') {
+          return;
+        }
+        const name = nameInfo.value;
+        const type = getControlType(node);
+        // Dynamic type (`type={{this.kind}}` / concat) — we can't classify
+        // the control's submission behavior. Skip duplicate-name collision
+        // checks for this node rather than guessing; false negatives here
+        // are safer than false positives on legitimate branches.
+        if ((node.tag === 'input' || node.tag === 'button') && type === 'unknown') {
+          return;
+        }
+        // Non-submitting controls contribute nothing to the form-data entry
+        // list, so their `name` can't collide with anything.
+        if ((node.tag === 'input' || node.tag === 'button') && NON_SUBMITTING_TYPES.has(type)) {
+          return;
+        }
+        const form = findEnclosingFormOrRoot(node);
+        const map = getMapForForm(form);
+        const path = getBranchPath(node);
+
+        const entries = map.get(name);
+        const currCategory = getShareCategory(node.tag, type);
+
+        if (!entries) {
+          map.set(name, [{ tag: node.tag, type, path, category: currCategory }]);
+          return;
+        }
+
+        const collides = entries.some((prev) => {
+          // Same share-category (radio group, or any mix of submit-like
+          // controls) coexist legitimately — at most one contributes to the
+          // form-data entry list per submission.
+          if (currCategory !== null && currCategory === prev.category) {
+            return false;
+          }
+          // Mutually exclusive control-flow branches never render together.
+          if (areMutuallyExclusive(prev.path, path)) {
+            return false;
+          }
+          return true;
+        });
+
+        entries.push({ tag: node.tag, type, path, category: currCategory });
+
+        if (collides) {
+          const nameAttr = findAttr(node, 'name');
+          context.report({
+            node: nameAttr || node,
+            messageId: 'duplicate',
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/template-no-duplicate-id.js
+++ b/lib/rules/template-no-duplicate-id.js
@@ -1,11 +1,10 @@
-const IGNORE_IDS = new Set(['{{unique-id}}', '{{(unique-id)}}']);
+const {
+  createConditionalScope,
+  isBranchingBlockStatement,
+  isConditionalBlockBranch,
+} = require('../utils/control-flow');
 
-function isControlFlowHelper(node) {
-  if (node.type === 'GlimmerBlockStatement' && node.path?.type === 'GlimmerPathExpression') {
-    return ['if', 'unless', 'each', 'each-in', 'let', 'with'].includes(node.path.original);
-  }
-  return false;
-}
+const IGNORE_IDS = new Set(['{{unique-id}}', '{{(unique-id)}}']);
 
 // Walk up the parent chain to find an ancestor element/block whose blockParams
 // include headName. Used to make block-param-derived IDs unique per invocation.
@@ -47,51 +46,10 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.sourceCode;
-    let seenIdStack = [];
-    let conditionalStack = [];
+    let scope = createConditionalScope();
 
     function enterTemplate() {
-      seenIdStack = [new Set()];
-      conditionalStack = [];
-    }
-
-    function isDuplicateId(id) {
-      for (const seenIds of seenIdStack) {
-        if (seenIds.has(id)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    function addId(id) {
-      seenIdStack.at(-1).add(id);
-      if (conditionalStack.length > 0) {
-        conditionalStack.at(-1).add(id);
-      }
-    }
-
-    function enterConditional() {
-      conditionalStack.push(new Set());
-    }
-
-    function exitConditional() {
-      const idsInConditional = conditionalStack.pop();
-      if (conditionalStack.length > 0) {
-        for (const id of idsInConditional) {
-          conditionalStack.at(-1).add(id);
-        }
-      } else {
-        seenIdStack.push(idsInConditional);
-      }
-    }
-
-    function enterConditionalBranch() {
-      seenIdStack.push(new Set());
-    }
-
-    function exitConditionalBranch() {
-      seenIdStack.pop();
+      scope = createConditionalScope();
     }
 
     // For a GlimmerMustacheStatement whose path is a PathExpression, return a
@@ -165,10 +123,10 @@ module.exports = {
       if (IGNORE_IDS.has(id)) {
         return;
       }
-      if (isDuplicateId(id)) {
+      if (scope.has(id)) {
         context.report({ node: reportNode, messageId: 'duplicate' });
       } else {
-        addId(id);
+        scope.add(id);
       }
     }
 
@@ -177,8 +135,7 @@ module.exports = {
         enterTemplate();
       },
       'GlimmerTemplate:exit'() {
-        seenIdStack = [new Set()];
-        conditionalStack = [];
+        enterTemplate(); // reset
       },
 
       GlimmerElementNode(node) {
@@ -208,8 +165,8 @@ module.exports = {
       },
 
       GlimmerBlockStatement(node) {
-        if (isControlFlowHelper(node)) {
-          enterConditional();
+        if (isBranchingBlockStatement(node)) {
+          scope.enterConditional();
         } else if (node.hash && node.hash.pairs) {
           for (const pair of node.hash.pairs) {
             if (['elementId', 'id'].includes(pair.key)) {
@@ -222,22 +179,20 @@ module.exports = {
       },
 
       'GlimmerBlockStatement:exit'(node) {
-        if (isControlFlowHelper(node)) {
-          exitConditional();
+        if (isBranchingBlockStatement(node)) {
+          scope.exitConditional();
         }
       },
 
       GlimmerBlock(node) {
-        const parent = node.parent;
-        if (parent && isControlFlowHelper(parent)) {
-          enterConditionalBranch();
+        if (isConditionalBlockBranch(node)) {
+          scope.enterConditionalBranch();
         }
       },
 
       'GlimmerBlock:exit'(node) {
-        const parent = node.parent;
-        if (parent && isControlFlowHelper(parent)) {
-          exitConditionalBranch();
+        if (isConditionalBlockBranch(node)) {
+          scope.exitConditionalBranch();
         }
       },
     };

--- a/lib/rules/template-no-duplicate-landmark-elements.js
+++ b/lib/rules/template-no-duplicate-landmark-elements.js
@@ -1,3 +1,5 @@
+const { getBranchPath, areMutuallyExclusive } = require('../utils/control-flow');
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -49,99 +51,89 @@ module.exports = {
     const SECTIONING_ELEMENTS = new Set(['article', 'aside', 'main', 'nav', 'section']);
     const elementStack = [];
 
-    // Stack-based scoping for landmarks to handle conditional branches.
-    // Each scope is a Map<role, [{node, tag}]>.
-    // When entering a GlimmerBlock that is a branch of an if/unless,
-    // we push a copy of the current scope so that each branch starts
-    // from the same baseline and landmarks from one branch don't
-    // leak into another.
-    const landmarksStack = [new Map()];
+    // Scope-root stack — a new scope starts at <dialog> and at any element
+    // carrying a `popover` attribute. Landmarks in different scope roots
+    // never collide with each other, matching the WAI-ARIA convention that
+    // these elements present their own landmark hierarchy.
+    const scopeRootStack = [null]; // root scope keyed by `null`
 
-    function currentLandmarks() {
-      return landmarksStack.at(-1);
-    }
-
-    function cloneLandmarks(landmarks) {
-      const clone = new Map();
-      for (const [role, entries] of landmarks) {
-        clone.set(role, [...entries]);
-      }
-      return clone;
+    function currentScopeRoot() {
+      return scopeRootStack.at(-1);
     }
 
     function isInsideSectioningElement() {
       return elementStack.some((tag) => SECTIONING_ELEMENTS.has(tag));
     }
 
-    function checkDuplicates(landmarks) {
-      for (const [, entries] of landmarks) {
-        if (entries.length > 1) {
-          const labeled = [];
-          const unlabeled = [];
+    // Accumulate every landmark in document order. At Program:exit we group
+    // by (scopeRoot, role) and do pairwise duplicate detection, filtering out
+    // pairs whose branch paths are mutually exclusive (different branches of
+    // the same {{#if}} / {{#unless}} / {{#each}}…{{else}}… — these never
+    // both render at runtime).
+    const landmarks = [];
 
-          for (const entry of entries) {
-            const label = getLabel(entry.node);
-            if (label) {
-              labeled.push({ node: entry.node, tag: entry.tag, label });
-            } else {
-              unlabeled.push({ node: entry.node, tag: entry.tag });
-            }
-          }
+    function reportAgainstLabelGroup(entries) {
+      // All-labeled same-label collisions: every entry after the first is a
+      // duplicate of earlier ones that can co-render.
+      const labeled = entries.filter((e) => e.label !== null);
+      const unlabeled = entries.filter((e) => e.label === null);
 
-          // When multiple landmarks of same type exist, unlabeled ones are violations
-          if (unlabeled.length > 0) {
-            if (unlabeled.length === entries.length) {
-              // All unlabeled — report all but the first
-              for (let i = 1; i < unlabeled.length; i++) {
-                context.report({
-                  node: unlabeled[i].node,
-                  messageId: 'duplicate',
-                });
-              }
-            } else {
-              // Some are labeled, some aren't — report the unlabeled ones
-              for (const entry of unlabeled) {
-                context.report({
-                  node: entry.node,
-                  messageId: 'duplicate',
-                });
-              }
-            }
+      // Unlabeled duplicates:
+      //   - If EVERY entry is unlabeled, report all except the first.
+      //   - If some are labeled, report all unlabeled entries.
+      if (unlabeled.length > 0) {
+        if (unlabeled.length === entries.length) {
+          for (let i = 1; i < unlabeled.length; i++) {
+            context.report({ node: unlabeled[i].node, messageId: 'duplicate' });
           }
+        } else {
+          for (const entry of unlabeled) {
+            context.report({ node: entry.node, messageId: 'duplicate' });
+          }
+        }
+      }
 
-          // Report same-label duplicates among labeled landmarks
-          const labelGroups = new Map();
-          for (const entry of labeled) {
-            if (!labelGroups.has(entry.label)) {
-              labelGroups.set(entry.label, []);
-            }
-            labelGroups.get(entry.label).push(entry);
-          }
-          for (const [, groupEntries] of labelGroups) {
-            if (groupEntries.length > 1) {
-              for (let i = 1; i < groupEntries.length; i++) {
-                context.report({
-                  node: groupEntries[i].node,
-                  messageId: 'duplicate',
-                });
-              }
-            }
+      // Same-label collisions among labeled entries: group by label.
+      const byLabel = new Map();
+      for (const entry of labeled) {
+        if (!byLabel.has(entry.label)) {
+          byLabel.set(entry.label, []);
+        }
+        byLabel.get(entry.label).push(entry);
+      }
+      for (const [, group] of byLabel) {
+        if (group.length > 1) {
+          for (let i = 1; i < group.length; i++) {
+            context.report({ node: group[i].node, messageId: 'duplicate' });
           }
         }
       }
     }
 
-    // Track elements that create new landmark scopes (dialog, popover)
-    const newScopeElements = [];
+    // For a cluster of landmarks sharing (scopeRoot, role), drop entries whose
+    // branch paths make them mutually exclusive with every other entry in the
+    // cluster — those can never co-render and so can't collide. What remains
+    // is the set of entries that COULD co-render; apply the labeled /
+    // unlabeled duplicate rules to that residue.
+    function checkCoRenderingCluster(entries) {
+      if (entries.length < 2) {
+        return;
+      }
+      // Keep any entry that has at least one other entry it can co-render
+      // with. `areMutuallyExclusive` is commutative, so a single pass is
+      // enough.
+      const coRendering = entries.filter((entry) =>
+        entries.some((other) => other !== entry && !areMutuallyExclusive(entry.path, other.path))
+      );
+      reportAgainstLabelGroup(coRendering);
+    }
 
     return {
       GlimmerElementNode(node) {
         elementStack.push(node.tag);
 
-        // <dialog> and elements with popover attribute create isolated landmark scopes
         if (isNewScopeElement(node)) {
-          landmarksStack.push(new Map());
-          newScopeElements.push(node);
+          scopeRootStack.push(node);
         }
 
         // Dynamic role values — skip (can't determine role statically)
@@ -156,44 +148,73 @@ module.exports = {
           ELEMENT_TO_ROLE,
           isInsideSectioningElement()
         );
-        if (landmarkRole) {
-          // Dynamic aria-label / aria-labelledby — can't statically determine whether
-          // this landmark duplicates a sibling, so skip registering it entirely.
-          const labelAttr =
-            node.attributes?.find((attr) => attr.name === 'aria-label') ||
-            node.attributes?.find((attr) => attr.name === 'aria-labelledby');
-          if (labelAttr && labelAttr.value?.type !== 'GlimmerTextNode') {
-            return;
-          }
-
-          const landmarks = currentLandmarks();
-          if (!landmarks.has(landmarkRole)) {
-            landmarks.set(landmarkRole, []);
-          }
-          landmarks.get(landmarkRole).push({ node, tag: node.tag });
+        if (!landmarkRole) {
+          return;
         }
+
+        // Dynamic aria-label / aria-labelledby — can't statically determine
+        // whether this landmark duplicates a sibling, so skip registering.
+        const labelAttr =
+          node.attributes?.find((attr) => attr.name === 'aria-label') ||
+          node.attributes?.find((attr) => attr.name === 'aria-labelledby');
+        if (labelAttr && labelAttr.value?.type !== 'GlimmerTextNode') {
+          return;
+        }
+
+        landmarks.push({
+          node,
+          tag: node.tag,
+          role: landmarkRole,
+          label: getLabel(node),
+          path: getBranchPath(node),
+          scopeRoot: currentScopeRoot(),
+        });
       },
 
       'GlimmerElementNode:exit'(node) {
         elementStack.pop();
-        if (newScopeElements.at(-1) === node) {
-          newScopeElements.pop();
-          landmarksStack.pop();
+        if (scopeRootStack.at(-1) === node) {
+          scopeRootStack.pop();
         }
       },
 
-      // Every Block gets its own scope (matching the original's Block visitor).
-      // This handles each, let, with, etc. — not just if/unless.
-      GlimmerBlock() {
-        landmarksStack.push(cloneLandmarks(currentLandmarks()));
-      },
-
-      'GlimmerBlock:exit'() {
-        landmarksStack.pop();
-      },
-
       'Program:exit'() {
-        checkDuplicates(currentLandmarks());
+        // Group by (scopeRoot, role). Keyed by node identity via WeakMap —
+        // string keys derived from `loc` risk collisions when loc is missing
+        // (synthetic nodes) or zeroed (parser edge cases). A WeakMap of the
+        // actual scope-root node objects is collision-free by construction.
+        // The root scope (no enclosing <dialog>/popover) lives in a
+        // sibling Map (WeakMap requires object keys, so null-keyed root
+        // clusters use a plain Map).
+        const rootClusters = new Map(); // role → entries[]
+        const byScopeRoot = new WeakMap(); // scopeRootNode → Map<role, entries[]>
+        for (const entry of landmarks) {
+          const map = entry.scopeRoot
+            ? byScopeRoot.get(entry.scopeRoot) ||
+              byScopeRoot.set(entry.scopeRoot, new Map()).get(entry.scopeRoot)
+            : rootClusters;
+          if (!map.has(entry.role)) {
+            map.set(entry.role, []);
+          }
+          map.get(entry.role).push(entry);
+        }
+        for (const [, entries] of rootClusters) {
+          checkCoRenderingCluster(entries);
+        }
+        // WeakMap is not iterable; walk back through the landmarks list to
+        // collect the unique scope-root nodes we saw, dedupe, then process.
+        const seenScopeRoots = new Set();
+        for (const entry of landmarks) {
+          if (entry.scopeRoot && !seenScopeRoots.has(entry.scopeRoot)) {
+            seenScopeRoots.add(entry.scopeRoot);
+            const map = byScopeRoot.get(entry.scopeRoot);
+            if (map) {
+              for (const [, entries] of map) {
+                checkCoRenderingCluster(entries);
+              }
+            }
+          }
+        }
       },
     };
   },

--- a/lib/utils/control-flow.js
+++ b/lib/utils/control-flow.js
@@ -185,6 +185,14 @@ function createConditionalScope() {
           conditionalStack.at(-1).add(key);
         }
       } else {
+        // Top-level conditional ended — its accumulated keys are now
+        // unconditionally "seen" at this scope. Push as a separate frame
+        // (rather than merging into seenStack[0]) to mirror upstream
+        // ember-template-lint's ConditionalScope (PR #1606) and keep
+        // per-conditional grouping for future debugging hooks. Functionally
+        // equivalent to a single merged Set for `has()` purposes; growth is
+        // O(top-level conditionals per template), which is bounded by source
+        // size.
         seenStack.push(keys);
       }
     },

--- a/lib/utils/control-flow.js
+++ b/lib/utils/control-flow.js
@@ -1,0 +1,222 @@
+'use strict';
+
+/**
+ * Control-flow helpers for rules that care whether two template elements can
+ * actually co-exist at runtime. The Handlebars/Glimmer constructs that
+ * introduce mutual exclusion between `program` and `inverse` branches are:
+ *   - `{{#if}}` / `{{#unless}}` — condition-based.
+ *   - `{{#each}}` / `{{#each-in}}` with `{{else}}` — program renders N>=1
+ *     iterations, inverse renders when the collection is empty. Exactly
+ *     one of the two branches executes. Exposed via
+ *     `BRANCHING_BLOCK_NAMES` / `isBranchingBlockStatement(node)`.
+ *
+ * Helpers that do NOT introduce mutual exclusion:
+ *   - `{{#each}}` / `{{#each-in}}` WITHOUT `{{else}}` — body renders 0..N
+ *     times, but multiple static children in the body are rendered N times
+ *     each and still duplicate at runtime.
+ *   - `{{#let}}` / `{{#with}}` are pure scope-binding: body renders
+ *     unconditionally.
+ *
+ * Two APIs live in this module:
+ *
+ *   1. Path primitives — `getBranchPath(node)` + `areMutuallyExclusive(a, b)`.
+ *      Compute once per element, pairwise-compare with arbitrary predicates.
+ *      Fit for rules that need per-entry metadata (e.g. checkbox-vs-submit
+ *      name-sharing in `template-no-duplicate-form-names`).
+ *
+ *   2. Stack wrapper — `createConditionalScope()`. Enter/exit hooks driven
+ *      by the ESLint visitor. Fit for simple "have I seen this key already
+ *      in any visible scope?" rules (e.g. `template-no-duplicate-id`).
+ *
+ * Both APIs agree on the same mutual-exclusion semantics.
+ */
+
+// Names of Glimmer block helpers that create mutually-exclusive branches
+// between `program` and `inverse`:
+//   - `if` / `unless`: condition-based exclusion.
+//   - `each` / `each-in` with `{{else}}`: program renders N>=1 iterations,
+//     inverse renders when the collection is empty. They never both render.
+//
+// `let` and `with` are NOT in this set — they are pure block-param binding
+// with no semantic inverse branch; any `{{else}}` alongside them wouldn't
+// carry mutual-exclusion semantics.
+const BRANCHING_BLOCK_NAMES = new Set(['if', 'unless', 'each', 'each-in']);
+
+function isBranchingBlockStatement(node) {
+  if (!node || node.type !== 'GlimmerBlockStatement') {
+    return false;
+  }
+  if (!node.path || node.path.type !== 'GlimmerPathExpression') {
+    return false;
+  }
+  const name = node.path.original;
+  if (!BRANCHING_BLOCK_NAMES.has(name)) {
+    return false;
+  }
+  // `each` / `each-in` only introduce an exclusive inverse when `{{else}}`
+  // is actually present. Without it, the body is the sole render path.
+  if ((name === 'each' || name === 'each-in') && !node.inverse) {
+    return false;
+  }
+  return true;
+}
+
+// Legacy alias kept for readability in call sites that only care about
+// if/unless. Semantically equivalent to `isBranchingBlockStatement` for those
+// two names.
+function isIfOrUnlessBlockStatement(node) {
+  if (!isBranchingBlockStatement(node)) {
+    return false;
+  }
+  return node.path.original === 'if' || node.path.original === 'unless';
+}
+
+// Returns true when `node` is the `program` or `inverse` body Block of an
+// enclosing branching block — i.e. a mutually-exclusive branch body.
+function isConditionalBlockBranch(node) {
+  if (!node || node.type !== 'GlimmerBlock') {
+    return false;
+  }
+  const parent = node.parent;
+  if (!isBranchingBlockStatement(parent)) {
+    return false;
+  }
+  return parent.program === node || parent.inverse === node;
+}
+
+// Legacy alias.
+const isIfOrUnlessBlockBranch = isConditionalBlockBranch;
+
+/**
+ * Compute the branching-block path from the root down to `node`. Each entry
+ * records the enclosing BlockStatement and which branch (`program` /
+ * `inverse`) the traversal passes through. Used to test whether two elements
+ * live in mutually-exclusive branches.
+ *
+ * "Branching block" covers any BlockStatement whose `program` and `inverse`
+ * subtrees are mutually exclusive at runtime — `{{#if}}`, `{{#unless}}`, and
+ * `{{#each}}…{{else}}` all qualify (the `else` branch of `{{#each}}` renders
+ * only when the collection is empty).
+ *
+ * Returns `[]` for elements not inside any branching block.
+ *
+ * @param {object} node - AST node with `.parent` back-references (set by
+ *   ember-eslint-parser during traversal).
+ * @returns {Array<{ block: object, branch: 'program' | 'inverse' }>}
+ */
+function getBranchPath(node) {
+  const path = [];
+  let current = node;
+  while (current && current.parent) {
+    const parent = current.parent;
+    const grand = parent.parent;
+    if (grand && isBranchingBlockStatement(grand)) {
+      if (grand.program === parent) {
+        path.unshift({ block: grand, branch: 'program' });
+      } else if (grand.inverse === parent) {
+        path.unshift({ block: grand, branch: 'inverse' });
+      }
+    }
+    current = parent;
+  }
+  return path;
+}
+
+/**
+ * Two paths are mutually exclusive if they share an ancestor branching block
+ * but diverge on its `program` vs `inverse` branch. Elements with mutually-
+ * exclusive paths never both render at runtime.
+ *
+ * @returns {boolean}
+ */
+function areMutuallyExclusive(pathA, pathB) {
+  const minLen = Math.min(pathA.length, pathB.length);
+  for (let i = 0; i < minLen; i++) {
+    const a = pathA[i];
+    const b = pathB[i];
+    if (a.block !== b.block) {
+      // Paths diverge into different ancestor blocks — no shared
+      // mutual-exclusion pivot remains.
+      return false;
+    }
+    if (a.branch !== b.branch) {
+      return true;
+    }
+  }
+  // One path is a prefix of the other (or equal) — both can render together.
+  return false;
+}
+
+/**
+ * Visitor-hook-driven scope for rules that ask "have I seen this key in any
+ * visible scope?". Traversal wires:
+ *
+ *   'GlimmerBlockStatement': (node) => {
+ *     if (isBranchingBlockStatement(node)) scope.enterConditional();
+ *   },
+ *   'GlimmerBlockStatement:exit': (node) => {
+ *     if (isBranchingBlockStatement(node)) scope.exitConditional();
+ *   },
+ *   'GlimmerBlock': (node) => {
+ *     if (isConditionalBlockBranch(node)) scope.enterConditionalBranch();
+ *   },
+ *   'GlimmerBlock:exit': (node) => {
+ *     if (isConditionalBlockBranch(node)) scope.exitConditionalBranch();
+ *   },
+ *
+ * Two-stack design matches upstream ember-template-lint's ConditionalScope
+ * (from PR #1606): `seenStack` holds nested branch-body Sets so exiting a
+ * branch forgets what it saw; `conditionalStack` accumulates everything any
+ * branch saw, then promotes those keys to "always visible at this level"
+ * when the whole conditional ends.
+ */
+function createConditionalScope() {
+  const seenStack = [new Set()];
+  const conditionalStack = [];
+
+  return {
+    enterConditional() {
+      conditionalStack.push(new Set());
+    },
+    exitConditional() {
+      const keys = conditionalStack.pop();
+      if (conditionalStack.length > 0) {
+        for (const key of keys) {
+          conditionalStack.at(-1).add(key);
+        }
+      } else {
+        seenStack.push(keys);
+      }
+    },
+    enterConditionalBranch() {
+      seenStack.push(new Set());
+    },
+    exitConditionalBranch() {
+      seenStack.pop();
+    },
+    has(key) {
+      for (const seen of seenStack) {
+        if (seen.has(key)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    add(key) {
+      seenStack.at(-1).add(key);
+      if (conditionalStack.length > 0) {
+        conditionalStack.at(-1).add(key);
+      }
+    },
+  };
+}
+
+module.exports = {
+  isBranchingBlockStatement,
+  isConditionalBlockBranch,
+  isIfOrUnlessBlockStatement,
+  isIfOrUnlessBlockBranch,
+  getBranchPath,
+  areMutuallyExclusive,
+  createConditionalScope,
+};

--- a/tests/lib/rules/template-no-duplicate-form-names.js
+++ b/tests/lib/rules/template-no-duplicate-form-names.js
@@ -1,0 +1,151 @@
+const rule = require('../../../lib/rules/template-no-duplicate-form-names');
+const RuleTester = require('eslint').RuleTester;
+
+const err = (name) => `Duplicate form control \`name="${name}"\` within the same form`;
+
+const validHbs = [
+  // Single occurrence.
+  '<form><input name="email" /></form>',
+  '<form><input name="email" /><input name="password" /></form>',
+  // Radio group with shared name.
+  '<form><input type="radio" name="c" value="r" /><input type="radio" name="c" value="b" /></form>',
+  // Submit buttons can share a name.
+  '<form><button type="submit" name="a" value="save">S</button><button type="submit" name="a" value="p">P</button></form>',
+  '<form><input type="submit" name="act" /><input type="submit" name="act" /></form>',
+  // Mixed submit-like controls — per HTML §4.10.21.4 only one contributes to
+  // the form-data entry list per submission, so any combination can share a
+  // name. Submit-like set: `<button [type=submit]>`, `<input type=submit>`,
+  // `<input type=image>`. Derived from aria-query's `button`-role mapping.
+  '<form><input type="submit" name="a" /><input type="image" name="a" src="/x.png" /></form>',
+  '<form><button name="a" value="save">Save</button><input type="image" name="a" src="/x.png" /></form>',
+  '<form><input type="image" name="a" src="/a.png" /><input type="image" name="a" src="/b.png" /></form>',
+  // Non-submitting types (button, reset) don't contribute to form data; their
+  // `name` is skipped entirely, so any combination is fine.
+  '<form><button type="reset" name="r">1</button><button type="reset" name="r">2</button></form>',
+  '<form><input type="button" name="x" /><input type="button" name="x" /></form>',
+  '<form><input type="button" name="x" /><input type="text" name="x" /></form>',
+  '<form><button type="button" name="x">1</button><input type="text" name="x" /></form>',
+  '<form><input type="reset" name="x" /><input type="text" name="x" /></form>',
+  // Dynamic name — skip.
+  '<form><input name={{this.fieldName}} /><input name="email" /></form>',
+  // Dynamic type — the control's submission category is unknown at lint
+  // time, so we can't prove a collision with a same-named static control.
+  // Skip rather than guess; false negatives here are safer than flagging a
+  // legitimate radio/button group that happens to share a name.
+  '<form><input type={{this.kind}} name="a" /><input type="text" name="a" /></form>',
+  '<form><button type={{this.kind}} name="a">x</button><input type="text" name="a" /></form>',
+  // Same name but in different forms — fine.
+  '<form><input name="a" /></form><form><input name="a" /></form>',
+  // Disabled control is ignored — it does not contribute to form data.
+  '<form><input name="a" /><input name="a" disabled /></form>',
+  '<form><input name="a" /><input name="a" disabled="disabled" /></form>',
+  // No name attribute — skip.
+  '<form><input /><input /></form>',
+  // Empty name — skip.
+  '<form><input name="" /><input name="" /></form>',
+
+  // Mutually-exclusive branches of {{#if}} / {{#unless}} / {{#each}}{{else}}
+  // never both render — same-name fields across branches aren't duplicates.
+  '<form>{{#if this.editing}}<input name="title" />{{else}}<input name="title" />{{/if}}</form>',
+  '<form>{{#unless this.readOnly}}<input name="q" />{{else}}<input name="q" />{{/unless}}</form>',
+  '<form>{{#each this.items}}<input name="items[]" />{{else}}<input name="items[]" />{{/each}}</form>',
+  // Nested: inner mutual exclusion under outer common ancestor.
+  '<form>{{#if this.a}}{{#if this.b}}<input name="x" />{{else}}<input name="x" />{{/if}}{{/if}}</form>',
+];
+
+const invalidHbs = [
+  {
+    code: '<form><input name="email" /><input name="email" /></form>',
+    errors: [{ message: err('email') }],
+  },
+  {
+    code: '<form><input name="x" /><textarea name="x"></textarea></form>',
+    errors: [{ message: err('x') }],
+  },
+  {
+    code: '<form><input name="x" /><select name="x"><option>a</option></select></form>',
+    errors: [{ message: err('x') }],
+  },
+  // Mixed radio + text type — not compatible.
+  {
+    code: '<form><input type="radio" name="c" /><input type="text" name="c" /></form>',
+    errors: [{ message: err('c') }],
+  },
+  // Radio + submit — different share categories (radio group vs submit-
+  // like). Both contribute to form data in different ways; same name is
+  // a real collision.
+  {
+    code: '<form><input type="radio" name="a" /><input type="submit" name="a" /></form>',
+    errors: [{ message: err('a') }],
+  },
+  // Text + image (image is submit-like; text is not shareable) — collision.
+  {
+    code: '<form><input type="text" name="a" /><input type="image" name="a" src="/x.png" /></form>',
+    errors: [{ message: err('a') }],
+  },
+  // `disabled={{false}}` renders no `disabled` attribute at runtime
+  // (Glimmer VM normalizes boolean false to attribute removal) — the
+  // control IS enabled and contributes to form data, so the duplicate
+  // name collides with the enabled sibling.
+  {
+    code: '<form><input name="a" /><input name="a" disabled={{false}} /></form>',
+    errors: [{ message: err('a') }],
+  },
+  // No enclosing form — template root acts as scope.
+  {
+    code: '<input name="x" /><input name="x" />',
+    errors: [{ message: err('x') }],
+  },
+  // `hidden` does not exempt from form submission per HTML spec — a hidden
+  // control carries a real value and can legitimately collide by name.
+  {
+    code: '<form><input name="x" hidden /><input name="x" /></form>',
+    errors: [{ message: err('x') }],
+  },
+  // Conditional WITH an unconditional sibling — the unconditional renders
+  // alongside EITHER branch, so it's flagged (only the unconditional gets
+  // the report; the two branch-inputs are mutually exclusive with each
+  // other and individually don't collide with any prior entry).
+  {
+    code: '<form>{{#if this.a}}<input name="x" />{{else}}<input name="x" />{{/if}}<input name="x" /></form>',
+    errors: [{ message: err('x') }],
+  },
+  // Two separate `{{#if}}`s are NOT mutually exclusive — both can render
+  // together when both conditions are true.
+  {
+    code: '<form>{{#if this.a}}<input name="x" />{{/if}}{{#if this.b}}<input name="x" />{{/if}}</form>',
+    errors: [{ message: err('x') }],
+  },
+  // {{#let}} is pure scoping, not mutual exclusion — two inputs across let
+  // bodies both render.
+  {
+    code: '<form>{{#let this.a as |x|}}<input name="n" />{{/let}}{{#let this.b as |y|}}<input name="n" />{{/let}}</form>',
+    errors: [{ message: err('n') }],
+  },
+];
+
+const gjsValid = validHbs.map((code) => `<template>${code}</template>`);
+const gjsInvalid = invalidHbs.map(({ code, errors }) => ({
+  code: `<template>${code}</template>`,
+  errors,
+}));
+
+const gjsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+gjsRuleTester.run('template-no-duplicate-form-names', rule, {
+  valid: gjsValid,
+  invalid: gjsInvalid,
+});
+
+const hbsRuleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser/hbs'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+hbsRuleTester.run('template-no-duplicate-form-names', rule, {
+  valid: validHbs,
+  invalid: invalidHbs,
+});

--- a/tests/lib/rules/template-no-duplicate-form-names.js
+++ b/tests/lib/rules/template-no-duplicate-form-names.js
@@ -19,6 +19,8 @@ const validHbs = [
   '<form><input type="submit" name="a" /><input type="image" name="a" src="/x.png" /></form>',
   '<form><button name="a" value="save">Save</button><input type="image" name="a" src="/x.png" /></form>',
   '<form><input type="image" name="a" src="/a.png" /><input type="image" name="a" src="/b.png" /></form>',
+  // Valueless `type` on <button> defaults to 'submit' per HTML §4.10.9.
+  '<form><button type name="a">S</button><button type name="a">P</button></form>',
   // Non-submitting types (button, reset) don't contribute to form data; their
   // `name` is skipped entirely, so any combination is fine.
   '<form><button type="reset" name="r">1</button><button type="reset" name="r">2</button></form>',

--- a/tests/lib/rules/template-no-duplicate-form-names.js
+++ b/tests/lib/rules/template-no-duplicate-form-names.js
@@ -38,9 +38,6 @@ const validHbs = [
   '<form><button type={{this.kind}} name="a">x</button><input type="text" name="a" /></form>',
   // Same name but in different forms — fine.
   '<form><input name="a" /></form><form><input name="a" /></form>',
-  // Disabled control is ignored — it does not contribute to form data.
-  '<form><input name="a" /><input name="a" disabled /></form>',
-  '<form><input name="a" /><input name="a" disabled="disabled" /></form>',
   // No name attribute — skip.
   '<form><input /><input /></form>',
   // Empty name — skip.
@@ -85,10 +82,16 @@ const invalidHbs = [
     code: '<form><input type="text" name="a" /><input type="image" name="a" src="/x.png" /></form>',
     errors: [{ message: err('a') }],
   },
-  // `disabled={{false}}` renders no `disabled` attribute at runtime
-  // (Glimmer VM normalizes boolean false to attribute removal) — the
-  // control IS enabled and contributes to form data, so the duplicate
-  // name collides with the enabled sibling.
+  // Disabled controls are still flagged — disabled state is dynamic and the
+  // duplicate name is a structural problem regardless.
+  {
+    code: '<form><input name="a" /><input name="a" disabled /></form>',
+    errors: [{ message: err('a') }],
+  },
+  {
+    code: '<form><input name="a" /><input name="a" disabled="disabled" /></form>',
+    errors: [{ message: err('a') }],
+  },
   {
     code: '<form><input name="a" /><input name="a" disabled={{false}} /></form>',
     errors: [{ message: err('a') }],

--- a/tests/lib/utils/control-flow-test.js
+++ b/tests/lib/utils/control-flow-test.js
@@ -1,0 +1,305 @@
+'use strict';
+
+// The AST builders below intentionally wire `.parent` back-pointers onto the
+// passed-in child nodes to match ember-eslint-parser's shape — mutation is
+// the point, not a bug. Per-line disables rather than a file-level pair to
+// match the codebase's idiom (eslint-comments/disable-enable-pair is on).
+
+const {
+  getBranchPath,
+  areMutuallyExclusive,
+  createConditionalScope,
+  isBranchingBlockStatement,
+  isIfOrUnlessBlockStatement,
+  isIfOrUnlessBlockBranch,
+} = require('../../../lib/utils/control-flow');
+
+// Tiny AST node builders — use plain objects with the same shape the Glimmer
+// parser produces. Each helper wires `.parent` back-references to match
+// ember-eslint-parser's behavior.
+function makeElement(tag) {
+  return { type: 'GlimmerElementNode', tag, parent: null };
+}
+
+function makeBlock(body) {
+  const node = { type: 'GlimmerBlock', body, parent: null };
+  for (const child of body) {
+    child.parent = node;
+  }
+  return node;
+}
+
+function makeIf(program, inverse = null) {
+  const node = {
+    type: 'GlimmerBlockStatement',
+    path: { type: 'GlimmerPathExpression', original: 'if' },
+    program,
+    inverse,
+    parent: null,
+  };
+  // eslint-disable-next-line no-param-reassign
+  program.parent = node;
+  if (inverse) {
+    // eslint-disable-next-line no-param-reassign
+    inverse.parent = node;
+  }
+  return node;
+}
+
+function makeUnless(program, inverse = null) {
+  const node = makeIf(program, inverse);
+  node.path.original = 'unless';
+  return node;
+}
+
+function makeEach(program, inverse = null) {
+  const node = {
+    type: 'GlimmerBlockStatement',
+    path: { type: 'GlimmerPathExpression', original: 'each' },
+    program,
+    inverse,
+    parent: null,
+  };
+  // eslint-disable-next-line no-param-reassign
+  program.parent = node;
+  if (inverse) {
+    // eslint-disable-next-line no-param-reassign
+    inverse.parent = node;
+  }
+  return node;
+}
+
+function makeLet(program) {
+  const node = {
+    type: 'GlimmerBlockStatement',
+    path: { type: 'GlimmerPathExpression', original: 'let' },
+    program,
+    inverse: null,
+    parent: null,
+  };
+  // eslint-disable-next-line no-param-reassign
+  program.parent = node;
+  return node;
+}
+
+describe('isIfOrUnlessBlockStatement', () => {
+  it('recognizes {{#if}}', () => {
+    expect(isIfOrUnlessBlockStatement(makeIf(makeBlock([])))).toBe(true);
+  });
+  it('recognizes {{#unless}}', () => {
+    expect(isIfOrUnlessBlockStatement(makeUnless(makeBlock([])))).toBe(true);
+  });
+  it('rejects {{#each}}', () => {
+    expect(isIfOrUnlessBlockStatement(makeEach(makeBlock([])))).toBe(false);
+  });
+  it('rejects non-block nodes', () => {
+    expect(isIfOrUnlessBlockStatement(makeElement('div'))).toBe(false);
+    expect(isIfOrUnlessBlockStatement(null)).toBe(false);
+  });
+});
+
+describe('isBranchingBlockStatement', () => {
+  it('recognizes {{#if}}', () => {
+    expect(isBranchingBlockStatement(makeIf(makeBlock([])))).toBe(true);
+  });
+  it('recognizes {{#each}}{{else}}{{/each}} (has inverse)', () => {
+    expect(isBranchingBlockStatement(makeEach(makeBlock([]), makeBlock([])))).toBe(true);
+  });
+  it('rejects {{#each}}{{/each}} without inverse (no mutual-exclusion branch)', () => {
+    expect(isBranchingBlockStatement(makeEach(makeBlock([])))).toBe(false);
+  });
+  it('rejects {{#let}} (pure scoping, no exclusive inverse)', () => {
+    expect(isBranchingBlockStatement(makeLet(makeBlock([])))).toBe(false);
+  });
+});
+
+describe('isIfOrUnlessBlockBranch', () => {
+  it('recognizes program branch of an if', () => {
+    const program = makeBlock([]);
+    makeIf(program);
+    expect(isIfOrUnlessBlockBranch(program)).toBe(true);
+  });
+  it('recognizes inverse branch of an if', () => {
+    const inverse = makeBlock([]);
+    makeIf(makeBlock([]), inverse);
+    expect(isIfOrUnlessBlockBranch(inverse)).toBe(true);
+  });
+  it('rejects body of an each', () => {
+    const body = makeBlock([]);
+    makeEach(body);
+    expect(isIfOrUnlessBlockBranch(body)).toBe(false);
+  });
+  it('rejects unrooted Block', () => {
+    expect(isIfOrUnlessBlockBranch(makeBlock([]))).toBe(false);
+  });
+});
+
+describe('getBranchPath', () => {
+  it('returns [] for an element outside any if/unless', () => {
+    const el = makeElement('div');
+    expect(getBranchPath(el)).toEqual([]);
+  });
+
+  it('records program branch of an if', () => {
+    // {{#if}}<div/>{{/if}}
+    const el = makeElement('div');
+    const program = makeBlock([el]);
+    const ifBlock = makeIf(program);
+    const path = getBranchPath(el);
+    expect(path).toHaveLength(1);
+    expect(path[0]).toEqual({ block: ifBlock, branch: 'program' });
+  });
+
+  it('records inverse branch of an if', () => {
+    // {{#if}}{{else}}<div/>{{/if}}
+    const el = makeElement('div');
+    const inverse = makeBlock([el]);
+    const ifBlock = makeIf(makeBlock([]), inverse);
+    const path = getBranchPath(el);
+    expect(path).toHaveLength(1);
+    expect(path[0].branch).toBe('inverse');
+    expect(path[0].block).toBe(ifBlock);
+  });
+
+  it('does NOT add entries for #each bodies WITHOUT {{else}} (no exclusion)', () => {
+    const el = makeElement('div');
+    const body = makeBlock([el]);
+    makeEach(body);
+    expect(getBranchPath(el)).toEqual([]);
+  });
+
+  it('records #each bodies WITH {{else}} (inverse creates exclusion)', () => {
+    // {{#each}}<a/>{{else}}<b/>{{/each}}
+    const a = makeElement('a');
+    const b = makeElement('b');
+    const eachBlock = makeEach(makeBlock([a]), makeBlock([b]));
+    expect(getBranchPath(a)).toEqual([{ block: eachBlock, branch: 'program' }]);
+    expect(getBranchPath(b)).toEqual([{ block: eachBlock, branch: 'inverse' }]);
+    expect(areMutuallyExclusive(getBranchPath(a), getBranchPath(b))).toBe(true);
+  });
+
+  it('does NOT add entries for #let bodies (pure scoping)', () => {
+    const el = makeElement('div');
+    const body = makeBlock([el]);
+    makeLet(body);
+    expect(getBranchPath(el)).toEqual([]);
+  });
+
+  it('records nested if/unless ancestors outermost-first', () => {
+    // {{#if outer}}{{#unless inner}}<div/>{{/unless}}{{/if}}
+    const el = makeElement('div');
+    const innerProgram = makeBlock([el]);
+    const innerUnless = makeUnless(innerProgram);
+    const outerProgram = makeBlock([innerUnless]);
+    const outerIf = makeIf(outerProgram);
+    const path = getBranchPath(el);
+    expect(path).toHaveLength(2);
+    expect(path[0].block).toBe(outerIf);
+    expect(path[0].branch).toBe('program');
+    expect(path[1].block).toBe(innerUnless);
+    expect(path[1].branch).toBe('program');
+  });
+});
+
+describe('areMutuallyExclusive', () => {
+  it('returns false for empty paths', () => {
+    expect(areMutuallyExclusive([], [])).toBe(false);
+  });
+  it("returns false when one path is empty and the other isn't", () => {
+    // {{#if}}<a/>{{/if}}<b/> — both render when if is true.
+    const a = makeElement('a');
+    const aProgram = makeBlock([a]);
+    makeIf(aProgram);
+    expect(areMutuallyExclusive(getBranchPath(a), [])).toBe(false);
+  });
+  it('detects program-vs-inverse of the same if as exclusive', () => {
+    // {{#if}}<a/>{{else}}<b/>{{/if}}
+    const a = makeElement('a');
+    const b = makeElement('b');
+    const ifBlock = makeIf(makeBlock([a]), makeBlock([b]));
+    expect(ifBlock).toBeTruthy();
+    expect(areMutuallyExclusive(getBranchPath(a), getBranchPath(b))).toBe(true);
+  });
+  it('returns false when both elements are in the same branch', () => {
+    const a = makeElement('a');
+    const b = makeElement('b');
+    makeIf(makeBlock([a, b]));
+    expect(areMutuallyExclusive(getBranchPath(a), getBranchPath(b))).toBe(false);
+  });
+  it('returns false when two ifs are siblings (different blocks)', () => {
+    // {{#if a}}<x/>{{/if}}{{#if b}}<y/>{{/if}}
+    const x = makeElement('x');
+    const y = makeElement('y');
+    makeIf(makeBlock([x]));
+    makeIf(makeBlock([y]));
+    expect(areMutuallyExclusive(getBranchPath(x), getBranchPath(y))).toBe(false);
+  });
+  it('handles nested conditionals: exclusive when any shared ancestor differs', () => {
+    // {{#if outer}}{{#if inner}}<a/>{{/if}}{{else}}<b/>{{/if}}
+    // a is in outer.program, inner.program. b is in outer.inverse.
+    // They diverge at outer → mutually exclusive.
+    const a = makeElement('a');
+    const b = makeElement('b');
+    const inner = makeIf(makeBlock([a]));
+    makeIf(makeBlock([inner]), makeBlock([b]));
+    expect(areMutuallyExclusive(getBranchPath(a), getBranchPath(b))).toBe(true);
+  });
+  it('is symmetric', () => {
+    const a = makeElement('a');
+    const b = makeElement('b');
+    makeIf(makeBlock([a]), makeBlock([b]));
+    const pa = getBranchPath(a);
+    const pb = getBranchPath(b);
+    expect(areMutuallyExclusive(pa, pb)).toBe(areMutuallyExclusive(pb, pa));
+  });
+});
+
+describe('createConditionalScope', () => {
+  it('tracks keys at the root scope', () => {
+    const scope = createConditionalScope();
+    expect(scope.has('x')).toBe(false);
+    scope.add('x');
+    expect(scope.has('x')).toBe(true);
+  });
+
+  it('hides keys added inside a conditional branch when the branch exits', () => {
+    // {{#if}}<x/>{{else}}<y/>{{/if}} — after the if closes, BOTH branches'
+    // keys are promoted to "always seen" (conservative upper bound), so
+    // siblings after the if see both.
+    const scope = createConditionalScope();
+    scope.enterConditional();
+    scope.enterConditionalBranch();
+    scope.add('x');
+    expect(scope.has('x')).toBe(true);
+    scope.exitConditionalBranch();
+    // Program branch just exited — x is not visible right now.
+    expect(scope.has('x')).toBe(false);
+    scope.enterConditionalBranch();
+    scope.add('y');
+    expect(scope.has('y')).toBe(true);
+    // In the inverse branch, x is NOT visible (branches are exclusive).
+    expect(scope.has('x')).toBe(false);
+    scope.exitConditionalBranch();
+    scope.exitConditional();
+    // After the conditional closes, both x and y are treated as "seen"
+    // at the outer scope (one or the other rendered at runtime).
+    expect(scope.has('x')).toBe(true);
+    expect(scope.has('y')).toBe(true);
+  });
+
+  it('handles nested conditionals', () => {
+    const scope = createConditionalScope();
+    scope.enterConditional();
+    scope.enterConditionalBranch();
+    scope.enterConditional();
+    scope.enterConditionalBranch();
+    scope.add('deep');
+    expect(scope.has('deep')).toBe(true);
+    scope.exitConditionalBranch();
+    scope.exitConditional();
+    scope.exitConditionalBranch();
+    scope.exitConditional();
+    // deep was seen somewhere in the nested conditional — surfaces outside.
+    expect(scope.has('deep')).toBe(true);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> This is part of a series where Claude has audited `eslint-plugin-ember` against [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility), [angular-eslint](https://github.com/angular-eslint/angular-eslint/tree/main/packages/eslint-plugin-template), [lit-a11y](https://github.com/open-wc/open-wc/blob/master/packages/eslint-plugin-lit-a11y) and [html-validate](https://gitlab.com/html-validate/html-validate), `ember-template-lint`, and the HTML and WCAG specs.

See [html-validate `form-dup-name`](https://html-validate.org/rules/form-dup-name.html) for the peer rule concept.

Adds `template-no-duplicate-form-names`: flags two form controls sharing a `name` attribute within the same `<form>` (or template root if no enclosing form). Radio groups and repeated submit-type controls are explicitly allowed to share a name.

## Premise

Per [HTML spec §4.10.22.4 — Constructing the entry list](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set), the serializer iterates submittable form controls and emits one entry per contributing control. Two regular controls with the same `name` both contribute, and server-side frameworks that expect a single value will silently see one — usually not the one the author intended.

The spec distinguishes three categories for name-collision purposes:

- **Non-submitting** — `<input type="button"|"reset">`, `<button type="button"|"reset">`. These do not contribute to the form-data entry list at all; their `name` can't collide with anything.
- **Activation-only** — `<input type="radio">`, submit-like controls (`<input type="submit">`, `<button type="submit">`). Sharing a name with same-type siblings is the legitimate pattern: a radio group, or multiple submits distinguished by `value`.
- **Regular** — everything else. Two regular controls with the same `name` is a real collision.

## Flags

```hbs
<form>
  <input name='email' />
  <input name='email' />              {{! duplicate }}
</form>

<form>
  <input type='text' name='field' />
  <textarea name='field'></textarea>  {{! different tag, same name }}
</form>

<form>
  <input type='radio' name='a' />
  <input type='submit' name='a' />   {{! both in shared set, but different types }}
</form>
```

## Allows

```hbs
{{! Radio group — legitimate shared name }}
<form>
  <input type='radio' name='color' value='red' />
  <input type='radio' name='color' value='blue' />
</form>

{{! Multiple submit buttons with same name — legitimate }}
<form>
  <button type='submit' name='action' value='save'>Save</button>
  <button type='submit' name='action' value='publish'>Publish</button>
</form>

{{! Disabled controls don't submit }}
<form>
  <input name='a' />
  <input name='a' disabled />
</form>

{{! Dynamic name — skipped }}
<form>
  <input name={{this.fieldName}} />
  <input name='email' />
</form>

{{! Mutually exclusive branches never render together }}
<form>
  {{#if @edit}}<input name='x' />{{/if}}
  {{#unless @edit}}<input name='x' />{{/unless}}
</form>
```

## Scope

This is a v1 implementation. Not ported from html-validate: `name[]` array syntax; the `<input type="hidden">` + `<input type="checkbox">` default-value pattern. Both are rarely seen in Ember apps; can be added on demand.

Opt-in: not added to any preset config.

## Prior art

| Plugin | Equivalent |
|---|---|
| html-validate | [`form-dup-name`](https://html-validate.org/rules/form-dup-name.html) — full implementation with `name[]` array handling and a complete form-associated-element registry |
| jsx-a11y | — |
| vuejs-accessibility | — |
| lit-a11y | — |
| @angular-eslint/template | `no-duplicate-attributes` — different concern (same attribute twice on one element, not same `name` across controls) |