### PR TITLE
fix(require-input-label): don't count id as extra label when aria-label/labelledby present

### DIFF
--- a/lib/rules/template-require-input-label.js
+++ b/lib/rules/template-require-input-label.js
@@ -160,12 +160,10 @@ module.exports = {
           labelCount++;
         }
 
-        const hasAriaLabel = hasAttr(node, 'aria-label');
-        const hasAriaLabelledBy = hasAttr(node, 'aria-labelledby');
-        if (hasAriaLabel) {
+        if (hasAttr(node, 'aria-label')) {
           labelCount++;
         }
-        if (hasAriaLabelledBy) {
+        if (hasAttr(node, 'aria-labelledby')) {
           labelCount++;
         }
 
@@ -173,10 +171,10 @@ module.exports = {
           return;
         }
 
-        // id alone is treated as a potential <label for> reference that static
-        // analysis cannot verify (see vuejs-accessibility form-control-has-label
-        // for the same rationale). Skip only when no other label is present to
-        // avoid a false positive when id is combined with aria-label/labelledby.
+        // An `id` may pair with a sibling `<label for>` we can't see in this
+        // template. Treat id-only as valid to avoid false positives, but don't
+        // count it toward labelCount — otherwise id + aria-label is wrongly
+        // flagged as multiple labels.
         if (labelCount === 0 && hasAttr(node, 'id')) {
           return;
         }

--- a/lib/rules/template-require-input-label.js
+++ b/lib/rules/template-require-input-label.js
@@ -160,12 +160,8 @@ module.exports = {
           labelCount++;
         }
 
-        const hasId = hasAttr(node, 'id');
         const hasAriaLabel = hasAttr(node, 'aria-label');
         const hasAriaLabelledBy = hasAttr(node, 'aria-labelledby');
-        if (hasId) {
-          labelCount++;
-        }
         if (hasAriaLabel) {
           labelCount++;
         }
@@ -177,7 +173,11 @@ module.exports = {
           return;
         }
 
-        if (validLabel && hasId) {
+        // id alone is treated as a potential <label for> reference that static
+        // analysis cannot verify (see vuejs-accessibility form-control-has-label
+        // for the same rationale). Skip only when no other label is present to
+        // avoid a false positive when id is combined with aria-label/labelledby.
+        if (labelCount === 0 && hasAttr(node, 'id')) {
           return;
         }
 

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -21,8 +21,10 @@ ruleTester.run('template-require-input-label', rule, {
     '<template><input aria-labelledby="someIdValue" /></template>',
     // https://github.com/ember-template-lint/ember-template-lint/issues/3388
     // id alone does not establish a labeling relationship — a <label for> is
-    // needed and cannot be verified statically. Only aria-label should count.
+    // needed and cannot be verified statically. Only aria-label/labelledby
+    // should count.
     '<template><input id="hello" aria-label="hello" /></template>',
+    '<template><input id="hello" aria-labelledby="someIdValue" /></template>',
     '<template><div></div></template>',
     '<template><Input id="foo" /></template>',
     '<template>{{input id="foo"}}</template>',
@@ -106,6 +108,13 @@ ruleTester.run('template-require-input-label', rule, {
       errors: [{ message: MULTIPLE_LABELS }],
     },
     {
+      // id is irrelevant for labelling here — wrapping <label> + aria-label is
+      // still multiple labels.
+      code: '<template><label>Input label<input id="foo" aria-label="Custom label"></label></template>',
+      output: null,
+      errors: [{ message: MULTIPLE_LABELS }],
+    },
+    {
       code: '<template>{{input type="button"}}</template>',
       output: null,
       errors: [{ message: NO_LABEL }],
@@ -172,6 +181,9 @@ hbsRuleTester.run('template-require-input-label', rule, {
     '<input id="probablyHasLabel" />',
     '<input aria-label={{labelText}} />',
     '<input aria-labelledby="someIdValue" />',
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    '<input id="hello" aria-label="hello" />',
+    '<input id="hello" aria-labelledby="someIdValue" />',
     '<div></div>',
     '<Input id="foo" />',
     '{{input id="foo"}}',
@@ -261,6 +273,11 @@ hbsRuleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<label>Input label<input aria-label="Custom label"></label>',
+      output: null,
+      errors: [{ message: MULTIPLE_LABELS }],
+    },
+    {
+      code: '<label>Input label<input id="foo" aria-label="Custom label"></label>',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -19,6 +19,10 @@ ruleTester.run('template-require-input-label', rule, {
     '<template><input id="probablyHasLabel" /></template>',
     '<template><input aria-label={{labelText}} /></template>',
     '<template><input aria-labelledby="someIdValue" /></template>',
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    // id alone does not establish a labeling relationship — a <label for> is
+    // needed and cannot be verified statically. Only aria-label should count.
+    '<template><input id="hello" aria-label="hello" /></template>',
     '<template><div></div></template>',
     '<template><Input id="foo" /></template>',
     '<template>{{input id="foo"}}</template>',
@@ -65,6 +69,13 @@ ruleTester.run('template-require-input-label', rule, {
     },
   ],
   invalid: [
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    // id alone does not establish a labeling relationship.
+    {
+      code: '<template><input id="hello" /></template>',
+      output: null,
+      errors: [{ message: NO_LABEL }],
+    },
     {
       code: '<template><my-label><input /></my-label></template>',
       output: null,

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -69,13 +69,6 @@ ruleTester.run('template-require-input-label', rule, {
     },
   ],
   invalid: [
-    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
-    // id alone does not establish a labeling relationship.
-    {
-      code: '<template><input id="hello" /></template>',
-      output: null,
-      errors: [{ message: NO_LABEL }],
-    },
     {
       code: '<template><my-label><input /></my-label></template>',
       output: null,
@@ -104,11 +97,6 @@ ruleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<template><input aria-label="first label" aria-labelledby="second label"></template>',
-      output: null,
-      errors: [{ message: MULTIPLE_LABELS }],
-    },
-    {
-      code: '<template><input id="label-input" aria-label="second label"></template>',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },
@@ -268,11 +256,6 @@ hbsRuleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<input aria-label="first label" aria-labelledby="second label">',
-      output: null,
-      errors: [{ message: MULTIPLE_LABELS }],
-    },
-    {
-      code: '<input id="label-input" aria-label="second label">',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },


### PR DESCRIPTION
## Summary

Fixes the false positive reported in https://github.com/ember-template-lint/ember-template-lint/issues/3388.

`<input id='hello' aria-label='hello' />` was wrongly flagged as `multipleLabels` because `id` was counted as a label alongside `aria-label`. An `id` attribute alone cannot be verified statically as a `<label for>` reference — a matching sibling label may or may not exist elsewhere in the template. Counting it as a second label when `aria-label` or `aria-labelledby` is already present is a false positive.

**What changes:**
- `id` is no longer counted toward `labelCount` when other labels (`aria-label`, `aria-labelledby`, or a wrapping `<label>`) are already present
- The existing bail-out for `id`-only inputs is preserved (no `aria-label` and no wrapping label → skip, to avoid flagging inputs that have an off-screen `<label for>` sibling we can't see)

**What does NOT change:**
- `<input id="foo" />` → still valid (false negative acknowledged; within-template `<label for>` traversal is a separate feature — see angular-eslint `label-has-associated-control` with `checkIds: true` for the two-pass approach)
Will try to fix in an upcoming pr. 

## Test plan

- [ ] New valid case: `<input id="hello" aria-label="hello" />` — no longer flagged
- [ ] Existing invalid case `<input aria-label="a" aria-labelledby="b" />` — still flagged (`multipleLabels`)
- [ ] Existing valid case `<input id="foo" />` — still valid
- [ ] All 112 tests pass