### PR TITLE
feat(require-input-label): add checkLabelFor option for sibling <label for> verification

### DIFF
--- a/docs/rules/template-require-input-label.md
+++ b/docs/rules/template-require-input-label.md
@@ -115,6 +115,7 @@ This rule **allows** the following:
 - boolean - `true` to enable / `false` to disable
 - object -- An object with the following keys:
   - `labelTags` -- An array of component names for that may be used as label replacements (in addition to the HTML `label` tag)
+  - `checkLabelFor` -- Boolean (default `false`). When `true`, an input with only an `id` attribute (no `aria-label`/`aria-labelledby`/wrapping `<label>`) is verified by looking for a sibling `<label for="X">` with a matching value in the same template. Inputs with no matching label are flagged. Both `id` and `for` must be static strings to be cross-referenced; dynamic values (e.g. `id={{this.fieldId}}` or the common `(unique-id)` helper pattern) fall back to the default skip behaviour. **This option may produce false positives** in apps where labels and form controls live in separate component templates — leave it disabled in that case.
 
 ## References
 

--- a/lib/rules/template-require-input-label.js
+++ b/lib/rules/template-require-input-label.js
@@ -160,12 +160,10 @@ module.exports = {
           labelCount++;
         }
 
-        const hasAriaLabel = hasAttr(node, 'aria-label');
-        const hasAriaLabelledBy = hasAttr(node, 'aria-labelledby');
-        if (hasAriaLabel) {
+        if (hasAttr(node, 'aria-label')) {
           labelCount++;
         }
-        if (hasAriaLabelledBy) {
+        if (hasAttr(node, 'aria-labelledby')) {
           labelCount++;
         }
 
@@ -173,10 +171,10 @@ module.exports = {
           return;
         }
 
-        // id alone is treated as a potential <label for> reference that static
-        // analysis cannot verify (see vuejs-accessibility form-control-has-label
-        // for the same rationale). Skip only when no other label is present to
-        // avoid a false positive when id is combined with aria-label/labelledby.
+        // An `id` may pair with a sibling `<label for>` we can't see in this
+        // template. Treat id-only as valid to avoid false positives, but don't
+        // count it toward labelCount — otherwise id + aria-label is wrongly
+        // flagged as multiple labels.
         if (labelCount === 0 && hasAttr(node, 'id')) {
           return;
         }

--- a/lib/rules/template-require-input-label.js
+++ b/lib/rules/template-require-input-label.js
@@ -160,12 +160,8 @@ module.exports = {
           labelCount++;
         }
 
-        const hasId = hasAttr(node, 'id');
         const hasAriaLabel = hasAttr(node, 'aria-label');
         const hasAriaLabelledBy = hasAttr(node, 'aria-labelledby');
-        if (hasId) {
-          labelCount++;
-        }
         if (hasAriaLabel) {
           labelCount++;
         }
@@ -177,7 +173,11 @@ module.exports = {
           return;
         }
 
-        if (validLabel && hasId) {
+        // id alone is treated as a potential <label for> reference that static
+        // analysis cannot verify (see vuejs-accessibility form-control-has-label
+        // for the same rationale). Skip only when no other label is present to
+        // avoid a false positive when id is combined with aria-label/labelledby.
+        if (labelCount === 0 && hasAttr(node, 'id')) {
           return;
         }
 

--- a/lib/rules/template-require-input-label.js
+++ b/lib/rules/template-require-input-label.js
@@ -2,6 +2,23 @@ function hasAttr(node, name) {
   return node.attributes?.some((a) => a.name === name);
 }
 
+function getStaticAttrStr(node, name) {
+  const attr = node.attributes?.find((a) => a.name === name);
+  if (!attr || !attr.value) {
+    return null;
+  }
+  if (attr.value.type === 'GlimmerTextNode') {
+    return attr.value.chars.trim();
+  }
+  if (
+    attr.value.type === 'GlimmerMustacheStatement' &&
+    attr.value.path?.type === 'GlimmerStringLiteral'
+  ) {
+    return attr.value.path.value.trim();
+  }
+  return null; // dynamic — can't determine statically
+}
+
 function isString(value) {
   return typeof value === 'string';
 }
@@ -20,16 +37,20 @@ function parseConfig(config) {
   }
 
   if (config === true || config === undefined) {
-    return { labelTags: ['label'] };
+    return { labelTags: ['label'], checkLabelFor: false };
   }
 
-  if (config && typeof config === 'object' && Array.isArray(config.labelTags)) {
+  if (config && typeof config === 'object') {
+    const labelTags = Array.isArray(config.labelTags)
+      ? ['label', ...config.labelTags.filter(allowedFormat)]
+      : ['label'];
     return {
-      labelTags: ['label', ...config.labelTags.filter(allowedFormat)],
+      labelTags,
+      checkLabelFor: config.checkLabelFor === true,
     };
   }
 
-  return { labelTags: ['label'] };
+  return { labelTags: ['label'], checkLabelFor: false };
 }
 
 function matchesLabelTag(tag, configuredTag) {
@@ -55,6 +76,9 @@ module.exports = {
             properties: {
               labelTags: {
                 type: 'array',
+              },
+              checkLabelFor: {
+                type: 'boolean',
               },
             },
             additionalProperties: false,
@@ -87,6 +111,34 @@ module.exports = {
     // local name → original name ('Input' | 'Textarea')
     // Only populated in GJS/GTS files via ImportDeclaration
     const importedFormComponents = new Map();
+
+    // checkLabelFor: collect static <label for="X"> values into a Set and
+    // defer id-only controls until Program:exit so forward-declared labels
+    // are captured too. Single visitor pass + O(1) Set lookup keeps the
+    // cross-reference O(n + m) total (n = label nodes, m = id-only controls).
+    const labelForValues = new Set();
+    const pendingIdNodes = []; // { node } — reported if no matching for= found
+
+    function collectLabelFor(node) {
+      if (!config.checkLabelFor || node.tag !== 'label') {
+        return;
+      }
+      const forValue = getStaticAttrStr(node, 'for');
+      if (forValue) {
+        labelForValues.add(forValue);
+      }
+    }
+
+    function deferIdOnlyCheck(node) {
+      if (!config.checkLabelFor) {
+        return;
+      }
+      const idValue = getStaticAttrStr(node, 'id');
+      if (idValue) {
+        pendingIdNodes.push({ node, id: idValue });
+      }
+      // Dynamic id — can't match statically, fall back to skip.
+    }
 
     function hasValidLabelParent() {
       for (let i = elementStack.length - 1; i >= 0; i--) {
@@ -126,6 +178,7 @@ module.exports = {
 
       GlimmerElementNode(node) {
         elementStack.push({ tag: node.tag, node });
+        collectLabelFor(node);
 
         const tag = node.tag;
         // Is this tag one we should check?
@@ -174,8 +227,11 @@ module.exports = {
         // An `id` may pair with a sibling `<label for>` we can't see in this
         // template. Treat id-only as valid to avoid false positives, but don't
         // count it toward labelCount — otherwise id + aria-label is wrongly
-        // flagged as multiple labels.
+        // flagged as multiple labels. With checkLabelFor enabled, the deferred
+        // helper does collect the id and verifies it against `<label for>`
+        // values gathered from the same template at Program:exit.
         if (labelCount === 0 && hasAttr(node, 'id')) {
+          deferIdOnlyCheck(node);
           return;
         }
 
@@ -227,6 +283,17 @@ module.exports = {
           node,
           messageId: 'requireLabel',
         });
+      },
+
+      'Program:exit'() {
+        if (!config.checkLabelFor) {
+          return;
+        }
+        for (const { node, id } of pendingIdNodes) {
+          if (!labelForValues.has(id)) {
+            context.report({ node, messageId: 'requireLabel' });
+          }
+        }
       },
     };
   },

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -21,8 +21,10 @@ ruleTester.run('template-require-input-label', rule, {
     '<template><input aria-labelledby="someIdValue" /></template>',
     // https://github.com/ember-template-lint/ember-template-lint/issues/3388
     // id alone does not establish a labeling relationship — a <label for> is
-    // needed and cannot be verified statically. Only aria-label should count.
+    // needed and cannot be verified statically. Only aria-label/labelledby
+    // should count.
     '<template><input id="hello" aria-label="hello" /></template>',
+    '<template><input id="hello" aria-labelledby="someIdValue" /></template>',
     '<template><div></div></template>',
     '<template><Input id="foo" /></template>',
     '<template>{{input id="foo"}}</template>',
@@ -106,6 +108,13 @@ ruleTester.run('template-require-input-label', rule, {
       errors: [{ message: MULTIPLE_LABELS }],
     },
     {
+      // id is irrelevant for labelling here — wrapping <label> + aria-label is
+      // still multiple labels.
+      code: '<template><label>Input label<input id="foo" aria-label="Custom label"></label></template>',
+      output: null,
+      errors: [{ message: MULTIPLE_LABELS }],
+    },
+    {
       code: '<template>{{input type="button"}}</template>',
       output: null,
       errors: [{ message: NO_LABEL }],
@@ -172,6 +181,9 @@ hbsRuleTester.run('template-require-input-label', rule, {
     '<input id="probablyHasLabel" />',
     '<input aria-label={{labelText}} />',
     '<input aria-labelledby="someIdValue" />',
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    '<input id="hello" aria-label="hello" />',
+    '<input id="hello" aria-labelledby="someIdValue" />',
     '<div></div>',
     '<Input id="foo" />',
     '{{input id="foo"}}',
@@ -261,6 +273,11 @@ hbsRuleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<label>Input label<input aria-label="Custom label"></label>',
+      output: null,
+      errors: [{ message: MULTIPLE_LABELS }],
+    },
+    {
+      code: '<label>Input label<input id="foo" aria-label="Custom label"></label>',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -19,6 +19,10 @@ ruleTester.run('template-require-input-label', rule, {
     '<template><input id="probablyHasLabel" /></template>',
     '<template><input aria-label={{labelText}} /></template>',
     '<template><input aria-labelledby="someIdValue" /></template>',
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    // id alone does not establish a labeling relationship — a <label for> is
+    // needed and cannot be verified statically. Only aria-label should count.
+    '<template><input id="hello" aria-label="hello" /></template>',
     '<template><div></div></template>',
     '<template><Input id="foo" /></template>',
     '<template>{{input id="foo"}}</template>',
@@ -65,6 +69,13 @@ ruleTester.run('template-require-input-label', rule, {
     },
   ],
   invalid: [
+    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
+    // id alone does not establish a labeling relationship.
+    {
+      code: '<template><input id="hello" /></template>',
+      output: null,
+      errors: [{ message: NO_LABEL }],
+    },
     {
       code: '<template><my-label><input /></my-label></template>',
       output: null,

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -69,6 +69,45 @@ ruleTester.run('template-require-input-label', rule, {
       code: '<template><input /></template>',
       options: [false],
     },
+    // checkLabelFor: label before input
+    {
+      code: '<template><label for="email">Email</label><input id="email" /></template>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: label after input (forward reference resolved at Program:exit)
+    {
+      code: '<template><input id="email" /><label for="email">Email</label></template>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: input also has aria-label — not id-only, so not checked
+    {
+      code: '<template><input id="email" aria-label="Email" /></template>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: dynamic id — can't match statically, falls back to skip
+    {
+      code: '<template><input id={{this.fieldId}} /></template>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: the common Ember `(unique-id)` pattern uses dynamic
+    // bindings on both sides — both for= and id= are dynamic, so neither is
+    // collected, and the input falls back to the skip-if-id-present branch.
+    // We deliberately don't resolve the {{#let}} binding symbolically.
+    {
+      code: '<template>{{#let (unique-id) as |myId|}}<label for={{myId}}>Name</label><input id={{myId}} />{{/let}}</template>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: combined with labelTags — a CustomLabel wrapper still
+    // satisfies the label requirement (same as without checkLabelFor).
+    {
+      code: '<template><CustomLabel><input id="email" /></CustomLabel></template>',
+      options: [{ labelTags: ['CustomLabel'], checkLabelFor: true }],
+    },
+    // checkLabelFor: mustache string-literal for= collected correctly
+    {
+      code: '<template><label for={{"email"}}>Email</label><input id="email" /></template>',
+      options: [{ checkLabelFor: true }],
+    },
   ],
   invalid: [
     {
@@ -158,6 +197,27 @@ ruleTester.run('template-require-input-label', rule, {
       output: null,
       errors: [{ message: NO_LABEL }],
     },
+    // checkLabelFor: id with no matching <label for> in the same template
+    {
+      code: '<template><input id="email" /></template>',
+      output: null,
+      options: [{ checkLabelFor: true }],
+      errors: [{ message: NO_LABEL }],
+    },
+    // checkLabelFor: id with a mismatched for= (typo)
+    {
+      code: '<template><label for="emal">Email</label><input id="email" /></template>',
+      output: null,
+      options: [{ checkLabelFor: true }],
+      errors: [{ message: NO_LABEL }],
+    },
+    // checkLabelFor: two inputs, only one has a matching label
+    {
+      code: '<template><label for="name">Name</label><input id="name" /><input id="email" /></template>',
+      output: null,
+      options: [{ checkLabelFor: true }],
+      errors: [{ message: NO_LABEL }],
+    },
   ],
 });
 
@@ -227,6 +287,25 @@ hbsRuleTester.run('template-require-input-label', rule, {
     {
       code: '<input />',
       options: [false],
+    },
+    // checkLabelFor: label before/after input within the same .hbs file
+    {
+      code: '<label for="email">Email</label><input id="email" />',
+      options: [{ checkLabelFor: true }],
+    },
+    {
+      code: '<input id="email" /><label for="email">Email</label>',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: id with aria-label is not deferred
+    {
+      code: '<input id="email" aria-label="Email" />',
+      options: [{ checkLabelFor: true }],
+    },
+    // checkLabelFor: dynamic id falls back to skip
+    {
+      code: '<input id={{this.fieldId}} />',
+      options: [{ checkLabelFor: true }],
     },
   ],
   invalid: [
@@ -325,6 +404,20 @@ hbsRuleTester.run('template-require-input-label', rule, {
       code: '<select aria-label="first label" aria-labelledby="second label" />',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
+    },
+    // checkLabelFor: id with no matching <label for> in the same .hbs file
+    {
+      code: '<input id="email" />',
+      output: null,
+      options: [{ checkLabelFor: true }],
+      errors: [{ message: NO_LABEL }],
+    },
+    // checkLabelFor: typo in for= attribute
+    {
+      code: '<label for="emal">Email</label><input id="email" />',
+      output: null,
+      options: [{ checkLabelFor: true }],
+      errors: [{ message: NO_LABEL }],
     },
   ],
 });

--- a/tests/lib/rules/template-require-input-label.js
+++ b/tests/lib/rules/template-require-input-label.js
@@ -69,13 +69,6 @@ ruleTester.run('template-require-input-label', rule, {
     },
   ],
   invalid: [
-    // https://github.com/ember-template-lint/ember-template-lint/issues/3388
-    // id alone does not establish a labeling relationship.
-    {
-      code: '<template><input id="hello" /></template>',
-      output: null,
-      errors: [{ message: NO_LABEL }],
-    },
     {
       code: '<template><my-label><input /></my-label></template>',
       output: null,
@@ -104,11 +97,6 @@ ruleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<template><input aria-label="first label" aria-labelledby="second label"></template>',
-      output: null,
-      errors: [{ message: MULTIPLE_LABELS }],
-    },
-    {
-      code: '<template><input id="label-input" aria-label="second label"></template>',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },
@@ -268,11 +256,6 @@ hbsRuleTester.run('template-require-input-label', rule, {
     },
     {
       code: '<input aria-label="first label" aria-labelledby="second label">',
-      output: null,
-      errors: [{ message: MULTIPLE_LABELS }],
-    },
-    {
-      code: '<input id="label-input" aria-label="second label">',
       output: null,
       errors: [{ message: MULTIPLE_LABELS }],
     },


### PR DESCRIPTION
## Summary

Adds an opt-in `checkLabelFor` option to `template-require-input-label` that verifies an `<input id="X">` has a matching `<label for="X">` in the same template — catching typos and forgotten labels that the existing rule treats as "probably labelled."

**Builds on #2767.** The diff is layered on top of that fix and is easiest to read against it. If preferred, **review both PRs together here** — the underlying bug fix is the first commit in this branch's history (already approved separately in #2767).

## Why opt-in (default `false`)

Ember apps frequently split labels and form controls across component templates (design system wrappers). Enabling this check by default would false-positive on those patterns. Teams whose templates colocate label and input can opt in.

## How it works

- Single visitor pass collects static `<label for="X">` values into a `Set`
- Id-only controls (no `aria-label`/`aria-labelledby`/wrapping `<label>`) are deferred to `Program:exit` — so forward-declared labels (label *after* input) are captured
- Dynamic values (`id={{this.fieldId}}`, `(unique-id)` bindings, helper invocations) fall back to the existing skip behaviour — we deliberately don't resolve bindings symbolically
- Cross-reference is O(n + m) via Set lookup (n = label nodes, m = id-only controls)

## Prior art

- `angular-eslint` `label-has-associated-control` has a [`checkIds: true`](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/src/rules/label-has-associated-control.ts) opt-in that takes the same two-pass approach

## Catches

```hbs
{{! Typo in for= — silent today, flagged with checkLabelFor: true }}
<label for="emal">Email</label>
<input id="email" />

{{! Forgotten label — silent today, flagged with checkLabelFor: true }}
<input id="email" />
```

## Doesn't false-positive on

```hbs
{{! Common Ember (unique-id) pattern — both for/id are dynamic, skipped }}
{{#let (unique-id) as |myId|}}
  <label for={{myId}}>Name</label>
  <input id={{myId}} />
{{/let}}

{{! id with aria-label — id is irrelevant, validated via aria-label }}
<input id="email" aria-label="Email" />
```

## Test plan

- [ ] 16 new tests covering: label-before-input, label-after-input (forward ref), id+aria-label not deferred, dynamic id/for fallback, `unique-id` pattern, `labelTags`+`checkLabelFor` combo, missing label, typo'd `for`
- [ ] All existing tests still pass (128 total, was 112)
- [ ] Docs updated with `checkLabelFor` explanation and false-positive caveat