### PR TITLE
fix(template-no-nested-interactive): More useful error message

### DIFF
--- a/lib/rules/template-no-nested-interactive.js
+++ b/lib/rules/template-no-nested-interactive.js
@@ -49,6 +49,50 @@ function isMenuItemNode(node) {
   return MENUITEM_ROLES.has(getTextAttr(node, 'role'));
 }
 
+// Build the element-description string used in error messages. Surfaces the
+// attribute that *makes* the element interactive when the bare tag would be
+// uninformative — e.g. `<div role="menu">`, `<div contenteditable>`, or
+// `<div tabindex="0">`. For self-explanatory native interactive tags
+// (button, input, a, etc.) the tag alone is returned, since adding the
+// triggering attribute would be redundant noise.
+function describeInteractive(node) {
+  const tag = node.tag;
+
+  const role = getTextAttr(node, 'role');
+  if (role && INTERACTIVE_ROLES.has(role)) {
+    return `${tag} role="${role}"`;
+  }
+
+  if (hasAttr(node, 'contenteditable')) {
+    const ce = getTextAttr(node, 'contenteditable');
+    const normalized = typeof ce === 'string' ? ce.trim().toLowerCase() : ce;
+    if (normalized !== 'false') {
+      // Surface 'plaintext-only' as a distinct spec keyword; collapse the
+      // empty string, 'true', and the bare attribute to a uniform form.
+      if (normalized === 'plaintext-only') {
+        return `${tag} contenteditable="plaintext-only"`;
+      }
+      return `${tag} contenteditable`;
+    }
+  }
+
+  // Tabindex-only interactivity: the tag (typically <div>/<span>) carries no
+  // signal on its own, so surface the tabindex value. Skip for elements that
+  // are already interactive via tag/usemap/canvas — for those the tag itself
+  // is the source of interactivity and the tabindex would be redundant.
+  if (
+    hasAttr(node, 'tabindex') &&
+    !isHtmlInteractiveContent(node, getTextAttr, { ignoreUsemap: false }) &&
+    tag !== 'canvas' &&
+    !(tag === 'object' && hasAttr(node, 'usemap'))
+  ) {
+    const tabindex = getTextAttr(node, 'tabindex');
+    return tabindex === undefined ? `${tag} tabindex` : `${tag} tabindex="${tabindex}"`;
+  }
+
+  return tag;
+}
+
 function isAllowedDetailsChild(childNode, parentEntry) {
   if (parentEntry.tag !== 'details') {
     return false;
@@ -222,7 +266,7 @@ module.exports = {
               context.report({
                 node,
                 messageId: 'nested',
-                data: { parent: parentEntry.tag, child: node.tag },
+                data: { parent: parentEntry.describe, child: describeInteractive(node) },
               });
             }
             parentEntry.interactiveChildCount++;
@@ -244,7 +288,7 @@ module.exports = {
             context.report({
               node,
               messageId: 'nested',
-              data: { parent: parentEntry.tag, child: node.tag },
+              data: { parent: parentEntry.describe, child: describeInteractive(node) },
             });
           }
         }
@@ -252,7 +296,12 @@ module.exports = {
         // Push interactive elements to the stack, but tabindex-only elements
         // should not become parent interactive nodes
         if (currentIsInteractive && !isInteractiveOnlyFromTabindex(node)) {
-          interactiveStack.push({ tag: node.tag, node, interactiveChildCount: 0 });
+          interactiveStack.push({
+            tag: node.tag,
+            node,
+            describe: describeInteractive(node),
+            interactiveChildCount: 0,
+          });
         }
       },
 

--- a/tests/lib/rules/template-no-nested-interactive.js
+++ b/tests/lib/rules/template-no-nested-interactive.js
@@ -274,6 +274,18 @@ ruleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [{ messageId: 'nested' }],
     },
+    // Error message surfaces the attribute that makes a <div> parent interactive
+    // (regression test for the original report against `<div role="menu">`).
+    {
+      code: '<template><div role="menu"><input type="search"></div></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <input> inside <div role="menu">.',
+        },
+      ],
+    },
   ],
 });
 
@@ -422,7 +434,9 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
     {
       code: '<button><div tabindex="1"></div></button>',
       output: null,
-      errors: [{ message: 'Do not nest interactive element <div> inside <button>.' }],
+      errors: [
+        { message: 'Do not nest interactive element <div tabindex="1"> inside <button>.' },
+      ],
     },
     {
       code: '<button><img usemap=""></button>',
@@ -465,6 +479,59 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
       code: '<canvas tabindex="0"><button>Click</button></canvas>',
       output: null,
       errors: [{ message: 'Do not nest interactive element <button> inside <canvas>.' }],
+    },
+    // Error message surfaces the attribute that makes a <div> parent interactive,
+    // so authors can see *why* the rule fired without inspecting the rule source.
+    {
+      code: '<div role="menu"><input type="search"></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <input> inside <div role="menu">.',
+        },
+      ],
+    },
+    {
+      code: '<div role="menu"><button type="button">Delete</button></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <button> inside <div role="menu">.',
+        },
+      ],
+    },
+    {
+      code: '<div contenteditable><button>Edit</button></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <button> inside <div contenteditable>.',
+        },
+      ],
+    },
+    {
+      code: '<div contenteditable="plaintext-only"><button>Edit</button></div>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <button> inside <div contenteditable="plaintext-only">.',
+        },
+      ],
+    },
+    // Child-side enrichment: a <div role="button"> child surfaces its role too.
+    {
+      code: '<button><div role="button">Inner</div></button>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Do not nest interactive element <div role="button"> inside <button>.',
+        },
+      ],
     },
   ],
 });

--- a/tests/lib/rules/template-no-nested-interactive.js
+++ b/tests/lib/rules/template-no-nested-interactive.js
@@ -293,8 +293,7 @@ ruleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Do not nest interactive element <input> inside <div role="menu">.',
+          message: 'Do not nest interactive element <input> inside <div role="menu">.',
         },
       ],
     },
@@ -456,9 +455,7 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
     {
       code: '<button><div tabindex="1"></div></button>',
       output: null,
-      errors: [
-        { message: 'Do not nest interactive element <div tabindex="1"> inside <button>.' },
-      ],
+      errors: [{ message: 'Do not nest interactive element <div tabindex="1"> inside <button>.' }],
     },
     {
       code: '<button><img usemap=""></button>',
@@ -509,8 +506,7 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Do not nest interactive element <input> inside <div role="menu">.',
+          message: 'Do not nest interactive element <input> inside <div role="menu">.',
         },
       ],
     },
@@ -519,8 +515,7 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Do not nest interactive element <button> inside <div role="menu">.',
+          message: 'Do not nest interactive element <button> inside <div role="menu">.',
         },
       ],
     },
@@ -529,8 +524,7 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Do not nest interactive element <button> inside <div contenteditable>.',
+          message: 'Do not nest interactive element <button> inside <div contenteditable>.',
         },
       ],
     },
@@ -550,8 +544,7 @@ hbsRuleTester.run('template-no-nested-interactive', rule, {
       output: null,
       errors: [
         {
-          message:
-            'Do not nest interactive element <div role="button"> inside <button>.',
+          message: 'Do not nest interactive element <div role="button"> inside <button>.',
         },
       ],
     },


### PR DESCRIPTION
## Summary

The current `template-no-nested-interactive` error message gives only the bare tag of each side:

> Do not nest interactive element \<button\> inside \<div\>.

When the parent is a `<div>` (or `<span>`, etc.) the message hides *why* it was classified as interactive — authors have to inspect the rule source or work backwards from `INTERACTIVE_ROLES` / `isHtmlInteractiveContent` to figure out that `role`, `contenteditable`, or `tabindex` triggered the rule.

This PR makes the message name the disambiguating attribute when the bare tag would be uninformative:

```
Do not nest interactive element <button> inside <div role="menu">.
Do not nest interactive element <input> inside <div contenteditable>.
Do not nest interactive element <div tabindex="1"> inside <button>.
Do not nest interactive element <div role="button"> inside <button>.
```

Self-explanatory native interactive tags (`button`, `input`, `a`, `label`, `select`, `textarea`, `details`, `summary`, `embed`, `iframe`, `audio[controls]`, `video[controls]`, `img[usemap]`, `canvas`, `object[usemap]`) keep their bare-tag form, since the tag itself already conveys interactivity. Applied symmetrically on both the parent and child sides.

The change is purely diagnostic — no rule firing/non-firing decisions are altered.

## Implementation

- New `describeInteractive(node)` helper at module scope. Surfaces:
  - `role="X"` when `X` is in `INTERACTIVE_ROLES`
  - `contenteditable` (and `contenteditable="plaintext-only"` when that exact spec keyword is used; `''` / `'true'` / bare attribute collapse to `contenteditable`)
  - `tabindex="X"` when interactivity comes from tabindex on a tag that isn't otherwise interactive
- Stored as `describe` on each `interactiveStack` entry at push time, used as `data.parent`.
- Computed fresh for the child at report time, used as `data.child`.

## Test impact

- 99 existing tests pass.
- One existing message assertion updated (`<button><div tabindex="1"></div></button>` → child now says `<div tabindex="1">` instead of `<div>`).
- New invalid cases added covering `role="menu"` parent (regression test for the original report), `contenteditable` parent, `contenteditable="plaintext-only"` parent, and `role="button"` child enrichment.

## Test plan

- [x] `pnpm exec vitest run tests/lib/rules/template-no-nested-interactive.js` — 99/99 pass
- [x] Verified MDN-canonical menu pattern (`<ul role="menu"><li role="presentation"><a role="menuitem" href>`) still passes the rule
- [x] Verified `<li role="menuitem"><button>` correctly fires with the new message naming the parent's role