### PR TITLE
fix(rules): adopt glimmer-attr-presence for runtime-correct attribute classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ If you have any suggestions, ideas, or problems, feel free to [create an issue](
 
 ### Creating a New Rule
 
+If your rule inspects template attribute values (e.g. mustache forms like `attr={{X}}` or `attr="{{X}}"`), read [docs/glimmer-attribute-behavior.md](docs/glimmer-attribute-behavior.md) first — Glimmer's actual rendering behavior is non-obvious for several common forms, and the doc has the empirically-verified table.
+
 - [Create an issue](https://github.com/ember-cli/eslint-plugin-ember/issues/new) with a description of the proposed rule
 - Create files for the [new rule](https://eslint.org/docs/developer-guide/working-with-rules):
   - `lib/rules/new-rule.js` (implementation, see [no-proxies](lib/rules/no-proxies.js) for an example)

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -146,20 +146,25 @@ Rule authors who classify attribute values must consume the reference table abov
 
 ### Recommended pattern
 
-A shared utility — `lib/utils/glimmer-attr-presence.js` (forthcoming) — encodes this table once. Rule authors should consume it rather than re-implementing the AST walk:
+The shared utility [`lib/utils/glimmer-attr-presence.js`](../lib/utils/glimmer-attr-presence.js) encodes the verdict table once. Rule authors should consume it rather than re-implementing the AST walk:
 
 ```js
-// Sketch of the API surface — actual implementation tracked separately.
 const { classifyAttribute } = require('../utils/glimmer-attr-presence');
 
-const result = classifyAttribute(attr, {
-  kind: 'boolean-coerced' /* or 'plain-string' / 'numeric' */,
-});
-// result.kind: 'absent' | 'omitted-bare-falsy' | 'static' | 'present-unknown'
-// result.value: string | null  (only present when kind === 'static')
+const attr = node.attributes?.find((a) => a.name === 'aria-hidden');
+const { presence, value } = classifyAttribute(attr);
+// presence: 'absent' | 'present' | 'unknown'
+// value:    string | null
+//
+// kind is inferred from attr.name (boolean / aria / numeric / plain-string).
+// Override with options.kind when needed: classifyAttribute(attr, { kind: 'aria' }).
+
+if (presence === 'present' && value === 'true') {
+  // hidden — covers h3, h7, h12, h14 in one branch.
+}
 ```
 
-Until the utility lands, follow the AST-shape table above directly and cite the specific row IDs in code comments where the classification logic lives.
+The utility maps every row in the reference table above to a single `(presence, value)` pair, including the surprising cases (`{{"false"}}` is JS-truthy, `aria-hidden={{true}}` renders empty per h5, concat is never falsy, etc.). Cite the doc row IDs from code comments where you call it so reviewers can confirm the lint truth without re-reading the AST.
 
 ## To reproduce the reference table
 

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -253,7 +253,7 @@ After rendering, paste this into the devtools console:
     lines.push(`\n==== ${label} ====`);
     for (let i = 1; i <= count; i++) {
       const id = prefix + i;
-      const el = document.getElementById(id);
+      const el = document.querySelector(`#${id}`);
       if (!el) {
         lines.push(`${id}: (NOT FOUND)`);
         continue;

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -1,0 +1,242 @@
+# Glimmer attribute rendering behavior
+
+Reference for rule authors. Most template lint rules need to answer: "given an attribute written as `attr={{X}}` or `attr="{{X}}"` or `attr="value"`, what does it actually do at runtime?" The answer is **non-obvious and attribute-specific**, and several common mental models are wrong. This doc captures empirically-verified Glimmer rendering behavior so rule classification logic matches reality instead of intuition.
+
+> **Read this before writing or modifying any rule that inspects attribute values via `GlimmerBooleanLiteral`, `GlimmerStringLiteral`, `GlimmerConcatStatement`, or `GlimmerTextNode`.**
+
+## TL;DR — the lint-truth table
+
+For static analysis, "is the attribute present at runtime?" reduces to:
+
+| Source form                                                     | Present at runtime?  |
+| --------------------------------------------------------------- | -------------------- |
+| `attr` (valueless)                                              | **YES**              |
+| `attr=""`                                                       | **YES**              |
+| `attr="any-static-text"`                                        | **YES**              |
+| `attr={{false}}`                                                | **NO**               |
+| `attr={{null}}`                                                 | **NO**               |
+| `attr={{undefined}}`                                            | **NO**               |
+| `attr={{true}}`                                                 | **YES**              |
+| `attr={{"any-string"}}` (incl. `"false"` and `"true"`)          | **YES**              |
+| `attr={{number}}`                                               | **YES**              |
+| `attr={{this.dynamic}}`                                         | UNKNOWN at lint time |
+| `attr="{{anything}}"` (concat single mustache, any inner value) | **YES**              |
+| `attr="text{{anything}}"` (concat with text + mustache)         | **YES**              |
+
+Note especially the surprising rows:
+
+- `attr={{"false"}}` — bare-mustache string `"false"` is JS-truthy → attribute present, value `"false"`.
+- `attr="{{false}}"` — concat-form _always_ sets the IDL property to truthy, regardless of the literal value inside, even when HTML serialization shows nothing. (Verified against `<video muted="{{false}}">` → `videoEl.muted === true`.)
+
+Common bug: rules treating `attr="{{false}}"` or `attr={{"false"}}` as "falsy" because the literal `false`/`"false"` is in the source. Both render to a present attribute at runtime.
+
+## HTML serialization is not the source of truth
+
+Two layers:
+
+1. **HTML serialization** (`element.outerHTML`) — what the browser's serialized HTML shows.
+2. **IDL property** (e.g. `videoEl.muted`) — the live runtime state.
+
+They can disagree, especially for **non-reflecting boolean HTML attributes** like `muted`, `autoplay`, `controls`, `loop` on media elements. The IDL property gets set by Glimmer, but the HTML serialization doesn't reflect it back.
+
+For accessibility and UX rules, the **IDL property / runtime state is what matters**, not the HTML string. A `<video muted={{true}}>` plays muted even though `outerHTML` doesn't show `muted`.
+
+## Verified rendering tables
+
+All rows below were verified by rendering in an Ember dev app and inspecting both `outerHTML` and (for boolean attrs) the IDL property in devtools. See [§ Reproduction template](#reproduction-template) at the end to re-verify if you suspect drift.
+
+### Table 1: bare-mustache `attr={{X}}`
+
+| `X`                             | HTML serialization                                                                                                               | IDL property (boolean attrs)                                   | Lint-truth                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------- |
+| `false`                         | omitted                                                                                                                          | false                                                          | **FALSY**                             |
+| `null`                          | omitted                                                                                                                          | false (assumed)                                                | **FALSY**                             |
+| `undefined`                     | omitted                                                                                                                          | false (assumed)                                                | **FALSY**                             |
+| `true`                          | reflecting attrs (`disabled` on `<input>`, `aria-hidden` on `<div>`): `attr=""`. Non-reflecting (`muted` on `<video>`): omitted. | **true**                                                       | **TRUTHY**                            |
+| `"any-string"`                  | `attr="any-string"`                                                                                                              | true (string truthy)                                           | **TRUTHY**                            |
+| `""` (empty string)             | `attr=""`                                                                                                                        | unverified — could be falsy IDL given JS empty-string-is-falsy | **TRUTHY** by HTML attribute presence |
+| number (e.g. `0`, `-1`)         | `attr="<number>"` (e.g. `attr="0"`)                                                                                              | unverified                                                     | **TRUTHY** by HTML attribute presence |
+| dynamic path (e.g. `this.flag`) | depends on runtime value                                                                                                         | depends                                                        | **UNKNOWN** at lint time              |
+
+### Table 2: concat-mustache `attr="…{{X}}…"`
+
+| Form                  | HTML serialization (boolean attrs)              | HTML serialization (string/ARIA attrs) | IDL property (boolean attrs)    | Lint-truth                                                                               |
+| --------------------- | ----------------------------------------------- | -------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `"{{true}}"`          | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="true"`                          | **true**                        | **TRUTHY**                                                                               |
+| `"{{false}}"`         | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="false"`                         | **true**                        | **TRUTHY**                                                                               |
+| `"{{'true'}}"`        | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="true"`                          | true (assumed)                  | **TRUTHY**                                                                               |
+| `"{{'false'}}"`       | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="false"`                         | true (assumed)                  | **TRUTHY**                                                                               |
+| `"text{{X}}"` (any X) | non-reflecting: omitted (verified for `muted`)  | `attr="text<stringified-X>"`           | true (assumed)                  | **TRUTHY**                                                                               |
+| `"{{this.dynamic}}"`  | depends                                         | depends                                | true (per the pattern; assumed) | **TRUTHY** at runtime, but rule may want to treat as UNKNOWN if it cares about the value |
+
+**Concat is always truthy at runtime, regardless of the literal value inside.** This is the most surprising finding and the source of most classification bugs. Glimmer's concat handling appears to set the IDL property based on attribute _presence in the source_, not on the literal value evaluating to true.
+
+### Table 3: static text attributes
+
+| Form                  | HTML                  | Lint-truth                 |
+| --------------------- | --------------------- | -------------------------- |
+| `attr` (valueless)    | `attr=""`             | **TRUTHY**                 |
+| `attr=""`             | `attr=""`             | **TRUTHY**                 |
+| `attr="literal text"` | `attr="literal text"` | **TRUTHY** with that value |
+
+For HTML boolean attributes (`muted`, `disabled`, `hidden`, etc.), HTML semantics treat any presence — including `attr="false"` — as the boolean being ON. This is HTML's rule, not Glimmer's.
+
+## Per-attribute notes
+
+**Reflecting boolean HTML attributes** (`disabled`, `hidden`, `readonly`, `required`, `multiple`, `selected`, `checked`, etc.):
+
+- IDL property reflects to HTML attribute. Setting `el.disabled = true` adds `disabled=""`.
+- Concat form like `disabled="{{false}}"` keeps the attribute as `disabled=""` in HTML serialization (because IDL is set true, and reflection writes it back).
+
+**Non-reflecting boolean HTML attributes** on media elements (`muted`, `autoplay`, `controls`, `loop`):
+
+- IDL property exists but does _not_ reflect to HTML serialization. Setting `videoEl.muted = true` does _not_ add `muted=""` to outerHTML.
+- HTML inspector misleads you here. **Always check the IDL property to know runtime state.**
+
+**ARIA / string attributes** (`aria-hidden`, `aria-label`, `role`, etc.):
+
+- No IDL property — HTML attribute is the ground truth.
+- Value matters, not just presence: `aria-hidden="false"` means _visible_; `aria-hidden="true"` means _hidden_. Rules need to check the value, not just presence.
+- Bare `attr={{true}}` renders as `attr=""` (empty string value) — _contested_ in ARIA semantics. Different tools treat valueless/empty `aria-hidden` differently. See `template-no-invalid-interactive` doc.
+
+**Numeric attributes** (`tabindex`, `colspan`, etc.):
+
+- Always render the literal value in HTML.
+- Both bare and concat forms preserve the numeric value as a string (e.g. `tabindex={{0}}` → `tabindex="0"`).
+- Rules checking value (e.g. positive vs. zero/negative tabindex) should extract the literal value from the AST, not just check presence.
+
+## Reproduction template
+
+If you suspect Glimmer behavior has changed, paste the following into a template in any Ember dev app and inspect the rendered output. Each input is preceded by an HTML comment showing the source form; the rendered HTML appears immediately after.
+
+```hbs
+{{! A. <video> + muted (boolean HTML, non-reflecting) }}
+<!-- <video muted></video>: -->
+<video muted></video>
+<!-- <video muted=""></video>: -->
+<video muted=''></video>
+<!-- <video muted="true"></video>: -->
+<video muted='true'></video>
+<!-- <video muted="false"></video>: -->
+<video muted='false'></video>
+<!-- <video muted={{true}}></video>: -->
+<video muted={{true}}></video>
+<!-- <video muted={{false}}></video>: -->
+<video muted={{false}}></video>
+<!-- <video muted={{"true"}}></video>: -->
+<video muted={{'true'}}></video>
+<!-- <video muted={{"false"}}></video>: -->
+<video muted={{'false'}}></video>
+<!-- <video muted={{null}}></video>: -->
+<video muted={{null}}></video>
+<!-- <video muted={{undefined}}></video>: -->
+<video muted={{undefined}}></video>
+<!-- <video muted={{""}}></video>: -->
+<video muted={{''}}></video>
+<!-- <video muted="{{true}}"></video>: -->
+<video muted='{{true}}'></video>
+<!-- <video muted="{{false}}"></video>: -->
+<video muted='{{false}}'></video>
+<!-- <video muted="{{'true'}}"></video>: -->
+<video muted='{{"true"}}'></video>
+<!-- <video muted="{{'false'}}"></video>: -->
+<video muted='{{"false"}}'></video>
+<!-- <video muted="x{{true}}"></video>: -->
+<video muted='x{{true}}'></video>
+<!-- <video muted="x{{false}}"></video>: -->
+<video muted='x{{false}}'></video>
+
+{{! B. <div> + aria-hidden (ARIA string, no IDL property) }}
+<!-- <div aria-hidden></div>: -->
+<div aria-hidden></div>
+<!-- <div aria-hidden=""></div>: -->
+<div aria-hidden=''></div>
+<!-- <div aria-hidden="true"></div>: -->
+<div aria-hidden='true'></div>
+<!-- <div aria-hidden="false"></div>: -->
+<div aria-hidden='false'></div>
+<!-- <div aria-hidden={{true}}></div>: -->
+<div aria-hidden={{true}}></div>
+<!-- <div aria-hidden={{false}}></div>: -->
+<div aria-hidden={{false}}></div>
+<!-- <div aria-hidden={{"true"}}></div>: -->
+<div aria-hidden={{'true'}}></div>
+<!-- <div aria-hidden={{"false"}}></div>: -->
+<div aria-hidden={{'false'}}></div>
+<!-- <div aria-hidden={{null}}></div>: -->
+<div aria-hidden={{null}}></div>
+<!-- <div aria-hidden={{undefined}}></div>: -->
+<div aria-hidden={{undefined}}></div>
+<!-- <div aria-hidden={{""}}></div>: -->
+<div aria-hidden={{''}}></div>
+<!-- <div aria-hidden="{{true}}"></div>: -->
+<div aria-hidden='{{true}}'></div>
+<!-- <div aria-hidden="{{false}}"></div>: -->
+<div aria-hidden='{{false}}'></div>
+<!-- <div aria-hidden="{{'true'}}"></div>: -->
+<div aria-hidden='{{"true"}}'></div>
+<!-- <div aria-hidden="{{'false'}}"></div>: -->
+<div aria-hidden='{{"false"}}'></div>
+
+{{! C. <input> + disabled (boolean HTML, reflecting) }}
+<!-- <input disabled />: -->
+<input disabled />
+<!-- <input disabled={{true}} />: -->
+<input disabled={{true}} />
+<!-- <input disabled={{false}} />: -->
+<input disabled={{false}} />
+<!-- <input disabled={{"false"}} />: -->
+<input disabled={{'false'}} />
+<!-- <input disabled="{{false}}" />: -->
+<input disabled='{{false}}' />
+
+{{! D. <div> + tabindex (numeric) }}
+<!-- <div tabindex={{0}}></div>: -->
+<div tabindex={{0}}></div>
+<!-- <div tabindex={{-1}}></div>: -->
+<div tabindex={{-1}}></div>
+<!-- <div tabindex="{{0}}"></div>: -->
+<div tabindex='{{0}}'></div>
+<!-- <div tabindex={{"0"}}></div>: -->
+<div tabindex={{'0'}}></div>
+
+{{! E. IDL property check for non-reflecting boolean attrs }}
+<video id='t1' muted={{true}}></video>
+<video id='t2' muted='{{true}}'></video>
+<video id='t3' muted='{{false}}'></video>
+<video id='t4'></video>
+{{! Then in devtools console:
+       document.getElementById('t1').muted  // expected: true
+       document.getElementById('t2').muted  // expected: true
+       document.getElementById('t3').muted  // expected: true (the surprising one)
+       document.getElementById('t4').muted  // expected: false (no attr → default)
+}}
+```
+
+## Open questions / unverified
+
+- **Bare `{{0}}`, `{{""}}`, `{{NaN}}` IDL property** — JS-falsy literal values in bare mustache. The HTML serialization keeps the attribute (e.g. `attr="0"`), but whether the IDL property is set to true (matching presence) or false (matching JS-falsy) is unverified. Rules should treat as TRUTHY for now (HTML presence), and revisit if a counter-example surfaces.
+- **Concat with dynamic path** (e.g. `attr="{{this.flag}}"`) — assumed truthy by analogy to literal-concat behavior, but not directly verified. Rules that care about the value (not just presence) should treat concat-with-dynamic as UNKNOWN.
+- **`{{false}}` followed by static text in concat** (e.g. `attr="{{false}}-suffix"`) — verified for boolean attrs only (`muted`); behavior on string/ARIA attrs not directly tested but assumed to follow the "concat always renders for string attrs" pattern.
+
+## How to extend this doc
+
+When you discover a new edge case:
+
+1. Render the source form in an Ember dev app and capture both `outerHTML` and (where relevant) the IDL property.
+2. Add a row to the appropriate table above with verified-only data. Mark assumptions explicitly with "(assumed)" or "(unverified)".
+3. Cite the date and Ember/Glimmer version of the verification in the commit message.
+4. If the new finding contradicts an existing rule's classification, open an issue or PR fixing the rule and link this doc.
+
+## Verification metadata
+
+- **Date verified:** 2026-04-28
+- **Ember/Glimmer version:** _TODO — fill in `ember-source` version from the dev app where t1–t4 were tested._
+- **Verified by:** [@johanrd](https://github.com/johanrd) (rendering app, devtools inspection)
+- **Methodology:** rendered template fragments, inspected `outerHTML` for HTML serialization and JS property access for IDL state
+
+## Related
+
+- The Glimmer VM source for attribute rendering: <https://github.com/glimmerjs/glimmer-vm>
+- HTML spec on boolean attributes and reflection: <https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes>
+- ARIA `aria-hidden` semantics: <https://www.w3.org/TR/wai-aria-1.2/#aria-hidden>

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -119,6 +119,48 @@ A regular string attribute. Glimmer's bare-mustache **does not** apply falsy-coe
 - **Concat-mustache forks by attribute kind.** For HTML boolean attrs (`muted`, `disabled`), any concat — including `"{{false}}"`, `"{{'false'}}"`, `"x{{false}}"` — sets the IDL property to `true`, regardless of the literal value inside. For ARIA / string attrs (`aria-hidden`, `autocomplete`), concat renders the stringified value as the attribute value (no boolean coercion); `aria-hidden="{{false}}"` becomes `aria-hidden="false"` (visible).
 - **Concat is never falsy.** Across all attribute kinds tested, no concat form produces an absent attribute. Rules treating `attr="{{false}}"` as "off" are wrong for boolean attrs (it's IDL-true) and wrong for string attrs (the rendered value is `"false"`, attribute present).
 
+## Reading attribute values in rules
+
+Rule authors who classify attribute values must consume the reference table above through one of these AST shapes — each maps to a known rendering verdict:
+
+| AST shape                                                                                                                                                                      | Source examples                                               | Verdict                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attr.value === null` (no value)                                                                                                                                               | `<input disabled />`                                          | Attribute is **present** with empty value (rendered as `attr=""`) — see d1, h1                                                                                                                                                                                       |
+| `attr.value.type === 'GlimmerTextNode'`                                                                                                                                        | `attr="literal text"`                                         | Attribute is **present** with the literal `chars` string — see m1–m4, h2–h4, d1, t-static, i1                                                                                                                                                                        |
+| `attr.value.type === 'GlimmerMustacheStatement'` with `path.type === 'GlimmerBooleanLiteral'` and `path.value === true`                                                        | `attr={{true}}`                                               | **Reflecting boolean attrs**: present (e.g., `disabled=""`). **Non-reflecting boolean attrs** (`muted`, `autoplay`, etc.): IDL property set true, HTML attribute omitted. **ARIA string attrs**: present as `attr=""`. **Numeric attrs**: untested. — see m5, d2, h5 |
+| `attr.value.type === 'GlimmerMustacheStatement'` with `path.type === 'GlimmerBooleanLiteral'` and `path.value === false` (or `GlimmerNullLiteral` / `GlimmerUndefinedLiteral`) | `attr={{false}}` / `{{null}}` / `{{undefined}}`               | Attribute is **omitted** at runtime — see m6, m9, m10, d3, d6, h6, h9, h10, t6, t7. **Exception:** plain string attrs (e.g., `autocomplete`) do _not_ falsy-coerce; bare `{{false}}` renders as `attr="false"` (i4).                                                 |
+| `attr.value.type === 'GlimmerMustacheStatement'` with `path.type === 'GlimmerStringLiteral'`                                                                                   | `attr={{"value"}}`                                            | Attribute is **present** with the literal `path.value` string — see m7, m8, h7, h8, d4, d5, i2                                                                                                                                                                       |
+| `attr.value.type === 'GlimmerMustacheStatement'` with `path.type === 'GlimmerNumberLiteral'` (verified for `tabindex` only)                                                    | `attr={{0}}`                                                  | **Numeric attrs**: present with stringified number (t1, t2, t3). **`muted={{0}}` is in the falsy-omit set** (m12); not yet tested for other kinds.                                                                                                                   |
+| `attr.value.type === 'GlimmerMustacheStatement'` with dynamic path                                                                                                             | `attr={{this.x}}`                                             | **Unknown** at lint time.                                                                                                                                                                                                                                            |
+| `attr.value.type === 'GlimmerConcatStatement'` with all-literal parts                                                                                                          | `attr="{{X}}"` (single literal-mustache) / `attr="text{{X}}"` | **Boolean HTML attrs** (`muted`, `disabled`, etc.): IDL true regardless of inner literal — m13–m19, d7–d10. **ARIA / string attrs** (`aria-hidden`, `autocomplete`): renders the stringified value literally — h12–h15, i3, i5.                                      |
+| `attr.value.type === 'GlimmerConcatStatement'` with any dynamic part                                                                                                           | `attr="{{this.x}}"` / `attr="x{{this.y}}"`                    | **Concat is never falsy** — present at runtime, but the value is generally **unknown** at lint time.                                                                                                                                                                 |
+
+### Common mistakes to avoid
+
+1. **Don't use `findAttr(node, 'foo')` (AST-presence) as a proxy for "attribute set at runtime."** It's wrong for bare `{{false}}` / `{{null}}` / `{{undefined}}` on boolean-coerced attrs (m6/m9/m10/d3/d6/h6/h9/h10/t6/t7) — those forms still create an `AttrNode` in the AST but are omitted at runtime.
+2. **Don't lump `BooleanLiteral(false)` with `StringLiteral("false")`.** Bare `{{"false"}}` is a JS-truthy string; it renders the literal `"false"` value (i4, h8, d4, m8). Treating them together as "off" is the most common audit footgun in this codebase.
+3. **Don't treat single-mustache concat as the inner literal.** `attr="{{X}}"` is **never** falsy. For boolean HTML attrs the IDL property is set true regardless of `X`'s literal value (m14 verified: `<video muted="{{false}}">` → `videoEl.muted === true`). For ARIA/string attrs the rendered HTML is the stringified value (h13: `aria-hidden="{{false}}"` → `aria-hidden="false"`, visible per ARIA spec).
+4. **Don't apply boolean-coercion to plain string attrs.** `autocomplete`, `name`, `id`, `for`, `href`, `role`, `type`, `method`, `lang`, `title`, `alt` etc. do **not** falsy-coerce. Bare `{{false}}` on these renders the literal `"false"`. Plain-string attrs are documented under `i1`–`i5`; the falsy-coercion list (cross-attribute observations) covers HTML boolean attrs, ARIA attrs, and numeric attrs only.
+5. **`role` is plain string, not ARIA-coerced.** Despite living in the ARIA family conceptually, `role` is a plain string DOM attribute — bare `role={{false}}` renders `role="false"` (analogous to i4), not omitted.
+6. **`{{true}}` for `aria-hidden` (h5) renders `aria-hidden=""` — contested per ARIA spec, _not_ `aria-hidden="true"`.** Rules deciding "is this hidden?" should be explicit about which interpretation they take. Don't conflate h5 with h7 (`{{"true"}}` → renders the string `"true"`, hidden).
+
+### Recommended pattern
+
+A shared utility — `lib/utils/glimmer-attr-presence.js` (forthcoming) — encodes this table once. Rule authors should consume it rather than re-implementing the AST walk:
+
+```js
+// Sketch of the API surface — actual implementation tracked separately.
+const { classifyAttribute } = require('../utils/glimmer-attr-presence');
+
+const result = classifyAttribute(attr, {
+  kind: 'boolean-coerced' /* or 'plain-string' / 'numeric' */,
+});
+// result.kind: 'absent' | 'omitted-bare-falsy' | 'static' | 'present-unknown'
+// result.value: string | null  (only present when kind === 'static')
+```
+
+Until the utility lands, follow the AST-shape table above directly and cite the specific row IDs in code comments where the classification logic lives.
+
 ## To reproduce the reference table
 
 Every cell above was populated by rendering the template below in an Ember dev app and running the bundled JS console snippet to print each test case's `outerHTML` and IDL state. To re-verify (or extend with new attributes):

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -1,241 +1,283 @@
 # Glimmer attribute rendering behavior
 
-Reference for rule authors. Most template lint rules need to answer: "given an attribute written as `attr={{X}}` or `attr="{{X}}"` or `attr="value"`, what does it actually do at runtime?" The answer is **non-obvious and attribute-specific**, and several common mental models are wrong. This doc captures empirically-verified Glimmer rendering behavior so rule classification logic matches reality instead of intuition.
+Reference for rule authors. Most template lint rules need to answer: "given an attribute written as `attr={{X}}` or `attr="{{X}}"` or `attr="value"`, what does it actually do at runtime?" The answer is non-obvious — Glimmer's bare-mustache and concat-mustache forms coerce values differently per attribute kind, HTML serialization can disagree with the live IDL property, and several intuitive mental models are wrong.
 
-> **Read this before writing or modifying any rule that inspects attribute values via `GlimmerBooleanLiteral`, `GlimmerStringLiteral`, `GlimmerConcatStatement`, or `GlimmerTextNode`.**
+This doc captures empirically-verified rendering behavior. Every cell in every table below comes from rendering the template under [§ To reproduce the reference table](#to-reproduce-the-reference-table) in an Ember dev app and inspecting `outerHTML` plus the relevant IDL property in devtools. **No extrapolation.** If a form isn't in a table, it hasn't been verified — extend the reproduction template and add the row.
 
-## TL;DR — the lint-truth table
+> Read this before writing or modifying any rule that inspects attribute values via `GlimmerBooleanLiteral`, `GlimmerStringLiteral`, `GlimmerConcatStatement`, or `GlimmerTextNode`.
 
-For static analysis, "is the attribute present at runtime?" reduces to:
+## Reference table
 
-| Source form                                                     | Present at runtime?  |
-| --------------------------------------------------------------- | -------------------- |
-| `attr` (valueless)                                              | **YES**              |
-| `attr=""`                                                       | **YES**              |
-| `attr="any-static-text"`                                        | **YES**              |
-| `attr={{false}}`                                                | **NO**               |
-| `attr={{null}}`                                                 | **NO**               |
-| `attr={{undefined}}`                                            | **NO**               |
-| `attr={{true}}`                                                 | **YES**              |
-| `attr={{"any-string"}}` (incl. `"false"` and `"true"`)          | **YES**              |
-| `attr={{number}}`                                               | **YES**              |
-| `attr={{this.dynamic}}`                                         | UNKNOWN at lint time |
-| `attr="{{anything}}"` (concat single mustache, any inner value) | **YES**              |
-| `attr="text{{anything}}"` (concat with text + mustache)         | **YES**              |
+Five per-attribute tables, one per representative attribute kind. IDs (`m1`–`m19`, `h1`–`h15`, `d1`–`d10`, `t1`–`t7`, `i1`–`i5`) cross-reference the reproduction template below.
 
-Note especially the surprising rows:
+### `<video>` + `muted` — boolean HTML attribute, non-reflecting
 
-- `attr={{"false"}}` — bare-mustache string `"false"` is JS-truthy → attribute present, value `"false"`.
-- `attr="{{false}}"` — concat-form _always_ sets the IDL property to truthy, regardless of the literal value inside, even when HTML serialization shows nothing. (Verified against `<video muted="{{false}}">` → `videoEl.muted === true`.)
+`muted` is an HTML boolean attribute on `<video>`. The IDL `videoEl.muted` is the **live** muted state (independent of the content attribute); `videoEl.defaultMuted` is what reflects. At media-load time the user agent sets `muted` from `defaultMuted`. The "IDL muted" column below is read **before media load**, so for cases where only the HTML attribute is set, IDL muted reads false at that snapshot but becomes true once the media loads. The "At play time" column derives the value the rule cares about: is the audio actually muted when autoplay starts?
 
-Common bug: rules treating `attr="{{false}}"` or `attr={{"false"}}` as "falsy" because the literal `false`/`"false"` is in the source. Both render to a present attribute at runtime.
+| ID  | Source                                     | outerHTML                       | IDL `muted` (preload) | hasAttr | At play time                                                  |
+| --- | ------------------------------------------ | ------------------------------- | --------------------- | ------- | ------------------------------------------------------------- |
+| m1  | `<video muted></video>`                    | `<video muted=""></video>`      | `false`               | `true`  | **muted ON** (defaultMuted via attr)                          |
+| m2  | `<video muted=""></video>`                 | `<video muted=""></video>`      | `false`               | `true`  | **muted ON**                                                  |
+| m3  | `<video muted="true"></video>`             | `<video muted="true"></video>`  | `false`               | `true`  | **muted ON**                                                  |
+| m4  | `<video muted="false"></video>`            | `<video muted="false"></video>` | `false`               | `true`  | **muted ON** (HTML boolean-attr presence)                     |
+| m5  | `<video muted={{true}}></video>`           | `<video></video>`               | `true`                | `false` | **muted ON** (IDL set directly)                               |
+| m6  | `<video muted={{false}}></video>`          | `<video></video>`               | `false`               | `false` | **muted OFF**                                                 |
+| m7  | `<video muted={{"true"}}></video>`         | `<video muted="true"></video>`  | `false`               | `true`  | **muted ON**                                                  |
+| m8  | `<video muted={{"false"}}></video>`        | `<video muted="false"></video>` | `false`               | `true`  | **muted ON** (HTML boolean-attr presence)                     |
+| m9  | `<video muted={{null}}></video>`           | `<video></video>`               | `false`               | `false` | **muted OFF**                                                 |
+| m10 | `<video muted={{undefined}}></video>`      | `<video></video>`               | `false`               | `false` | **muted OFF**                                                 |
+| m11 | `<video muted={{""}}></video>`             | `<video muted=""></video>`      | `false`               | `true`  | **muted ON**                                                  |
+| m12 | `<video muted={{0}}></video>`              | `<video></video>`               | `false`               | `false` | **muted OFF**                                                 |
+| m13 | `<video muted="{{true}}"></video>`         | `<video></video>`               | `true`                | `false` | **muted ON** (concat sets IDL true)                           |
+| m14 | `<video muted="{{false}}"></video>`        | `<video></video>`               | `true`                | `false` | **muted ON** (concat sets IDL true regardless of inner value) |
+| m15 | `<video muted="{{'true'}}"></video>`       | `<video></video>`               | `true`                | `false` | **muted ON**                                                  |
+| m16 | `<video muted="{{'false'}}"></video>`      | `<video></video>`               | `true`                | `false` | **muted ON**                                                  |
+| m17 | `<video muted="x{{true}}"></video>`        | `<video></video>`               | `true`                | `false` | **muted ON**                                                  |
+| m18 | `<video muted="x{{false}}"></video>`       | `<video></video>`               | `true`                | `false` | **muted ON**                                                  |
+| m19 | `<video muted="{{false}}-suffix"></video>` | `<video></video>`               | `true`                | `false` | **muted ON**                                                  |
 
-## HTML serialization is not the source of truth
+**Lint truth for `muted`:** OFF iff the source is bare `{{false}}` / `{{null}}` / `{{undefined}}` / `{{0}}`. Every other form is ON at play time — including the surprising ones (any concat regardless of literal value; bare string `"false"`).
 
-Two layers:
+### `<input>` + `disabled` — boolean HTML attribute, reflecting
 
-1. **HTML serialization** (`element.outerHTML`) — what the browser's serialized HTML shows.
-2. **IDL property** (e.g. `videoEl.muted`) — the live runtime state.
+Same boolean-coercion behavior as `muted` for the bare-mustache form, but `disabled` reflects: when the IDL `disabled` is set, the HTML attribute appears as `disabled=""`.
 
-They can disagree, especially for **non-reflecting boolean HTML attributes** like `muted`, `autoplay`, `controls`, `loop` on media elements. The IDL property gets set by Glimmer, but the HTML serialization doesn't reflect it back.
+| ID  | Source                             | outerHTML                  | IDL `disabled` | hasAttr | At runtime                             |
+| --- | ---------------------------------- | -------------------------- | -------------- | ------- | -------------------------------------- |
+| d1  | `<input disabled />`               | `<input disabled="">`      | `true`         | `true`  | **disabled ON**                        |
+| d2  | `<input disabled={{true}} />`      | `<input disabled="">`      | `true`         | `true`  | **disabled ON**                        |
+| d3  | `<input disabled={{false}} />`     | `<input>`                  | `false`        | `false` | **disabled OFF**                       |
+| d4  | `<input disabled={{"false"}} />`   | `<input disabled="false">` | `true`         | `true`  | **disabled ON**                        |
+| d5  | `<input disabled={{"true"}} />`    | `<input disabled="true">`  | `true`         | `true`  | **disabled ON**                        |
+| d6  | `<input disabled={{null}} />`      | `<input>`                  | `false`        | `false` | **disabled OFF**                       |
+| d7  | `<input disabled="{{false}}" />`   | `<input disabled="">`      | `true`         | `true`  | **disabled ON** (concat sets IDL true) |
+| d8  | `<input disabled="{{true}}" />`    | `<input disabled="">`      | `true`         | `true`  | **disabled ON**                        |
+| d9  | `<input disabled="{{'false'}}" />` | `<input disabled="">`      | `true`         | `true`  | **disabled ON**                        |
+| d10 | `<input disabled="x{{true}}" />`   | `<input disabled="">`      | `true`         | `true`  | **disabled ON**                        |
 
-For accessibility and UX rules, the **IDL property / runtime state is what matters**, not the HTML string. A `<video muted={{true}}>` plays muted even though `outerHTML` doesn't show `muted`.
+**Lint truth for `disabled`:** identical falsy-set as `muted` — bare `{{false}}` / `{{null}}` (and by inference `{{undefined}}` / `{{0}}`, not yet tested for this attribute). Every other form is ON. The HTML serialization differs from `muted` (because `disabled` reflects), but the boolean lint truth is the same.
 
-## Verified rendering tables
+### `<div>` + `aria-hidden` — ARIA string attribute
 
-All rows below were verified by rendering in an Ember dev app and inspecting both `outerHTML` and (for boolean attrs) the IDL property in devtools. See [§ Reproduction template](#reproduction-template) at the end to re-verify if you suspect drift.
+ARIA attributes are string-valued, but Glimmer's bare-mustache form applies the same falsy-coercion as for boolean HTML attributes (omit on `false`/`null`/`undefined`). Bare-string and concat forms render the value literally — concat does **not** coerce to a boolean here. The "At runtime (per ARIA spec)" column derives whether the element is hidden from assistive tech: `aria-hidden="true"` is hidden; `aria-hidden="false"` is visible; `aria-hidden=""` (and the implied default) is contested.
 
-### Table 1: bare-mustache `attr={{X}}`
+| ID  | Source                                  | outerHTML                         | IDL `ariaHidden` | hasAttr | At runtime (ARIA)                              |
+| --- | --------------------------------------- | --------------------------------- | ---------------- | ------- | ---------------------------------------------- |
+| h1  | `<div aria-hidden></div>`               | `<div aria-hidden=""></div>`      | `""`             | `true`  | **contested** (empty value)                    |
+| h2  | `<div aria-hidden=""></div>`            | `<div aria-hidden=""></div>`      | `""`             | `true`  | **contested**                                  |
+| h3  | `<div aria-hidden="true"></div>`        | `<div aria-hidden="true"></div>`  | `"true"`         | `true`  | **hidden**                                     |
+| h4  | `<div aria-hidden="false"></div>`       | `<div aria-hidden="false"></div>` | `"false"`        | `true`  | **visible**                                    |
+| h5  | `<div aria-hidden={{true}}></div>`      | `<div aria-hidden=""></div>`      | `""`             | `true`  | **contested** (rendered empty, _not_ `"true"`) |
+| h6  | `<div aria-hidden={{false}}></div>`     | `<div></div>`                     | `null`           | `false` | **visible** (default)                          |
+| h7  | `<div aria-hidden={{"true"}}></div>`    | `<div aria-hidden="true"></div>`  | `"true"`         | `true`  | **hidden**                                     |
+| h8  | `<div aria-hidden={{"false"}}></div>`   | `<div aria-hidden="false"></div>` | `"false"`        | `true`  | **visible**                                    |
+| h9  | `<div aria-hidden={{null}}></div>`      | `<div></div>`                     | `null`           | `false` | **visible**                                    |
+| h10 | `<div aria-hidden={{undefined}}></div>` | `<div></div>`                     | `null`           | `false` | **visible**                                    |
+| h11 | `<div aria-hidden={{""}}></div>`        | `<div aria-hidden=""></div>`      | `""`             | `true`  | **contested**                                  |
+| h12 | `<div aria-hidden="{{true}}"></div>`    | `<div aria-hidden="true"></div>`  | `"true"`         | `true`  | **hidden**                                     |
+| h13 | `<div aria-hidden="{{false}}"></div>`   | `<div aria-hidden="false"></div>` | `"false"`        | `true`  | **visible**                                    |
+| h14 | `<div aria-hidden="{{'true'}}"></div>`  | `<div aria-hidden="true"></div>`  | `"true"`         | `true`  | **hidden**                                     |
+| h15 | `<div aria-hidden="{{'false'}}"></div>` | `<div aria-hidden="false"></div>` | `"false"`        | `true`  | **visible**                                    |
 
-| `X`                             | HTML serialization                                                                                                               | IDL property (boolean attrs)                                   | Lint-truth                            |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------- |
-| `false`                         | omitted                                                                                                                          | false                                                          | **FALSY**                             |
-| `null`                          | omitted                                                                                                                          | false (assumed)                                                | **FALSY**                             |
-| `undefined`                     | omitted                                                                                                                          | false (assumed)                                                | **FALSY**                             |
-| `true`                          | reflecting attrs (`disabled` on `<input>`, `aria-hidden` on `<div>`): `attr=""`. Non-reflecting (`muted` on `<video>`): omitted. | **true**                                                       | **TRUTHY**                            |
-| `"any-string"`                  | `attr="any-string"`                                                                                                              | true (string truthy)                                           | **TRUTHY**                            |
-| `""` (empty string)             | `attr=""`                                                                                                                        | unverified — could be falsy IDL given JS empty-string-is-falsy | **TRUTHY** by HTML attribute presence |
-| number (e.g. `0`, `-1`)         | `attr="<number>"` (e.g. `attr="0"`)                                                                                              | unverified                                                     | **TRUTHY** by HTML attribute presence |
-| dynamic path (e.g. `this.flag`) | depends on runtime value                                                                                                         | depends                                                        | **UNKNOWN** at lint time              |
+**Lint truth for `aria-hidden`:** the rule depends on the value, not just presence. Notable differences from boolean attrs: bare `{{true}}` renders as `aria-hidden=""` (contested, not `"true"`); concat `="{{false}}"` renders as `aria-hidden="false"` (visible — _not_ IDL-coerced like boolean attrs).
 
-### Table 2: concat-mustache `attr="…{{X}}…"`
+### `<div>` + `tabindex` — numeric attribute
 
-| Form                  | HTML serialization (boolean attrs)              | HTML serialization (string/ARIA attrs) | IDL property (boolean attrs)    | Lint-truth                                                                               |
-| --------------------- | ----------------------------------------------- | -------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
-| `"{{true}}"`          | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="true"`                          | **true**                        | **TRUTHY**                                                                               |
-| `"{{false}}"`         | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="false"`                         | **true**                        | **TRUTHY**                                                                               |
-| `"{{'true'}}"`        | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="true"`                          | true (assumed)                  | **TRUTHY**                                                                               |
-| `"{{'false'}}"`       | reflecting: `attr=""`. Non-reflecting: omitted. | `attr="false"`                         | true (assumed)                  | **TRUTHY**                                                                               |
-| `"text{{X}}"` (any X) | non-reflecting: omitted (verified for `muted`)  | `attr="text<stringified-X>"`           | true (assumed)                  | **TRUTHY**                                                                               |
-| `"{{this.dynamic}}"`  | depends                                         | depends                                | true (per the pattern; assumed) | **TRUTHY** at runtime, but rule may want to treat as UNKNOWN if it cares about the value |
+Falsy-coercion (`false`/`null`) omits, like boolean attrs. Numeric and string-numeric values render the literal. IDL `tabIndex` returns `-1` when no attribute is set (the default for non-focusable elements), so `hasAttr` is the cleaner signal for "tabindex is set" than checking `tabIndex`.
 
-**Concat is always truthy at runtime, regardless of the literal value inside.** This is the most surprising finding and the source of most classification bugs. Glimmer's concat handling appears to set the IDL property based on attribute _presence in the source_, not on the literal value evaluating to true.
+| ID  | Source                           | outerHTML                   | IDL `tabIndex` | hasAttr | Effective   |
+| --- | -------------------------------- | --------------------------- | -------------- | ------- | ----------- |
+| t1  | `<div tabindex={{0}}></div>`     | `<div tabindex="0"></div>`  | `0`            | `true`  | tabindex 0  |
+| t2  | `<div tabindex={{-1}}></div>`    | `<div tabindex="-1"></div>` | `-1`           | `true`  | tabindex -1 |
+| t3  | `<div tabindex={{1}}></div>`     | `<div tabindex="1"></div>`  | `1`            | `true`  | tabindex 1  |
+| t4  | `<div tabindex="{{0}}"></div>`   | `<div tabindex="0"></div>`  | `0`            | `true`  | tabindex 0  |
+| t5  | `<div tabindex={{"0"}}></div>`   | `<div tabindex="0"></div>`  | `0`            | `true`  | tabindex 0  |
+| t6  | `<div tabindex={{false}}></div>` | `<div></div>`               | `-1` (default) | `false` | not set     |
+| t7  | `<div tabindex={{null}}></div>`  | `<div></div>`               | `-1` (default) | `false` | not set     |
 
-### Table 3: static text attributes
+**Lint truth for `tabindex`:** rules that care about the value should extract the literal from the AST (the value is preserved as-written across all bare and concat literal forms). Rules that care about presence should check that the source is not bare `{{false}}` / `{{null}}` (and by inference `{{undefined}}`, not tested).
 
-| Form                  | HTML                  | Lint-truth                 |
-| --------------------- | --------------------- | -------------------------- |
-| `attr` (valueless)    | `attr=""`             | **TRUTHY**                 |
-| `attr=""`             | `attr=""`             | **TRUTHY**                 |
-| `attr="literal text"` | `attr="literal text"` | **TRUTHY** with that value |
+### `<input>` + `autocomplete` — string attribute (not boolean-coerced)
 
-For HTML boolean attributes (`muted`, `disabled`, `hidden`, etc.), HTML semantics treat any presence — including `attr="false"` — as the boolean being ON. This is HTML's rule, not Glimmer's.
+A regular string attribute. Glimmer's bare-mustache **does not** apply falsy-coercion here — `autocomplete={{false}}` renders as `autocomplete="false"` (kept). This is the key difference from boolean HTML attrs and from `aria-*`. The IDL `el.autocomplete` canonicalizes the attribute value (returns `""` for invalid tokens), so it differs from `getAttribute('autocomplete')` for non-spec values.
 
-## Per-attribute notes
+| ID  | Source                               | outerHTML                      | IDL `autocomplete`   | hasAttr | attrValue |
+| --- | ------------------------------------ | ------------------------------ | -------------------- | ------- | --------- |
+| i1  | `<input autocomplete="off" />`       | `<input autocomplete="off">`   | `"off"`              | `true`  | `"off"`   |
+| i2  | `<input autocomplete={{"off"}} />`   | `<input autocomplete="off">`   | `"off"`              | `true`  | `"off"`   |
+| i3  | `<input autocomplete="{{'off'}}" />` | `<input autocomplete="off">`   | `"off"`              | `true`  | `"off"`   |
+| i4  | `<input autocomplete={{false}} />`   | `<input autocomplete="false">` | `""` (canonicalized) | `true`  | `"false"` |
+| i5  | `<input autocomplete="{{false}}" />` | `<input autocomplete="false">` | `""` (canonicalized) | `true`  | `"false"` |
 
-**Reflecting boolean HTML attributes** (`disabled`, `hidden`, `readonly`, `required`, `multiple`, `selected`, `checked`, etc.):
+**Lint truth for `autocomplete`:** rules should check `getAttribute('autocomplete')` (or its AST equivalent) against the spec's valid token list, not the IDL property. The bare-mustache `{{false}}` form will give a literal `"false"` value — almost certainly an authoring bug worth flagging.
 
-- IDL property reflects to HTML attribute. Setting `el.disabled = true` adds `disabled=""`.
-- Concat form like `disabled="{{false}}"` keeps the attribute as `disabled=""` in HTML serialization (because IDL is set true, and reflection writes it back).
+### Cross-attribute observations
 
-**Non-reflecting boolean HTML attributes** on media elements (`muted`, `autoplay`, `controls`, `loop`):
+- **Glimmer's bare-mustache "boolean coercion" list.** For `muted` (HTML boolean), `disabled` (HTML boolean), `aria-hidden` (ARIA string), and `tabindex` (numeric), bare `{{false}}` / `{{null}}` / `{{undefined}}` (and `{{0}}` for `muted`) cause the attribute to be **omitted**. For `autocomplete` (plain string), bare `{{false}}` renders as `autocomplete="false"`. So Glimmer applies boolean-coercion to a known set — at minimum HTML boolean attrs, ARIA attrs, and numeric attrs. Plain string attrs do not get coerced.
+- **Bare-mustache string literals never coerce.** `attr={{"false"}}`, `attr={{"true"}}`, `attr={{""}}` always render as `attr="<the-string>"` for every attribute kind tested. The literal `"false"` is JS-truthy and gets passed through.
+- **Bare-mustache numeric `0` is in the falsy set for `muted`.** Verified for `muted` (`{{0}}` → omitted). Not yet tested for `disabled` / `aria-hidden` / `autocomplete`.
+- **Concat-mustache forks by attribute kind.** For HTML boolean attrs (`muted`, `disabled`), any concat — including `"{{false}}"`, `"{{'false'}}"`, `"x{{false}}"` — sets the IDL property to `true`, regardless of the literal value inside. For ARIA / string attrs (`aria-hidden`, `autocomplete`), concat renders the stringified value as the attribute value (no boolean coercion); `aria-hidden="{{false}}"` becomes `aria-hidden="false"` (visible).
+- **Concat is never falsy.** Across all attribute kinds tested, no concat form produces an absent attribute. Rules treating `attr="{{false}}"` as "off" are wrong for boolean attrs (it's IDL-true) and wrong for string attrs (the rendered value is `"false"`, attribute present).
 
-- IDL property exists but does _not_ reflect to HTML serialization. Setting `videoEl.muted = true` does _not_ add `muted=""` to outerHTML.
-- HTML inspector misleads you here. **Always check the IDL property to know runtime state.**
+## To reproduce the reference table
 
-**ARIA / string attributes** (`aria-hidden`, `aria-label`, `role`, etc.):
+Every cell above was populated by rendering the template below in an Ember dev app and running the bundled JS console snippet to print each test case's `outerHTML` and IDL state. To re-verify (or extend with new attributes):
 
-- No IDL property — HTML attribute is the ground truth.
-- Value matters, not just presence: `aria-hidden="false"` means _visible_; `aria-hidden="true"` means _hidden_. Rules need to check the value, not just presence.
-- Bare `attr={{true}}` renders as `attr=""` (empty string value) — _contested_ in ARIA semantics. Different tools treat valueless/empty `aria-hidden` differently. See `template-no-invalid-interactive` doc.
-
-**Numeric attributes** (`tabindex`, `colspan`, etc.):
-
-- Always render the literal value in HTML.
-- Both bare and concat forms preserve the numeric value as a string (e.g. `tabindex={{0}}` → `tabindex="0"`).
-- Rules checking value (e.g. positive vs. zero/negative tabindex) should extract the literal value from the AST, not just check presence.
-
-## Reproduction template
-
-If you suspect Glimmer behavior has changed, paste the following into a template in any Ember dev app and inspect the rendered output. Each input is preceded by an HTML comment showing the source form; the rendered HTML appears immediately after.
+1. Paste sections A–E into a template in your Ember dev app.
+2. Render in the browser, open devtools.
+3. Paste the JS snippet (after the template) into the console.
+4. Compare the printed output against the tables above.
+5. If anything diverges, update the changed cell, cite the new `ember-source` version in the commit, and note the change.
 
 ```hbs
 {{! A. <video> + muted (boolean HTML, non-reflecting) }}
-<!-- <video muted></video>: -->
-<video muted></video>
-<!-- <video muted=""></video>: -->
-<video muted=''></video>
-<!-- <video muted="true"></video>: -->
-<video muted='true'></video>
-<!-- <video muted="false"></video>: -->
-<video muted='false'></video>
-<!-- <video muted={{true}}></video>: -->
-<video muted={{true}}></video>
-<!-- <video muted={{false}}></video>: -->
-<video muted={{false}}></video>
-<!-- <video muted={{"true"}}></video>: -->
-<video muted={{'true'}}></video>
-<!-- <video muted={{"false"}}></video>: -->
-<video muted={{'false'}}></video>
-<!-- <video muted={{null}}></video>: -->
-<video muted={{null}}></video>
-<!-- <video muted={{undefined}}></video>: -->
-<video muted={{undefined}}></video>
-<!-- <video muted={{""}}></video>: -->
-<video muted={{''}}></video>
-<!-- <video muted="{{true}}"></video>: -->
-<video muted='{{true}}'></video>
-<!-- <video muted="{{false}}"></video>: -->
-<video muted='{{false}}'></video>
-<!-- <video muted="{{'true'}}"></video>: -->
-<video muted='{{"true"}}'></video>
-<!-- <video muted="{{'false'}}"></video>: -->
-<video muted='{{"false"}}'></video>
-<!-- <video muted="x{{true}}"></video>: -->
-<video muted='x{{true}}'></video>
-<!-- <video muted="x{{false}}"></video>: -->
-<video muted='x{{false}}'></video>
+<video id='m1' muted></video>
+<video id='m2' muted=''></video>
+<video id='m3' muted='true'></video>
+<video id='m4' muted='false'></video>
+<video id='m5' muted={{true}}></video>
+<video id='m6' muted={{false}}></video>
+<video id='m7' muted={{'true'}}></video>
+<video id='m8' muted={{'false'}}></video>
+<video id='m9' muted={{null}}></video>
+<video id='m10' muted={{undefined}}></video>
+<video id='m11' muted={{''}}></video>
+<video id='m12' muted={{0}}></video>
+<video id='m13' muted='{{true}}'></video>
+<video id='m14' muted='{{false}}'></video>
+<video id='m15' muted='{{"true"}}'></video>
+<video id='m16' muted='{{"false"}}'></video>
+<video id='m17' muted='x{{true}}'></video>
+<video id='m18' muted='x{{false}}'></video>
+<video id='m19' muted='{{false}}-suffix'></video>
 
-{{! B. <div> + aria-hidden (ARIA string, no IDL property) }}
-<!-- <div aria-hidden></div>: -->
-<div aria-hidden></div>
-<!-- <div aria-hidden=""></div>: -->
-<div aria-hidden=''></div>
-<!-- <div aria-hidden="true"></div>: -->
-<div aria-hidden='true'></div>
-<!-- <div aria-hidden="false"></div>: -->
-<div aria-hidden='false'></div>
-<!-- <div aria-hidden={{true}}></div>: -->
-<div aria-hidden={{true}}></div>
-<!-- <div aria-hidden={{false}}></div>: -->
-<div aria-hidden={{false}}></div>
-<!-- <div aria-hidden={{"true"}}></div>: -->
-<div aria-hidden={{'true'}}></div>
-<!-- <div aria-hidden={{"false"}}></div>: -->
-<div aria-hidden={{'false'}}></div>
-<!-- <div aria-hidden={{null}}></div>: -->
-<div aria-hidden={{null}}></div>
-<!-- <div aria-hidden={{undefined}}></div>: -->
-<div aria-hidden={{undefined}}></div>
-<!-- <div aria-hidden={{""}}></div>: -->
-<div aria-hidden={{''}}></div>
-<!-- <div aria-hidden="{{true}}"></div>: -->
-<div aria-hidden='{{true}}'></div>
-<!-- <div aria-hidden="{{false}}"></div>: -->
-<div aria-hidden='{{false}}'></div>
-<!-- <div aria-hidden="{{'true'}}"></div>: -->
-<div aria-hidden='{{"true"}}'></div>
-<!-- <div aria-hidden="{{'false'}}"></div>: -->
-<div aria-hidden='{{"false"}}'></div>
+{{! B. <div> + aria-hidden (ARIA string) }}
+<div id='h1' aria-hidden></div>
+<div id='h2' aria-hidden=''></div>
+<div id='h3' aria-hidden='true'></div>
+<div id='h4' aria-hidden='false'></div>
+<div id='h5' aria-hidden={{true}}></div>
+<div id='h6' aria-hidden={{false}}></div>
+<div id='h7' aria-hidden={{'true'}}></div>
+<div id='h8' aria-hidden={{'false'}}></div>
+<div id='h9' aria-hidden={{null}}></div>
+<div id='h10' aria-hidden={{undefined}}></div>
+<div id='h11' aria-hidden={{''}}></div>
+<div id='h12' aria-hidden='{{true}}'></div>
+<div id='h13' aria-hidden='{{false}}'></div>
+<div id='h14' aria-hidden='{{"true"}}'></div>
+<div id='h15' aria-hidden='{{"false"}}'></div>
 
 {{! C. <input> + disabled (boolean HTML, reflecting) }}
-<!-- <input disabled />: -->
-<input disabled />
-<!-- <input disabled={{true}} />: -->
-<input disabled={{true}} />
-<!-- <input disabled={{false}} />: -->
-<input disabled={{false}} />
-<!-- <input disabled={{"false"}} />: -->
-<input disabled={{'false'}} />
-<!-- <input disabled="{{false}}" />: -->
-<input disabled='{{false}}' />
+<input id='d1' disabled />
+<input id='d2' disabled={{true}} />
+<input id='d3' disabled={{false}} />
+<input id='d4' disabled={{'false'}} />
+<input id='d5' disabled={{'true'}} />
+<input id='d6' disabled={{null}} />
+<input id='d7' disabled='{{false}}' />
+<input id='d8' disabled='{{true}}' />
+<input id='d9' disabled='{{"false"}}' />
+<input id='d10' disabled='x{{true}}' />
 
 {{! D. <div> + tabindex (numeric) }}
-<!-- <div tabindex={{0}}></div>: -->
-<div tabindex={{0}}></div>
-<!-- <div tabindex={{-1}}></div>: -->
-<div tabindex={{-1}}></div>
-<!-- <div tabindex="{{0}}"></div>: -->
-<div tabindex='{{0}}'></div>
-<!-- <div tabindex={{"0"}}></div>: -->
-<div tabindex={{'0'}}></div>
+<div id='t1' tabindex={{0}}></div>
+<div id='t2' tabindex={{-1}}></div>
+<div id='t3' tabindex={{1}}></div>
+<div id='t4' tabindex='{{0}}'></div>
+<div id='t5' tabindex={{'0'}}></div>
+<div id='t6' tabindex={{false}}></div>
+<div id='t7' tabindex={{null}}></div>
 
-{{! E. IDL property check for non-reflecting boolean attrs }}
-<video id='t1' muted={{true}}></video>
-<video id='t2' muted='{{true}}'></video>
-<video id='t3' muted='{{false}}'></video>
-<video id='t4'></video>
-{{! Then in devtools console:
-       document.getElementById('t1').muted  // expected: true
-       document.getElementById('t2').muted  // expected: true
-       document.getElementById('t3').muted  // expected: true (the surprising one)
-       document.getElementById('t4').muted  // expected: false (no attr → default)
-}}
+{{! E. <input> + autocomplete (string) }}
+<input id='i1' autocomplete='off' />
+<input id='i2' autocomplete={{'off'}} />
+<input id='i3' autocomplete='{{"off"}}' />
+<input id='i4' autocomplete={{false}} />
+<input id='i5' autocomplete='{{false}}' />
 ```
 
-## Open questions / unverified
+After rendering, paste this into the devtools console:
 
-- **Bare `{{0}}`, `{{""}}`, `{{NaN}}` IDL property** — JS-falsy literal values in bare mustache. The HTML serialization keeps the attribute (e.g. `attr="0"`), but whether the IDL property is set to true (matching presence) or false (matching JS-falsy) is unverified. Rules should treat as TRUTHY for now (HTML presence), and revisit if a counter-example surfaces.
-- **Concat with dynamic path** (e.g. `attr="{{this.flag}}"`) — assumed truthy by analogy to literal-concat behavior, but not directly verified. Rules that care about the value (not just presence) should treat concat-with-dynamic as UNKNOWN.
-- **`{{false}}` followed by static text in concat** (e.g. `attr="{{false}}-suffix"`) — verified for boolean attrs only (`muted`); behavior on string/ARIA attrs not directly tested but assumed to follow the "concat always renders for string attrs" pattern.
-
-## How to extend this doc
-
-When you discover a new edge case:
-
-1. Render the source form in an Ember dev app and capture both `outerHTML` and (where relevant) the IDL property.
-2. Add a row to the appropriate table above with verified-only data. Mark assumptions explicitly with "(assumed)" or "(unverified)".
-3. Cite the date and `ember-source` version of the verification in the commit message.
-4. If the new finding contradicts an existing rule's classification, open an issue or PR fixing the rule and link this doc.
+```js
+(() => {
+  const groups = {
+    'A. video.muted': {
+      prefix: 'm',
+      count: 19,
+      idl: (el) => ({
+        muted: el.muted,
+        hasAttr: el.hasAttribute('muted'),
+        attrValue: el.getAttribute('muted'),
+      }),
+    },
+    'B. div.ariaHidden': {
+      prefix: 'h',
+      count: 15,
+      idl: (el) => ({
+        ariaHidden: el.ariaHidden,
+        hasAttr: el.hasAttribute('aria-hidden'),
+        attrValue: el.getAttribute('aria-hidden'),
+      }),
+    },
+    'C. input.disabled': {
+      prefix: 'd',
+      count: 10,
+      idl: (el) => ({
+        disabled: el.disabled,
+        hasAttr: el.hasAttribute('disabled'),
+        attrValue: el.getAttribute('disabled'),
+      }),
+    },
+    'D. div.tabIndex': {
+      prefix: 't',
+      count: 7,
+      idl: (el) => ({
+        tabIndex: el.tabIndex,
+        hasAttr: el.hasAttribute('tabindex'),
+        attrValue: el.getAttribute('tabindex'),
+      }),
+    },
+    'E. input.autocomplete': {
+      prefix: 'i',
+      count: 5,
+      idl: (el) => ({
+        autocomplete: el.autocomplete,
+        hasAttr: el.hasAttribute('autocomplete'),
+        attrValue: el.getAttribute('autocomplete'),
+      }),
+    },
+  };
+  const lines = [];
+  for (const [label, { prefix, count, idl }] of Object.entries(groups)) {
+    lines.push(`\n==== ${label} ====`);
+    for (let i = 1; i <= count; i++) {
+      const id = prefix + i;
+      const el = document.getElementById(id);
+      if (!el) {
+        lines.push(`${id}: (NOT FOUND)`);
+        continue;
+      }
+      const idlPairs = Object.entries(idl(el))
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join(' ');
+      lines.push(`${id.padEnd(4)} ${el.outerHTML.padEnd(75)} | ${idlPairs}`);
+    }
+  }
+  console.log(lines.join('\n'));
+})();
+```
 
 ## Verification metadata
 
 - **Date verified:** 2026-04-28
 - **Ember version:** `ember-source` 6.12 (Glimmer VM is merged into the main Ember repo, no separate version)
 - **Verified by:** [@johanrd](https://github.com/johanrd) (rendering app, devtools inspection)
-- **Methodology:** rendered template fragments, inspected `outerHTML` for HTML serialization and JS property access for IDL state
+- **Methodology:** rendered template fragments via the reproduction template above, captured `outerHTML` and IDL property state via the bundled JS console snippet
 
 ## Related
 
 - HTML spec on boolean attributes and reflection: <https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes>
+- HTML spec on `muted` IDL vs. `defaultMuted`: <https://html.spec.whatwg.org/multipage/media.html#dom-media-muted>
 - ARIA `aria-hidden` semantics: <https://www.w3.org/TR/wai-aria-1.2/#aria-hidden>
+- ARIA reflection via `ARIAMixin`: <https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin>

--- a/docs/glimmer-attribute-behavior.md
+++ b/docs/glimmer-attribute-behavior.md
@@ -225,18 +225,17 @@ When you discover a new edge case:
 
 1. Render the source form in an Ember dev app and capture both `outerHTML` and (where relevant) the IDL property.
 2. Add a row to the appropriate table above with verified-only data. Mark assumptions explicitly with "(assumed)" or "(unverified)".
-3. Cite the date and Ember/Glimmer version of the verification in the commit message.
+3. Cite the date and `ember-source` version of the verification in the commit message.
 4. If the new finding contradicts an existing rule's classification, open an issue or PR fixing the rule and link this doc.
 
 ## Verification metadata
 
 - **Date verified:** 2026-04-28
-- **Ember/Glimmer version:** _TODO — fill in `ember-source` version from the dev app where t1–t4 were tested._
+- **Ember version:** `ember-source` 6.12 (Glimmer VM is merged into the main Ember repo, no separate version)
 - **Verified by:** [@johanrd](https://github.com/johanrd) (rendering app, devtools inspection)
 - **Methodology:** rendered template fragments, inspected `outerHTML` for HTML serialization and JS property access for IDL state
 
 ## Related
 
-- The Glimmer VM source for attribute rendering: <https://github.com/glimmerjs/glimmer-vm>
 - HTML spec on boolean attributes and reflection: <https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes>
 - ARIA `aria-hidden` semantics: <https://www.w3.org/TR/wai-aria-1.2/#aria-hidden>

--- a/lib/rules/template-block-indentation.js
+++ b/lib/rules/template-block-indentation.js
@@ -1,25 +1,9 @@
 'use strict';
 
+const { htmlVoidElements } = require('html-void-elements');
 const editorConfigUtil = require('../utils/editorconfig');
 
-const VOID_TAGS = new Set([
-  'area',
-  'base',
-  'br',
-  'col',
-  'command',
-  'embed',
-  'hr',
-  'img',
-  'input',
-  'keygen',
-  'link',
-  'meta',
-  'param',
-  'source',
-  'track',
-  'wbr',
-]);
+const VOID_TAGS = new Set(htmlVoidElements);
 const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'textarea']);
 
 function isControlChar(char) {

--- a/lib/rules/template-link-rel-noopener.js
+++ b/lib/rules/template-link-rel-noopener.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { classifyAttribute } = require('../utils/glimmer-attr-presence');
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -27,16 +31,31 @@ module.exports = {
           return;
         }
 
+        // `target` is a plain string attribute. Use classifyAttribute so the
+        // rule recognizes any source form that renders as `target="_blank"` —
+        // including `target={{"_blank"}}` (i2 analog) and `target="{{'_blank'}}"`
+        // (i3 analog) — instead of only the static text-node case.
         const targetAttr = node.attributes?.find((a) => a.name === 'target');
-        if (!targetAttr?.value || targetAttr.value.type !== 'GlimmerTextNode') {
-          return;
-        }
-        if (targetAttr.value.chars !== '_blank') {
+        const targetClass = classifyAttribute(targetAttr);
+        if (targetClass.presence !== 'present' || targetClass.value !== '_blank') {
           return;
         }
 
         const relAttr = node.attributes?.find((a) => a.name === 'rel');
-        const relValue = relAttr?.value?.type === 'GlimmerTextNode' ? relAttr.value.chars : '';
+        const relClass = classifyAttribute(relAttr);
+
+        // Conservative-skip when rel is present but its runtime value cannot
+        // be determined statically (e.g., `rel={{this.x}}` or
+        // `rel="prefix-{{this.y}}"`). Flagging here would be a false positive
+        // — the runtime value may already include the required tokens. The
+        // doc cross-attribute observation "Concat is never falsy" guarantees
+        // that any concat form does render *some* attribute value; it just
+        // isn't statically extractable.
+        if (relClass.presence === 'present' && relClass.value === null) {
+          return;
+        }
+
+        const relValue = relClass.value || '';
         const hasNoopener = /(?:^|\s)noopener(?:\s|$)/.test(relValue);
         const hasNoreferrer = /(?:^|\s)noreferrer(?:\s|$)/.test(relValue);
         const hasProperRel = hasNoopener && hasNoreferrer;
@@ -55,6 +74,13 @@ module.exports = {
                   .join(' ');
                 const newValue = `${filtered} noopener noreferrer`.trim();
                 return fixer.replaceText(relAttr.value, `"${newValue}"`);
+              }
+              // Don't autofix when rel is present in a non-text form (e.g.,
+              // bare-string-literal mustache or concat) — replacing/inserting
+              // would either produce a duplicate `rel` attribute or destroy
+              // the author's binding. Report-only.
+              if (relAttr) {
+                return null;
               }
               // No rel attribute — insert one before the closing >
               const sourceCode = context.sourceCode;

--- a/lib/rules/template-no-nested-interactive.js
+++ b/lib/rules/template-no-nested-interactive.js
@@ -2,6 +2,7 @@
 
 const { isHtmlInteractiveContent } = require('../utils/html-interactive-content');
 const { INTERACTIVE_ROLES, COMPOSITE_WIDGET_CHILDREN } = require('../utils/interactive-roles');
+const { classifyAttribute } = require('../utils/glimmer-attr-presence');
 
 function hasAttr(node, name) {
   return node.attributes?.some((a) => a.name === name);
@@ -13,6 +14,17 @@ function getTextAttr(node, name) {
     return attr.value.chars;
   }
   return undefined;
+}
+
+// Returns true only when `tabindex` will actually render on the element.
+// Bare `tabindex={{false}}` / `{{null}}` / `{{undefined}}` cause Glimmer to
+// omit the attribute (doc rows t6, t7) — `hasAttr` is wrong because the AST
+// node is present but the runtime element has no tabindex. Dynamic values
+// (`tabindex={{this.x}}`) classify as 'unknown' and are conservative-skipped
+// (we cannot statically prove the runtime keeps the attribute).
+function isTabindexEffectivelySet(node) {
+  const attr = node.attributes?.find((a) => a.name === 'tabindex');
+  return classifyAttribute(attr).presence === 'present';
 }
 
 function getRole(node) {
@@ -148,8 +160,8 @@ module.exports = {
         return true;
       }
 
-      // Check tabindex
-      if (!ignoreTabindex && hasAttr(node, 'tabindex')) {
+      // Check tabindex (rendered, not just AST-present — see isTabindexEffectivelySet).
+      if (!ignoreTabindex && isTabindexEffectivelySet(node)) {
         return true;
       }
 
@@ -206,7 +218,7 @@ module.exports = {
       if ((tag === 'img' || tag === 'object') && hasAttr(node, 'usemap')) {
         return false;
       }
-      return hasAttr(node, 'tabindex');
+      return isTabindexEffectivelySet(node);
     }
 
     return {

--- a/lib/rules/template-require-context-role.js
+++ b/lib/rules/template-require-context-role.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const { classifyAttribute } = require('../utils/glimmer-attr-presence');
+
 const ROLES_REQUIRING_CONTEXT = {
   cell: ['row'],
   listitem: ['group', 'list'],
@@ -89,9 +93,18 @@ function getRoleFromNode(node) {
   return null;
 }
 
+// Recognize every source form that renders `aria-hidden="true"` at runtime
+// per the verified model (doc rows h3, h7, h12, h14). The previous
+// `GlimmerTextNode + chars === 'true'` check missed bare `{{"true"}}` and
+// concat forms `"{{true}}"` / `"{{'true'}}"` — all three render identical
+// HTML and are interpreted as "hidden" by every assistive tech. Notably,
+// bare `{{true}}` is *not* hidden (h5: renders `aria-hidden=""`, contested
+// per ARIA spec) — `classifyAttribute` returns value="" for that case so
+// the equality check correctly excludes it.
 function hasAriaHiddenTrue(node) {
   const attr = node.attributes?.find((a) => a.name === 'aria-hidden');
-  return attr?.value?.type === 'GlimmerTextNode' && attr.value.chars === 'true';
+  const { presence, value } = classifyAttribute(attr);
+  return presence === 'present' && value === 'true';
 }
 
 /**

--- a/lib/rules/template-require-mandatory-role-attributes.js
+++ b/lib/rules/template-require-mandatory-role-attributes.js
@@ -1,14 +1,25 @@
+'use strict';
+
 const { roles } = require('aria-query');
 const { AXObjectRoles, elementAXObjects } = require('axobject-query');
+const { classifyAttribute } = require('../utils/glimmer-attr-presence');
 
 // ARIA role values are whitespace-separated tokens compared ASCII-case-insensitively.
 // Returns the list of normalised tokens, or undefined when the attribute is
 // missing or dynamic.
+//
+// `role` is a plain string attribute (no boolean coercion — see
+// docs/glimmer-attribute-behavior.md cross-attribute observations).
+// Recognise every source form that renders a statically-known role string:
+//   - GlimmerTextNode (i1): `role="button"`
+//   - bare-mustache string literal (i2 analog): `role={{"button"}}`
+//   - concat with all-literal parts (i3 analog): `role="{{'button'}}"`
+// classifyAttribute resolves all three to the same string value.
 function getStaticRolesFromElement(node) {
   const roleAttr = node.attributes?.find((attr) => attr.name === 'role');
-
-  if (roleAttr?.value?.type === 'GlimmerTextNode') {
-    return splitRoleTokens(roleAttr.value.chars);
+  const { presence, value } = classifyAttribute(roleAttr);
+  if (presence === 'present' && value !== null) {
+    return splitRoleTokens(value);
   }
 
   return undefined;
@@ -231,8 +242,19 @@ module.exports = {
           return;
         }
 
+        // Per docs/glimmer-attribute-behavior.md cross-attribute observations,
+        // bare-mustache falsy literals on aria-* attributes (rows h6, h9, h10)
+        // cause Glimmer to OMIT the attribute at runtime. AST-presence is not
+        // a proxy for runtime-presence here: an element written as
+        // <div role="option" aria-selected={{false}}> renders without any
+        // aria-selected attribute and should NOT be treated as satisfying
+        // role="option"'s required ARIA state.
         const foundAriaAttributes = (node.attributes ?? [])
-          .filter((attribute) => attribute.name?.startsWith('aria-'))
+          .filter(
+            (attribute) =>
+              attribute.name?.startsWith('aria-') &&
+              classifyAttribute(attribute).presence !== 'absent'
+          )
           .map((attribute) => attribute.name);
 
         const result = getMissingRequiredAttributes(roleTokens, foundAriaAttributes, node, context);

--- a/lib/rules/template-self-closing-void-elements.js
+++ b/lib/rules/template-self-closing-void-elements.js
@@ -1,3 +1,9 @@
+'use strict';
+
+const { htmlVoidElements } = require('html-void-elements');
+
+const VOID_ELEMENTS = new Set(htmlVoidElements);
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
@@ -27,25 +33,6 @@ module.exports = {
   },
 
   create(context) {
-    const VOID_ELEMENTS = new Set([
-      'area',
-      'base',
-      'br',
-      'col',
-      'command',
-      'embed',
-      'hr',
-      'img',
-      'input',
-      'keygen',
-      'link',
-      'meta',
-      'param',
-      'source',
-      'track',
-      'wbr',
-    ]);
-
     const sourceCode = context.sourceCode;
     const config = context.options[0] ?? true;
 

--- a/lib/utils/glimmer-attr-presence.js
+++ b/lib/utils/glimmer-attr-presence.js
@@ -1,42 +1,12 @@
 'use strict';
 
+const { find, html } = require('property-information');
 const { getStaticAttrValue } = require('./static-attr-value');
 
-// HTML boolean attributes per WHATWG HTML Living Standard
-// (https://html.spec.whatwg.org/multipage/indices.html#attributes-3, "Boolean
-// attribute" column). Glimmer's bare-mustache falsy-coercion applies to these.
-const BOOLEAN_HTML_ATTRS = new Set([
-  'allowfullscreen',
-  'async',
-  'autofocus',
-  'autoplay',
-  'checked',
-  'controls',
-  'default',
-  'defer',
-  'disabled',
-  'formnovalidate',
-  'hidden',
-  'inert',
-  'ismap',
-  'itemscope',
-  'loop',
-  'multiple',
-  'muted',
-  'nomodule',
-  'novalidate',
-  'open',
-  'playsinline',
-  'readonly',
-  'required',
-  'reversed',
-  'selected',
-]);
-
-// Numeric attributes whose bare-falsy coercion is verified or expected.
-// Verified for `tabindex` (rows t6, t7). `colspan` / `rowspan` follow the same
-// numeric-attribute pattern but are not directly verified.
-const NUMERIC_ATTRS = new Set(['tabindex', 'colspan', 'rowspan']);
+// `colspan` is a positive-integer attribute per WHATWG, but property-information
+// 7.1.0 doesn't mark it as `number: true` (likely upstream gap — `rowspan`,
+// `cols`, etc. do have it). Override locally; remove if upstream fixes.
+const NUMERIC_OVERRIDES = new Set(['colspan']);
 
 /**
  * Infer the attribute kind from its name. Used when the caller doesn't pass
@@ -44,21 +14,34 @@ const NUMERIC_ATTRS = new Set(['tabindex', 'colspan', 'rowspan']);
  *
  * Returns one of: 'boolean' | 'aria' | 'numeric' | 'plain-string'.
  *
- * NOTE: `role` is intentionally classified as `'plain-string'` (not `'aria'`)
- * because empirically it does NOT participate in the bare-mustache
- * falsy-coercion list (per cross-attribute observations in the doc — `role`
- * is a plain DOM string attribute despite living conceptually with ARIA).
+ * Classification flows from the `property-information` package, which encodes
+ * attribute type info per WHATWG HTML / WAI-ARIA. ARIA prefix is checked first
+ * because Glimmer's rendering for `aria-*` attrs diverges from HTML booleans
+ * (e.g., `aria-hidden={{true}}` renders empty per h5, but `disabled={{true}}`
+ * renders `disabled=""` per d2). `role` falls through to plain-string because
+ * Glimmer does not falsy-coerce it (the doc's cross-attribute observations
+ * confirm this — `role={{false}}` renders `role="false"`).
  */
 function inferAttrKind(name) {
-  if (BOOLEAN_HTML_ATTRS.has(name)) {
-    return 'boolean';
-  }
-  if (NUMERIC_ATTRS.has(name)) {
-    return 'numeric';
-  }
-  if (name.startsWith('aria-')) {
+  // HTML attribute names are case-insensitive; normalize before lookup so
+  // `Disabled`, `ARIA-Hidden`, etc. classify the same as the lowercase form.
+  const lower = name.toLowerCase();
+  if (lower.startsWith('aria-')) {
     return 'aria';
   }
+  const info = find(html, lower);
+  // boolean: standard HTML boolean attrs (disabled, muted, …).
+  // overloadedBoolean: hidden, download — boolean-like with extra string values,
+  // but Glimmer's falsy-omit coercion still applies (verified for `hidden`-style).
+  if (info.boolean || info.overloadedBoolean) {
+    return 'boolean';
+  }
+  if (info.number || NUMERIC_OVERRIDES.has(lower)) {
+    return 'numeric';
+  }
+  // Everything else (plain strings, booleanish HTML attrs like contenteditable
+  // and draggable whose Glimmer behavior isn't verified in the doc) routes to
+  // plain-string. Conservative: no falsy-omit coercion, render the literal.
   return 'plain-string';
 }
 
@@ -121,13 +104,17 @@ function classifyAttribute(attrNode, options = {}) {
 
   // Concat-mustache: attr="...{{X}}..." — never falsy.
   // Doc cross-attribute observation: "Concat is never falsy."
-  // For plain-string/aria/numeric, the rendered value is the stringified
-  // concatenation of parts; if any part is dynamic, value is unknown.
-  // For boolean attrs, the IDL property is set true regardless of inner literal
-  // (rows m13-m19, d7-d10), so the conceptual "value" is irrelevant for
-  // boolean callers — but we still report the resolved string when known so
-  // string-comparing callers (e.g., aria-hidden === "true") work for h12-h15.
   if (value.type === 'GlimmerConcatStatement') {
+    // For boolean attrs, the IDL property is set true regardless of inner
+    // literal (rows m13–m19, d7–d10). Report the canonical "on" value so
+    // callers comparing `value === 'false'` to detect "off" don't get a
+    // wrong answer from the inner literal of `attr="{{false}}"`.
+    if (kind === 'boolean') {
+      return { presence: 'present', value: 'true' };
+    }
+    // For aria/numeric/plain-string, the rendered HTML value is the
+    // stringified concatenation of parts (h12–h15, i3, i5). If any part
+    // is dynamic, the resolved value is unknown but presence is still 'present'.
     const resolved = getStaticAttrValue(value);
     return { presence: 'present', value: resolved === undefined ? null : resolved };
   }
@@ -152,19 +139,21 @@ function classifyBareMustache(value, kind, isFalsyCoerced) {
       }
       return { presence: 'present', value: 'false' };
     }
-    // {{true}}: present on all kinds.
-    // For aria-coerced specifically, h5 shows the rendered HTML value is "" —
-    // not "true". Callers comparing aria-hidden values to "true" should NOT
-    // match this case. Reflect that asymmetry in the resolved value:
+    // {{true}}: behavior diverges by kind.
+    //   - boolean: verified (m5, d2). HTML may be empty (d2) or omitted (m5),
+    //     but the attribute is conceptually "on". Surface 'true' so callers
+    //     can string-compare like for {{"true"}}.
+    //   - aria: verified (h5). Renders aria-hidden="" — empty, NOT "true".
+    //     Callers comparing aria-hidden to "true" must not match this row.
+    //   - numeric / plain-string: untested in the verification doc. Be
+    //     conservative — return 'unknown' rather than guess.
+    if (kind === 'boolean') {
+      return { presence: 'present', value: 'true' };
+    }
     if (kind === 'aria') {
       return { presence: 'present', value: '' };
     }
-    // Boolean reflecting (d2: disabled=""), boolean non-reflecting (m5: HTML
-    // omitted but IDL true), numeric (untested for {{true}}), plain-string
-    // (untested for {{true}}) — for the rule's purposes, the attribute is
-    // present and conceptually "true". We surface the literal source value
-    // "true" so string-comparing callers behave like for {{"true"}} (m7, h7).
-    return { presence: 'present', value: 'true' };
+    return { presence: 'unknown', value: null };
   }
 
   // {{null}} / {{undefined}}
@@ -210,6 +199,4 @@ function classifyBareMustache(value, kind, isFalsyCoerced) {
 module.exports = {
   classifyAttribute,
   inferAttrKind,
-  BOOLEAN_HTML_ATTRS,
-  NUMERIC_ATTRS,
 };

--- a/lib/utils/glimmer-attr-presence.js
+++ b/lib/utils/glimmer-attr-presence.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { getStaticAttrValue } = require('./static-attr-value');
+
+// HTML boolean attributes per WHATWG HTML Living Standard
+// (https://html.spec.whatwg.org/multipage/indices.html#attributes-3, "Boolean
+// attribute" column). Glimmer's bare-mustache falsy-coercion applies to these.
+const BOOLEAN_HTML_ATTRS = new Set([
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected',
+]);
+
+// Numeric attributes whose bare-falsy coercion is verified or expected.
+// Verified for `tabindex` (rows t6, t7). `colspan` / `rowspan` follow the same
+// numeric-attribute pattern but are not directly verified.
+const NUMERIC_ATTRS = new Set(['tabindex', 'colspan', 'rowspan']);
+
+/**
+ * Infer the attribute kind from its name. Used when the caller doesn't pass
+ * `options.kind` explicitly.
+ *
+ * Returns one of: 'boolean' | 'aria' | 'numeric' | 'plain-string'.
+ *
+ * NOTE: `role` is intentionally classified as `'plain-string'` (not `'aria'`)
+ * because empirically it does NOT participate in the bare-mustache
+ * falsy-coercion list (per cross-attribute observations in the doc — `role`
+ * is a plain DOM string attribute despite living conceptually with ARIA).
+ */
+function inferAttrKind(name) {
+  if (BOOLEAN_HTML_ATTRS.has(name)) {
+    return 'boolean';
+  }
+  if (NUMERIC_ATTRS.has(name)) {
+    return 'numeric';
+  }
+  if (name.startsWith('aria-')) {
+    return 'aria';
+  }
+  return 'plain-string';
+}
+
+/**
+ * Classify a Glimmer attribute against the verified rendering model in
+ * docs/glimmer-attribute-behavior.md.
+ *
+ * Result shape: { presence, value }
+ *
+ *   presence: 'absent' | 'present' | 'unknown'
+ *     - 'absent'  — attribute will not be on the rendered element.
+ *                   Either attrNode is null/undefined, OR the source is
+ *                   bare {{false}}/{{null}}/{{undefined}} (or {{0}} for
+ *                   `boolean` kind) on a falsy-coerced attribute kind
+ *                   (boolean / aria / numeric). Doc rows: m6, m9, m10, m12,
+ *                   d3, d6, h6, h9, h10, t6, t7.
+ *     - 'present' — attribute will be present at runtime. `value` is the
+ *                   resolved static string when known, or null when the
+ *                   value is dynamic (e.g., bare {{this.x}} on a plain-string
+ *                   attribute).
+ *     - 'unknown' — cannot determine statically (dynamic mustache / dynamic
+ *                   concat part on a falsy-coerced kind, since the runtime
+ *                   value could be falsy and thus omit the attribute).
+ *
+ *   value: string | null
+ *     The resolved HTML attribute value when statically known. null when:
+ *       - presence is 'absent' or 'unknown'
+ *       - presence is 'present' but the value is dynamic
+ *
+ * @param {object|null|undefined} attrNode - The AttrNode, or null/undefined when not found.
+ * @param {object} [options]
+ * @param {'boolean'|'aria'|'numeric'|'plain-string'} [options.kind] - Override inferred kind.
+ * @returns {{presence: 'absent'|'present'|'unknown', value: string|null}}
+ */
+function classifyAttribute(attrNode, options = {}) {
+  if (!attrNode) {
+    return { presence: 'absent', value: null };
+  }
+
+  const kind = options.kind || inferAttrKind(attrNode.name);
+  const isFalsyCoerced = kind === 'boolean' || kind === 'aria' || kind === 'numeric';
+  const value = attrNode.value;
+
+  // Valueless attribute: <input disabled />, <div aria-hidden></div>
+  // Renders as `attr=""`. Doc rows: d1, h1.
+  if (value === null || value === undefined) {
+    return { presence: 'present', value: '' };
+  }
+
+  // Static text: attr="anything". Renders the literal chars.
+  // Doc rows: m1-m4, h2-h4, d1, t-static, i1.
+  if (value.type === 'GlimmerTextNode') {
+    return { presence: 'present', value: value.chars };
+  }
+
+  // Bare-mustache: attr={{X}}
+  if (value.type === 'GlimmerMustacheStatement') {
+    return classifyBareMustache(value, kind, isFalsyCoerced);
+  }
+
+  // Concat-mustache: attr="...{{X}}..." — never falsy.
+  // Doc cross-attribute observation: "Concat is never falsy."
+  // For plain-string/aria/numeric, the rendered value is the stringified
+  // concatenation of parts; if any part is dynamic, value is unknown.
+  // For boolean attrs, the IDL property is set true regardless of inner literal
+  // (rows m13-m19, d7-d10), so the conceptual "value" is irrelevant for
+  // boolean callers — but we still report the resolved string when known so
+  // string-comparing callers (e.g., aria-hidden === "true") work for h12-h15.
+  if (value.type === 'GlimmerConcatStatement') {
+    const resolved = getStaticAttrValue(value);
+    return { presence: 'present', value: resolved === undefined ? null : resolved };
+  }
+
+  // Unknown AST shape (e.g., a future Glimmer node type) — be conservative.
+  return { presence: 'unknown', value: null };
+}
+
+function classifyBareMustache(value, kind, isFalsyCoerced) {
+  const path = value.path;
+  if (!path) {
+    return { presence: 'unknown', value: null };
+  }
+
+  // {{true}} / {{false}}
+  if (path.type === 'GlimmerBooleanLiteral') {
+    if (path.value === false) {
+      // {{false}} on falsy-coerced kind → omitted (m6, d3, h6, t6 verified).
+      // {{false}} on plain-string → renders "false" (i4 verified for autocomplete).
+      if (isFalsyCoerced) {
+        return { presence: 'absent', value: null };
+      }
+      return { presence: 'present', value: 'false' };
+    }
+    // {{true}}: present on all kinds.
+    // For aria-coerced specifically, h5 shows the rendered HTML value is "" —
+    // not "true". Callers comparing aria-hidden values to "true" should NOT
+    // match this case. Reflect that asymmetry in the resolved value:
+    if (kind === 'aria') {
+      return { presence: 'present', value: '' };
+    }
+    // Boolean reflecting (d2: disabled=""), boolean non-reflecting (m5: HTML
+    // omitted but IDL true), numeric (untested for {{true}}), plain-string
+    // (untested for {{true}}) — for the rule's purposes, the attribute is
+    // present and conceptually "true". We surface the literal source value
+    // "true" so string-comparing callers behave like for {{"true"}} (m7, h7).
+    return { presence: 'present', value: 'true' };
+  }
+
+  // {{null}} / {{undefined}}
+  if (path.type === 'GlimmerNullLiteral' || path.type === 'GlimmerUndefinedLiteral') {
+    // Verified for falsy-coerced kinds via cross-attribute observation
+    // (rows m9, m10, h9, h10, d6, t7).
+    // For plain-string, behavior is not yet verified — return 'unknown' to
+    // avoid claiming behavior the doc doesn't guarantee.
+    if (isFalsyCoerced) {
+      return { presence: 'absent', value: null };
+    }
+    return { presence: 'unknown', value: null };
+  }
+
+  // {{"string"}}
+  // Bare-mustache string literals never coerce — render literal value.
+  // Doc rows: m7, m8, h7, h8, d4, d5, i2.
+  if (path.type === 'GlimmerStringLiteral') {
+    return { presence: 'present', value: path.value };
+  }
+
+  // {{0}}, {{1}}, {{-1}}, etc.
+  if (path.type === 'GlimmerNumberLiteral') {
+    // {{0}} for boolean kind → omitted (m12 verified for muted).
+    // For numeric kind, t1 verifies {{0}} renders "0" (focusable).
+    // For plain-string, untested.
+    if (path.value === 0 && kind === 'boolean') {
+      return { presence: 'absent', value: null };
+    }
+    return { presence: 'present', value: String(path.value) };
+  }
+
+  // Dynamic path: {{this.x}}, {{x}}, {{(some-helper)}}, etc.
+  // For falsy-coerced kinds, runtime value could be falsy → attribute omitted.
+  // For plain-string, the attribute renders something (even null/undefined coerce
+  // via stringification), but the value isn't statically known.
+  if (isFalsyCoerced) {
+    return { presence: 'unknown', value: null };
+  }
+  return { presence: 'present', value: null };
+}
+
+module.exports = {
+  classifyAttribute,
+  inferAttrKind,
+  BOOLEAN_HTML_ATTRS,
+  NUMERIC_ATTRS,
+};

--- a/lib/utils/html-interactive-content.js
+++ b/lib/utils/html-interactive-content.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { classifyAttribute } = require('./glimmer-attr-presence');
+
 /**
  * HTML "interactive content" classification, authoritative per
  * [HTML Living Standard §3.2.5.2.7 Interactive content]
@@ -79,9 +81,18 @@ function isHtmlInteractiveContent(node, getTextAttrValue, options = {}) {
     return hasAttribute(node, 'usemap');
   }
 
-  // audio / video — interactive only when controls is present
+  // audio / video — interactive only when controls is present.
+  //
+  // `controls` is an HTML boolean attribute, so `controls={{false}}` /
+  // `{{null}}` / `{{undefined}}` cause Glimmer to omit the attribute at
+  // runtime (rows m6, m9, m10 by attribute-kind analogy + cross-attribute
+  // observation in docs/glimmer-attribute-behavior.md). AST-presence is
+  // wrong here — use classifyAttribute so the runtime presence drives the
+  // answer. `href` / `usemap` are plain string attrs that don't falsy-coerce
+  // (i4 analog), so AST-presence remains correct for them.
   if (tag === 'audio' || tag === 'video') {
-    return hasAttribute(node, 'controls');
+    const controlsAttr = node.attributes?.find((a) => a.name === 'controls');
+    return classifyAttribute(controlsAttr).presence === 'present';
   }
 
   return false;

--- a/package.json
+++ b/package.json
@@ -72,10 +72,12 @@
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",
     "html-tags": "^3.3.1",
+    "html-void-elements": "^3.0.0",
     "language-tags": "^1.0.9",
     "lodash.camelcase": "^4.3.0",
     "lodash.kebabcase": "^4.1.1",
     "mathml-tag-names": "^4.0.0",
+    "property-information": "^7.1.0",
     "requireindex": "^1.2.0",
     "snake-case": "^3.0.3",
     "svg-tags": "^1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       html-tags:
         specifier: ^3.3.1
         version: 3.3.1
+      html-void-elements:
+        specifier: ^3.0.0
+        version: 3.0.0
       language-tags:
         specifier: ^1.0.9
         version: 1.0.9
@@ -50,6 +53,9 @@ importers:
       mathml-tag-names:
         specifier: ^4.0.0
         version: 4.0.0
+      property-information:
+        specifier: ^7.1.0
+        version: 7.1.0
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -2313,6 +2319,9 @@ packages:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
 
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -3393,6 +3402,9 @@ packages:
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -6447,6 +6459,8 @@ snapshots:
 
   html-tags@5.1.0: {}
 
+  html-void-elements@3.0.0: {}
+
   http-cache-semantics@4.2.0: {}
 
   http-proxy-agent@4.0.1:
@@ -7692,6 +7706,8 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  property-information@7.1.0: {}
 
   proto-list@1.2.4: {}
 

--- a/tests/lib/rules/template-link-rel-noopener.js
+++ b/tests/lib/rules/template-link-rel-noopener.js
@@ -16,6 +16,17 @@ ruleTester.run('template-link-rel-noopener', rule, {
     '<template><a href="/">Link</a></template>',
     // target="_self" does not require rel
     '<template><a href="/some/where" target="_self"></a></template>',
+    // Bare-string-literal mustache on rel: renders the literal string per
+    // doc row i2 analog. Was previously a false-positive (rule treated all
+    // non-GlimmerTextNode rel values as empty); now correctly recognized.
+    '<template><a href="/" target="_blank" rel={{"noopener noreferrer"}}>Link</a></template>',
+    // Bare-string-literal mustache on target — i2 analog renders target="_blank".
+    '<template><a href="/" target={{"_blank"}} rel="noopener noreferrer">Link</a></template>',
+    // Dynamic rel — runtime value isn't statically known; conservative skip
+    // (no flag). Glimmer's "concat is never falsy" guarantees the attribute
+    // is rendered; the rule simply can't verify the tokens at lint time.
+    '<template><a href="/" target="_blank" rel={{this.relValue}}>Link</a></template>',
+    '<template><a href="/" target="_blank" rel="noopener {{this.extra}}">Link</a></template>',
   ],
   invalid: [
     // no rel attribute at all

--- a/tests/lib/rules/template-no-nested-interactive.js
+++ b/tests/lib/rules/template-no-nested-interactive.js
@@ -56,6 +56,14 @@ ruleTester.run('template-no-nested-interactive', rule, {
     '<template><button><input type="hidden"></button></template>',
     '<template><div tabindex=-1><button>Click me!</button></div></template>',
     '<template><div tabindex="1"><button></button></div></template>',
+    // Bare-mustache falsy literals on tabindex omit the attribute at runtime
+    // (doc rows t6, t7) — the wrapping element is NOT interactive, so nesting
+    // a button inside is valid. AST-presence-only check would have flagged.
+    '<template><button><div tabindex={{false}}></div></button></template>',
+    '<template><button><div tabindex={{null}}></div></button></template>',
+    '<template><button><div tabindex={{undefined}}></div></button></template>',
+    // Dynamic tabindex — runtime value is unknown; conservative skip.
+    '<template><button><div tabindex={{this.idx}}></div></button></template>',
     '<template><label><input></label></template>',
     // Config: ignoreUsemapAttribute (alias for ignoreUsemap)
     {
@@ -295,6 +303,10 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
     '<button><input type="hidden"></button>',
     '<div tabindex=-1><button>Click me!</button></div>',
     '<div tabindex="1"><button></button></div>',
+    // Bare-mustache falsy literals omit the attribute at runtime (t6, t7).
+    '<button><div tabindex={{false}}></div></button>',
+    '<button><div tabindex={{null}}></div></button>',
+    '<button><div tabindex={{this.idx}}></div></button>',
     '<label><input></label>',
     '<details><summary>Details</summary>Something small enough to escape casual notice.</details>',
     '<details> <summary>Details</summary>Something small enough to escape casual notice.</details>',

--- a/tests/lib/rules/template-require-context-role.js
+++ b/tests/lib/rules/template-require-context-role.js
@@ -56,6 +56,14 @@ ruleTester.run('template-require-context-role', rule, {
     '<template><div role="rowgroup"><div role="row">Item One</div></div></template>',
     '<template><div role="treegrid"><div role="row">Item One</div></div></template>',
     '<template><div aria-hidden="true" role="tablist"><div role="treeitem">Item One</div></div></template>',
+    // Mustache forms that render `aria-hidden="true"` at runtime (doc rows
+    // h7, h12, h14) — were previously false-positive flagged because the
+    // rule only matched the static text node. classifyAttribute resolves
+    // each form to value="true" and the parent is correctly recognized as
+    // hidden, suppressing the missing-context check.
+    '<template><div aria-hidden={{"true"}} role="tablist"><div role="treeitem">Item</div></div></template>',
+    '<template><div aria-hidden="{{true}}" role="tablist"><div role="treeitem">Item</div></div></template>',
+    '<template><div aria-hidden="{{\'true\'}}" role="tablist"><div role="treeitem">Item</div></div></template>',
     '<template><div role="grid"><div role="rowgroup">Item One</div></div></template>',
     '<template><div role="row"><div role="rowheader">Item One</div></div></template>',
     '<template><div role="tablist"><div role="tab">Item One</div></div></template>',
@@ -321,6 +329,10 @@ hbsRuleTester.run('template-require-context-role', rule, {
     '<div role="rowgroup"><div role="row">Item One</div></div>',
     '<div role="treegrid"><div role="row">Item One</div></div>',
     '<div aria-hidden="true" role="tablist"><div role="treeitem">Item One</div></div>',
+    // Mustache forms that render `aria-hidden="true"` at runtime (doc rows h7, h12, h14)
+    '<div aria-hidden={{"true"}} role="tablist"><div role="treeitem">Item</div></div>',
+    '<div aria-hidden="{{true}}" role="tablist"><div role="treeitem">Item</div></div>',
+    '<div aria-hidden="{{\'true\'}}" role="tablist"><div role="treeitem">Item</div></div>',
     '<div role="grid"><div role="rowgroup">Item One</div></div>',
     '<div role="row"><div role="rowheader">Item One</div></div>',
     '<div role="tablist"><div role="tab">Item One</div></div>',

--- a/tests/lib/rules/template-require-mandatory-role-attributes.js
+++ b/tests/lib/rules/template-require-mandatory-role-attributes.js
@@ -12,7 +12,15 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
     '<template><div aria-disabled="true" /></template>',
     '<template><div role="complementary" /></template>',
     '<template><div role="combobox" aria-expanded="false" aria-controls="ctrlId" /></template>',
-    '<template><div role="option" aria-selected={{false}} /></template>',
+    // Static aria-selected satisfies role="option"'s required ARIA. Both empty-
+    // value and any literal value are recognized — what matters is that the
+    // attribute is rendered at runtime.
+    '<template><div role="option" aria-selected="true" /></template>',
+    '<template><div role="option" aria-selected="false" /></template>',
+    // Bare-mustache string-literal role (i2 analog) renders `role="option"`
+    // and is now recognized as a static role token. The required aria-selected
+    // is satisfied by its static text value.
+    '<template><div role={{"option"}} aria-selected="true" /></template>',
     '<template><FakeComponent /></template>',
     '<template><FakeComponent role="fakerole" /></template>',
     '<template><CustomComponent role="checkbox" aria-checked="false" /></template>',
@@ -71,6 +79,29 @@ ruleTester.run('template-require-mandatory-role-attributes', rule, {
     },
     {
       code: '<template><div role="option"  /></template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    // Bare-mustache falsy aria attribute (h6) — Glimmer omits the attribute at
+    // runtime, so the required-ARIA check should NOT consider it satisfied.
+    // Previously this case was silently treated as valid (encoded as a passing
+    // fixture) because the rule counted AST attribute names, not runtime
+    // presence. Per docs/glimmer-attribute-behavior.md cross-attribute
+    // observations, aria-* is in the falsy-coercion list.
+    {
+      code: '<template><div role="option" aria-selected={{false}} /></template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    {
+      code: '<template><div role="option" aria-selected={{null}} /></template>',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    // Bare-mustache string-literal role (i2 analog) — now recognized; missing
+    // aria-selected is correctly flagged.
+    {
+      code: '<template><div role={{"option"}} /></template>',
       output: null,
       errors: [{ message: 'The attribute aria-selected is required by the role option' }],
     },
@@ -246,7 +277,10 @@ hbsRuleTester.run('template-require-mandatory-role-attributes', rule, {
     '<div aria-disabled="true" />',
     '<div role="complementary" />',
     '<div role="combobox" aria-expanded="false" aria-controls="ctrlId" />',
-    '<div role="option" aria-selected={{false}} />',
+    '<div role="option" aria-selected="true" />',
+    '<div role="option" aria-selected="false" />',
+    // i2 analog: bare-mustache string-literal role renders `role="option"`.
+    '<div role={{"option"}} aria-selected="true" />',
     '<FakeComponent />',
     '<FakeComponent role="fakerole" />',
     '<CustomComponent role="checkbox" aria-checked="false" />',
@@ -282,6 +316,23 @@ hbsRuleTester.run('template-require-mandatory-role-attributes', rule, {
     },
     {
       code: '<div role="option"  />',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    // Bare-mustache falsy aria attribute (h6, h9) — Glimmer omits at runtime.
+    {
+      code: '<div role="option" aria-selected={{false}} />',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    {
+      code: '<div role="option" aria-selected={{null}} />',
+      output: null,
+      errors: [{ message: 'The attribute aria-selected is required by the role option' }],
+    },
+    // Bare-mustache string-literal role (i2 analog) — now recognized.
+    {
+      code: '<div role={{"option"}} />',
       output: null,
       errors: [{ message: 'The attribute aria-selected is required by the role option' }],
     },

--- a/tests/lib/utils/glimmer-attr-presence-test.js
+++ b/tests/lib/utils/glimmer-attr-presence-test.js
@@ -1,0 +1,381 @@
+'use strict';
+
+const {
+  classifyAttribute,
+  inferAttrKind,
+  BOOLEAN_HTML_ATTRS,
+  NUMERIC_ATTRS,
+} = require('../../../lib/utils/glimmer-attr-presence');
+
+// Helpers to build minimal AttrNode-shaped objects for tests.
+function attr(name, value) {
+  return { name, value };
+}
+function textNode(chars) {
+  return { type: 'GlimmerTextNode', chars };
+}
+function bareMustache(path) {
+  return { type: 'GlimmerMustacheStatement', path };
+}
+function concat(parts) {
+  return { type: 'GlimmerConcatStatement', parts };
+}
+const boolLit = (v) => ({ type: 'GlimmerBooleanLiteral', value: v });
+const stringLit = (v) => ({ type: 'GlimmerStringLiteral', value: v });
+const numberLit = (v) => ({ type: 'GlimmerNumberLiteral', value: v });
+const nullLit = () => ({ type: 'GlimmerNullLiteral' });
+const undefinedLit = () => ({ type: 'GlimmerUndefinedLiteral' });
+const pathExpr = (original) => ({ type: 'GlimmerPathExpression', original });
+
+describe('inferAttrKind', () => {
+  it('classifies known HTML boolean attrs', () => {
+    expect(inferAttrKind('disabled')).toBe('boolean');
+    expect(inferAttrKind('muted')).toBe('boolean');
+    expect(inferAttrKind('autoplay')).toBe('boolean');
+    expect(inferAttrKind('hidden')).toBe('boolean');
+    expect(inferAttrKind('controls')).toBe('boolean');
+  });
+
+  it('classifies aria-* attributes', () => {
+    expect(inferAttrKind('aria-hidden')).toBe('aria');
+    expect(inferAttrKind('aria-label')).toBe('aria');
+    expect(inferAttrKind('aria-checked')).toBe('aria');
+  });
+
+  it('classifies known numeric attrs', () => {
+    expect(inferAttrKind('tabindex')).toBe('numeric');
+    expect(inferAttrKind('colspan')).toBe('numeric');
+  });
+
+  it('treats role as plain-string (not aria-coerced)', () => {
+    // Despite living conceptually with ARIA, role is a plain DOM string
+    // attribute and does NOT participate in falsy-coercion (per the
+    // cross-attribute observations in docs/glimmer-attribute-behavior.md).
+    expect(inferAttrKind('role')).toBe('plain-string');
+  });
+
+  it('classifies unknown attrs as plain-string', () => {
+    expect(inferAttrKind('autocomplete')).toBe('plain-string');
+    expect(inferAttrKind('href')).toBe('plain-string');
+    expect(inferAttrKind('id')).toBe('plain-string');
+    expect(inferAttrKind('for')).toBe('plain-string');
+    expect(inferAttrKind('type')).toBe('plain-string');
+  });
+});
+
+describe('classifyAttribute', () => {
+  describe('absent attribute', () => {
+    it('returns absent for null/undefined attrNode', () => {
+      expect(classifyAttribute(null)).toEqual({ presence: 'absent', value: null });
+      expect(classifyAttribute(undefined)).toEqual({ presence: 'absent', value: null });
+    });
+  });
+
+  describe('valueless attribute', () => {
+    it('returns present with empty string (doc rows d1, h1)', () => {
+      expect(classifyAttribute(attr('disabled', null))).toEqual({
+        presence: 'present',
+        value: '',
+      });
+      expect(classifyAttribute(attr('aria-hidden', undefined))).toEqual({
+        presence: 'present',
+        value: '',
+      });
+    });
+  });
+
+  describe('GlimmerTextNode (static text)', () => {
+    it('returns present with literal chars (doc rows m1-m4, h2-h4, d1, i1)', () => {
+      expect(classifyAttribute(attr('aria-hidden', textNode('true')))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+      expect(classifyAttribute(attr('autocomplete', textNode('off')))).toEqual({
+        presence: 'present',
+        value: 'off',
+      });
+      expect(classifyAttribute(attr('muted', textNode('false')))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+    });
+  });
+
+  describe('bare-mustache {{true}} / {{false}}', () => {
+    it('{{false}} on boolean attr → absent (doc rows m6, d3)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(boolLit(false))))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+      expect(classifyAttribute(attr('disabled', bareMustache(boolLit(false))))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{false}} on aria attr → absent (doc row h6)', () => {
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(boolLit(false))))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{false}} on numeric attr → absent (doc row t6)', () => {
+      expect(classifyAttribute(attr('tabindex', bareMustache(boolLit(false))))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{false}} on plain-string attr → present "false" (doc row i4)', () => {
+      expect(classifyAttribute(attr('autocomplete', bareMustache(boolLit(false))))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+      // role is plain-string (not aria-coerced) — bare {{false}} renders literal
+      expect(classifyAttribute(attr('role', bareMustache(boolLit(false))))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+    });
+
+    it('{{true}} on aria attr → present "" (doc row h5: renders aria-hidden="")', () => {
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(boolLit(true))))).toEqual({
+        presence: 'present',
+        value: '',
+      });
+    });
+
+    it('{{true}} on boolean / numeric / plain-string → present "true"', () => {
+      expect(classifyAttribute(attr('disabled', bareMustache(boolLit(true))))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+      expect(classifyAttribute(attr('muted', bareMustache(boolLit(true))))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+    });
+  });
+
+  describe('bare-mustache {{null}} / {{undefined}}', () => {
+    it('{{null}} on falsy-coerced kinds → absent (doc rows m9, d6, h9, t7)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(nullLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+      expect(classifyAttribute(attr('disabled', bareMustache(nullLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(nullLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+      expect(classifyAttribute(attr('tabindex', bareMustache(nullLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{undefined}} on falsy-coerced kinds → absent (doc rows m10, h10)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(undefinedLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(undefinedLit())))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{null}} / {{undefined}} on plain-string → unknown (untested in doc)', () => {
+      expect(classifyAttribute(attr('autocomplete', bareMustache(nullLit())))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+      expect(classifyAttribute(attr('autocomplete', bareMustache(undefinedLit())))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+    });
+  });
+
+  describe('bare-mustache string literal {{"x"}}', () => {
+    it('renders the literal value across all kinds (doc rows m7, m8, h7, h8, d4, d5, i2)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(stringLit('false'))))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(stringLit('true'))))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+      expect(classifyAttribute(attr('disabled', bareMustache(stringLit('false'))))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+      expect(classifyAttribute(attr('autocomplete', bareMustache(stringLit('off'))))).toEqual({
+        presence: 'present',
+        value: 'off',
+      });
+    });
+
+    it('handles empty string literal {{""}} as present empty', () => {
+      // Doc row m11: <video muted={{""}}> renders <video muted=""></video>
+      expect(classifyAttribute(attr('muted', bareMustache(stringLit(''))))).toEqual({
+        presence: 'present',
+        value: '',
+      });
+    });
+  });
+
+  describe('bare-mustache number literal {{0}} / {{N}}', () => {
+    it('{{0}} on boolean attr → absent (doc row m12)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(numberLit(0))))).toEqual({
+        presence: 'absent',
+        value: null,
+      });
+    });
+
+    it('{{0}} on numeric attr → present "0" (doc row t1, focusable)', () => {
+      expect(classifyAttribute(attr('tabindex', bareMustache(numberLit(0))))).toEqual({
+        presence: 'present',
+        value: '0',
+      });
+    });
+
+    it('{{-1}} / {{1}} render as stringified value', () => {
+      expect(classifyAttribute(attr('tabindex', bareMustache(numberLit(-1))))).toEqual({
+        presence: 'present',
+        value: '-1',
+      });
+      expect(classifyAttribute(attr('tabindex', bareMustache(numberLit(1))))).toEqual({
+        presence: 'present',
+        value: '1',
+      });
+    });
+  });
+
+  describe('bare-mustache dynamic path {{this.x}}', () => {
+    it('on falsy-coerced kinds → unknown (could be falsy at runtime)', () => {
+      expect(classifyAttribute(attr('muted', bareMustache(pathExpr('this.x'))))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+      expect(classifyAttribute(attr('aria-hidden', bareMustache(pathExpr('this.x'))))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+      expect(classifyAttribute(attr('tabindex', bareMustache(pathExpr('this.x'))))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+    });
+
+    it('on plain-string attr → present with unknown value', () => {
+      expect(classifyAttribute(attr('autocomplete', bareMustache(pathExpr('this.x'))))).toEqual({
+        presence: 'present',
+        value: null,
+      });
+    });
+  });
+
+  describe('GlimmerConcatStatement (concat-mustache)', () => {
+    it('"{{false}}" on boolean attr → present (concat sets IDL true regardless; doc row m14)', () => {
+      // Per doc m14, <video muted="{{false}}"> sets IDL muted=true.
+      // Conceptual presence is true; the resolved string is "false" but
+      // semantically the attribute is "on" for boolean kind.
+      expect(classifyAttribute(attr('muted', concat([bareMustache(boolLit(false))])))).toEqual({
+        presence: 'present',
+        value: 'false',
+      });
+    });
+
+    it('"{{false}}" on aria attr → present "false" (doc row h13, visible)', () => {
+      expect(
+        classifyAttribute(attr('aria-hidden', concat([bareMustache(boolLit(false))])))
+      ).toEqual({ presence: 'present', value: 'false' });
+    });
+
+    it('"{{true}}" on aria attr → present "true" (doc row h12, hidden)', () => {
+      expect(classifyAttribute(attr('aria-hidden', concat([bareMustache(boolLit(true))])))).toEqual(
+        { presence: 'present', value: 'true' }
+      );
+    });
+
+    it('"{{\'true\'}}" on aria → present "true" (doc row h14)', () => {
+      expect(
+        classifyAttribute(attr('aria-hidden', concat([bareMustache(stringLit('true'))])))
+      ).toEqual({ presence: 'present', value: 'true' });
+    });
+
+    it('multi-part static concat resolves the joined string', () => {
+      expect(
+        classifyAttribute(
+          attr(
+            'aria-label',
+            concat([textNode('prefix-'), bareMustache(stringLit('mid')), textNode('-suffix')])
+          )
+        )
+      ).toEqual({ presence: 'present', value: 'prefix-mid-suffix' });
+    });
+
+    it('concat with dynamic part → present, value null', () => {
+      expect(
+        classifyAttribute(
+          attr('aria-label', concat([textNode('prefix-'), bareMustache(pathExpr('this.x'))]))
+        )
+      ).toEqual({ presence: 'present', value: null });
+    });
+  });
+
+  describe('options.kind override', () => {
+    it('respects explicit kind over inferred', () => {
+      // Force aria semantics on a non-aria-prefixed attribute name
+      expect(
+        classifyAttribute(attr('myCustomAttr', bareMustache(boolLit(false))), { kind: 'aria' })
+      ).toEqual({ presence: 'absent', value: null });
+
+      // Force plain-string on a known boolean attribute
+      expect(
+        classifyAttribute(attr('disabled', bareMustache(boolLit(false))), {
+          kind: 'plain-string',
+        })
+      ).toEqual({ presence: 'present', value: 'false' });
+    });
+  });
+
+  describe('unknown AST node type', () => {
+    it('returns unknown for an unrecognized value type', () => {
+      expect(classifyAttribute(attr('foo', { type: 'GlimmerSubExpression' }))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+    });
+
+    it('returns unknown when bare-mustache has no path', () => {
+      expect(classifyAttribute(attr('foo', bareMustache(null)))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+    });
+  });
+});
+
+describe('exported sets', () => {
+  it('BOOLEAN_HTML_ATTRS contains the standard HTML boolean attributes', () => {
+    expect(BOOLEAN_HTML_ATTRS.has('disabled')).toBe(true);
+    expect(BOOLEAN_HTML_ATTRS.has('muted')).toBe(true);
+    expect(BOOLEAN_HTML_ATTRS.has('controls')).toBe(true);
+    expect(BOOLEAN_HTML_ATTRS.has('autoplay')).toBe(true);
+    expect(BOOLEAN_HTML_ATTRS.has('hidden')).toBe(true);
+    // Non-boolean attrs should not appear:
+    expect(BOOLEAN_HTML_ATTRS.has('id')).toBe(false);
+    expect(BOOLEAN_HTML_ATTRS.has('role')).toBe(false);
+  });
+
+  it('NUMERIC_ATTRS contains tabindex', () => {
+    expect(NUMERIC_ATTRS.has('tabindex')).toBe(true);
+  });
+});

--- a/tests/lib/utils/glimmer-attr-presence-test.js
+++ b/tests/lib/utils/glimmer-attr-presence-test.js
@@ -1,11 +1,6 @@
 'use strict';
 
-const {
-  classifyAttribute,
-  inferAttrKind,
-  BOOLEAN_HTML_ATTRS,
-  NUMERIC_ATTRS,
-} = require('../../../lib/utils/glimmer-attr-presence');
+const { classifyAttribute, inferAttrKind } = require('../../../lib/utils/glimmer-attr-presence');
 
 // Helpers to build minimal AttrNode-shaped objects for tests.
 function attr(name, value) {
@@ -60,6 +55,14 @@ describe('inferAttrKind', () => {
     expect(inferAttrKind('id')).toBe('plain-string');
     expect(inferAttrKind('for')).toBe('plain-string');
     expect(inferAttrKind('type')).toBe('plain-string');
+  });
+
+  it('is case-insensitive (HTML attribute names are case-insensitive)', () => {
+    expect(inferAttrKind('Disabled')).toBe('boolean');
+    expect(inferAttrKind('MUTED')).toBe('boolean');
+    expect(inferAttrKind('TabIndex')).toBe('numeric');
+    expect(inferAttrKind('ARIA-Hidden')).toBe('aria');
+    expect(inferAttrKind('Aria-Label')).toBe('aria');
   });
 });
 
@@ -146,7 +149,7 @@ describe('classifyAttribute', () => {
       });
     });
 
-    it('{{true}} on boolean / numeric / plain-string → present "true"', () => {
+    it('{{true}} on boolean → present "true" (verified m5, d2)', () => {
       expect(classifyAttribute(attr('disabled', bareMustache(boolLit(true))))).toEqual({
         presence: 'present',
         value: 'true',
@@ -154,6 +157,17 @@ describe('classifyAttribute', () => {
       expect(classifyAttribute(attr('muted', bareMustache(boolLit(true))))).toEqual({
         presence: 'present',
         value: 'true',
+      });
+    });
+
+    it('{{true}} on numeric / plain-string → unknown (untested in doc)', () => {
+      expect(classifyAttribute(attr('tabindex', bareMustache(boolLit(true))))).toEqual({
+        presence: 'unknown',
+        value: null,
+      });
+      expect(classifyAttribute(attr('autocomplete', bareMustache(boolLit(true))))).toEqual({
+        presence: 'unknown',
+        value: null,
       });
     });
   });
@@ -282,14 +296,25 @@ describe('classifyAttribute', () => {
   });
 
   describe('GlimmerConcatStatement (concat-mustache)', () => {
-    it('"{{false}}" on boolean attr → present (concat sets IDL true regardless; doc row m14)', () => {
+    it('"{{false}}" on boolean attr → present "true" (concat sets IDL true regardless; doc row m14)', () => {
       // Per doc m14, <video muted="{{false}}"> sets IDL muted=true.
-      // Conceptual presence is true; the resolved string is "false" but
-      // semantically the attribute is "on" for boolean kind.
+      // Surface canonical "true" rather than the inner literal so callers
+      // checking `value === 'false'` for "off" don't get the wrong answer.
       expect(classifyAttribute(attr('muted', concat([bareMustache(boolLit(false))])))).toEqual({
         presence: 'present',
-        value: 'false',
+        value: 'true',
       });
+      expect(classifyAttribute(attr('disabled', concat([bareMustache(boolLit(false))])))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+      expect(classifyAttribute(attr('muted', concat([bareMustache(stringLit('false'))])))).toEqual({
+        presence: 'present',
+        value: 'true',
+      });
+      expect(
+        classifyAttribute(attr('muted', concat([textNode('x'), bareMustache(boolLit(false))])))
+      ).toEqual({ presence: 'present', value: 'true' });
     });
 
     it('"{{false}}" on aria attr → present "false" (doc row h13, visible)', () => {
@@ -360,22 +385,5 @@ describe('classifyAttribute', () => {
         value: null,
       });
     });
-  });
-});
-
-describe('exported sets', () => {
-  it('BOOLEAN_HTML_ATTRS contains the standard HTML boolean attributes', () => {
-    expect(BOOLEAN_HTML_ATTRS.has('disabled')).toBe(true);
-    expect(BOOLEAN_HTML_ATTRS.has('muted')).toBe(true);
-    expect(BOOLEAN_HTML_ATTRS.has('controls')).toBe(true);
-    expect(BOOLEAN_HTML_ATTRS.has('autoplay')).toBe(true);
-    expect(BOOLEAN_HTML_ATTRS.has('hidden')).toBe(true);
-    // Non-boolean attrs should not appear:
-    expect(BOOLEAN_HTML_ATTRS.has('id')).toBe(false);
-    expect(BOOLEAN_HTML_ATTRS.has('role')).toBe(false);
-  });
-
-  it('NUMERIC_ATTRS contains tabindex', () => {
-    expect(NUMERIC_ATTRS.has('tabindex')).toBe(true);
   });
 });

--- a/tests/lib/utils/html-interactive-content-test.js
+++ b/tests/lib/utils/html-interactive-content-test.js
@@ -111,6 +111,61 @@ describe('isHtmlInteractiveContent', () => {
     it('<video> without controls is NOT interactive', () => {
       expect(isHtmlInteractiveContent(makeNode('video'), getTextAttrValue)).toBe(false);
     });
+
+    // Bare-mustache falsy on `controls` (per cross-attribute observation in
+    // docs/glimmer-attribute-behavior.md) causes Glimmer to omit the attribute
+    // at runtime — so `<video controls={{false}}>` has NO controls and is not
+    // interactive. Was previously a false positive: AST-presence treated it
+    // as having controls.
+    it('<video controls={{false}}> is NOT interactive (Glimmer omits the attribute)', () => {
+      const node = {
+        tag: 'video',
+        attributes: [
+          {
+            name: 'controls',
+            value: {
+              type: 'GlimmerMustacheStatement',
+              path: { type: 'GlimmerBooleanLiteral', value: false },
+            },
+          },
+        ],
+      };
+      expect(isHtmlInteractiveContent(node, getTextAttrValue)).toBe(false);
+    });
+
+    it('<audio controls={{null}}> is NOT interactive', () => {
+      const node = {
+        tag: 'audio',
+        attributes: [
+          {
+            name: 'controls',
+            value: { type: 'GlimmerMustacheStatement', path: { type: 'GlimmerNullLiteral' } },
+          },
+        ],
+      };
+      expect(isHtmlInteractiveContent(node, getTextAttrValue)).toBe(false);
+    });
+
+    it('<video controls="{{false}}"> IS interactive (concat sets IDL true regardless)', () => {
+      const node = {
+        tag: 'video',
+        attributes: [
+          {
+            name: 'controls',
+            value: {
+              type: 'GlimmerConcatStatement',
+              parts: [
+                {
+                  type: 'GlimmerMustacheStatement',
+                  path: { type: 'GlimmerBooleanLiteral', value: false },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      expect(isHtmlInteractiveContent(node, getTextAttrValue)).toBe(true);
+    });
   });
 
   describe('elements NOT in §3.2.5.2.7', () => {


### PR DESCRIPTION
## Summary

Adopts the new `lib/utils/glimmer-attr-presence.js` shared utility (introduced in #2769) across **4 master rules** that misclassified attributes whose source-AST shape differs from runtime rendering. Each fix is a separate commit with regression-locking test cases that demonstrate the bug being closed.

> **Depends on #2769** ([docs/glimmer-attribute-behavior](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/glimmer-attribute-behavior.md) + the `classifyAttribute` utility). This PR's diff includes #2769's commits until that lands; rebase will clean it up.

## Why

A recent empirical audit against `ember-source@6.12` (documented in #2769) verified that several Glimmer attribute-rendering forms produce runtime DOM that doesn't match the obvious AST reading. Five common audit footguns that affect master rules:

1. Bare-mustache `attr={{"false"}}` is JS-truthy → renders `attr="false"` (kept), not omitted.
2. Concat `attr="{{X}}"` is **never** falsy at runtime — IDL property is set true regardless of inner literal value.
3. Bare-mustache `attr={{false}}` / `{{null}}` / `{{undefined}}` on boolean / ARIA / numeric attributes causes Glimmer to *omit* the attribute at runtime — `findAttr` AST-presence is the wrong check.
4. Plain string attrs (e.g. `role`, `autocomplete`, `href`) do **not** participate in falsy-coercion — bare `{{false}}` renders the literal `"false"`.
5. `aria-hidden={{true}}` (h5) renders `aria-hidden=""` (contested per ARIA), *not* `aria-hidden="true"` (h7).

Each commit fixes one rule against the specific row IDs from the verified reference table.

## Per-rule changes (one commit each)

### 1. `template-link-rel-noopener` — recognize mustache forms; conservative-skip dynamic `rel`

**Before:** `target` and `rel` were inspected as `GlimmerTextNode` only. Dynamic `rel={{this.x}}` (or concat `rel="x{{y}}"`) was treated as the empty string and false-positive flagged. `target={{"_blank"}}` (i2 analog) was silently missed.

**After:**
- Both attributes flow through `classifyAttribute`. Static text, bare-string-literal, and concat-with-literals all map to the same resolved string.
- Dynamic `rel` values are conservative-skipped (the doc's *concat is never falsy* observation guarantees the attribute is rendered; lint can't verify the tokens).
- Autofix becomes report-only when `rel` is present in a non-text form, to avoid duplicate-attribute or binding-destruction.

**Doc rows cited:** i1, i2, i3, *concat is never falsy*.

### 2. `template-no-nested-interactive` — `tabindex` AST-presence → effective-runtime check (rows t6, t7)

**Before:** `hasAttr(node, 'tabindex')` returned true for any AST attribute, including bare `{{false}}` / `{{null}}` / `{{undefined}}` that Glimmer omits at runtime. False-positive flag on `<button><div tabindex={{false}}></div></button>`.

**After:** new `isTabindexEffectivelySet` helper uses `classifyAttribute` and returns true only when the attribute will actually render. Both call sites in `isInteractive` and `isInteractiveOnlyFromTabindex` are updated.

**Doc rows cited:** t6, t7.

Other `hasAttr` sites (`usemap`, `disabled`, `contenteditable`) are intentionally unchanged — `usemap` and `disabled` are non-falsy-coerced or already value-checked; the doc-verified bug is `tabindex`.

### 3. `template-require-context-role` — `aria-hidden` truthy-detection broadened (rows h3, h7, h12, h14)

**Before:** `hasAriaHiddenTrue` matched only `aria-hidden="true"` as a `GlimmerTextNode`. Mustache forms that render the same `aria-hidden="true"` at runtime were missed:
- `aria-hidden={{"true"}}` (h7)
- `aria-hidden="{{true}}"` (h12)
- `aria-hidden="{{'true'}}"` (h14)

Each was a false positive: a child with `role="treeitem"` inside a hidden ancestor was reported as missing-context, even though the entire subtree is hidden from AT.

**After:** `presence === 'present' && value === 'true'` via `classifyAttribute` matches exactly h3/h7/h12/h14. Note that h5 (bare `{{true}}` → renders `aria-hidden=""`, contested) deliberately does *not* match.

**Doc rows cited:** h3 (existing), h7, h12, h14. h5 deliberately excluded.

### 4. `template-require-mandatory-role-attributes` — two bugs (rows i2, h6, h9, h10)

Bug 4a — bare-mustache string-literal `role={{"option"}}` was silently skipped (treated as dynamic) even though it renders `role="option"`. The required-ARIA validation never ran for these forms.

Bug 4b — required-ARIA satisfaction was checked by AST attribute *name* presence. The fixture `<div role="option" aria-selected={{false}} />` was encoded as a passing valid case despite the attribute being omitted at runtime per row h6 (the bug was locked into the test suite).

**After:**
- `getStaticRolesFromElement` uses `classifyAttribute` — recognizes i1 / i2 / i3 forms uniformly.
- The aria-attribute filter excludes attributes whose `classifyAttribute(attr).presence === 'absent'`, so bare `aria-foo={{false}}` no longer pretends to satisfy the role.
- The bug-encoding fixture moved from valid to invalid; replaced with `aria-selected="true"` / `"false"` static-value cases that preserve the original "aria-selected satisfies role=option" intent.

**Doc rows cited:** i1, i2, i3 (role classification); h6, h9, h10 (aria-* falsy-coercion); cross-attribute observation on falsy-coercion list.

### Not changed: `template-require-iframe-title`

The audit pass against this rule flagged `title={{""}}` as a REAL_BUG. On closer inspection the rule already handles bare-mustache string-literal title via `processStaticTitle` (lib/rules/template-require-iframe-title.js:156-158), and the case is asserted at tests/lib/rules/template-require-iframe-title.js:41 (`emptyTitle` error). No change needed; audit finding withdrawn.

## Test plan

- [x] All four rules pass their own test suites (existing + new fixtures).
- [x] Full suite: 9552 / 9552 passing.
- [x] Prettier and ESLint clean.
- [ ] Visual diff review against #2769 (this PR includes its commits until #2769 merges).

## Doc cross-references

Every fix commit message cites the specific doc rows from `docs/glimmer-attribute-behavior.md` (introduced in #2769) that justify the new behavior. Where the new behavior diverges from a doc-verified row, the rule code carries an inline comment with the row ID so future maintainers can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)