### PR TITLE
fix: scope of template-no-multiple-empty-lines rule

### DIFF
--- a/lib/rules/template-no-multiple-empty-lines.js
+++ b/lib/rules/template-no-multiple-empty-lines.js
@@ -37,11 +37,12 @@ module.exports = {
     const sourceCode = context.sourceCode;
 
     return {
-      Program(node) {
+      GlimmerTemplate(node) {
         const text = sourceCode.getText();
         const lines = text.split('\n');
 
-        // Precompute the character offset of the start of each line.
+        // Precompute the character offset of the start of each line so the
+        // fixer can splice excess blank lines out of the original source.
         const lineOffsets = [];
         let offset = 0;
         for (const line of lines) {
@@ -49,9 +50,9 @@ module.exports = {
           offset += line.length + 1; // +1 for the '\n'
         }
 
-        // Swallow the final newline, as some editors add it automatically
-        // and we don't want it to cause an issue.
-        const effectiveLines = lines.length > 0 && lines.at(-1) === '' ? lines.slice(0, -1) : lines;
+        // Inclusive zero-based line range covered by this template.
+        const firstLineIdx = node.loc.start.line - 1;
+        const lastLineIdx = node.loc.end.line - 1;
 
         let emptyCount = 0;
         let firstEmptyLine = -1;
@@ -82,7 +83,8 @@ module.exports = {
           });
         }
 
-        for (const [index, line] of effectiveLines.entries()) {
+        for (let index = firstLineIdx; index <= lastLineIdx && index < lines.length; index++) {
+          const line = lines[index];
           if (line.trim() === '') {
             if (emptyCount === 0) {
               firstEmptyLine = index;
@@ -97,9 +99,9 @@ module.exports = {
           }
         }
 
-        // Handle trailing empty lines at the end of the effective content
+        // Handle trailing empty lines at the end of the template's range.
         if (emptyCount > max) {
-          reportExcess(effectiveLines.length);
+          reportExcess(Math.min(lastLineIdx + 1, lines.length));
         }
       },
     };

--- a/tests/lib/rules/template-no-multiple-empty-lines.js
+++ b/tests/lib/rules/template-no-multiple-empty-lines.js
@@ -50,6 +50,14 @@ r
 
 <div>bar</div>
 </template>`,
+    // Plain JS files have no <template> tags — multiple blank lines in
+    // surrounding code (or inside unrelated template literals) must not be
+    // flagged.
+    'const a = 1;\n\n\n\nconst b = 2;\n',
+    "import Foo from 'foo';\n\n\n\n\nconst html = `<div></div>\n\n\n\n<div></div>`;\n",
+    // Blank lines surrounding a <template> in .gjs (outside the template body)
+    // are unrelated to template formatting and must not be flagged either.
+    "import Component from '@glimmer/component';\n\n\n\nexport default class Foo extends Component {\n  <template>Hi</template>\n}\n",
   ],
 
   invalid: [


### PR DESCRIPTION
The `template-` prefix of this rule suggests it should only apply to `<template>` content. However, it was also applying to multiline strings in vanilla JS.