### PR TITLE
Upgrade ember-eslint-parser to ^0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "axobject-query": "^4.1.0",
     "css-tree": "^3.0.1",
     "editorconfig": "^3.0.2",
-    "ember-eslint-parser": "^0.14.0",
+    "ember-eslint-parser": "^0.14.2",
     "ember-rfc176-data": "^0.3.18",
     "eslint-utils": "^3.0.0",
     "estraverse": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       ember-eslint-parser:
-        specifier: ^0.14.0
-        version: 0.14.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.62.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^0.14.2
+        version: 0.14.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.62.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-rfc176-data:
         specifier: ^0.3.18
         version: 0.3.18
@@ -1823,8 +1823,8 @@ packages:
   electron-to-chromium@1.5.376:
     resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
 
-  ember-eslint-parser@0.14.0:
-    resolution: {integrity: sha512-lFF19I8DhsAdNfUIV5ljC+2lHVUp1So1iQE1/ZbhMwHCq/c1s2G2XnUtal/DxLM/L+ZCwU0VTf2hwDqvqCxkZw==}
+  ember-eslint-parser@0.14.2:
+    resolution: {integrity: sha512-7hHPr4VbM/KGXXtJiIMthVhHsa38CQzsY2dWOgT0L1FmZ2es59Up651pYLTUUC5A4k2a04PkMeV8BPuB9KZBiQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@babel/eslint-parser': ^7.28.6 || ^8.0.0
@@ -1835,8 +1835,8 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  ember-estree@0.6.4:
-    resolution: {integrity: sha512-/0+JLFt200RB/gUfLfRALTFWby6fGS7Bu+NN985Y8gadEntX4KoiYHhOl2hkzvy+AmBi+PbHxBa9QVCV7K/PUg==}
+  ember-estree@0.6.10:
+    resolution: {integrity: sha512-5nItZGzvxHgoCdASQbn9qBzF4sdjSggUeZpXdihAanmYWm6XkObT/TlUvakYtoKret1/8gm0jNLwNPqZYwHtCw==}
 
   ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
@@ -5228,7 +5228,7 @@ snapshots:
 
   '@typescript-eslint/project-service@8.61.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.61.1
       debug: 4.4.3
       typescript: 5.9.3
@@ -5895,12 +5895,12 @@ snapshots:
 
   electron-to-chromium@1.5.376: {}
 
-  ember-eslint-parser@0.14.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.62.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3):
+  ember-eslint-parser@0.14.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.62.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
       content-tag: 4.2.0
-      ember-estree: 0.6.4
+      ember-estree: 0.6.10
       eslint-scope: 9.1.2
       html-tags: 5.1.0
       mathml-tag-names: 4.0.0
@@ -5911,7 +5911,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  ember-estree@0.6.4:
+  ember-estree@0.6.10:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/syntax': 0.95.0


### PR DESCRIPTION
Upgrades `ember-eslint-parser` from `^0.14.0` to `^0.14.2`.

0.14.2 pulls in ember-estree 0.6.10, which fixes a placeholder-length overflow in the `<template>` → JS transform: templates containing 12+ backticks or dollar signs (e.g. in `{{! ... }}` comments) leaked a raw `static{`...`}` block into the AST with shifted offsets. For users of this plugin, that surfaced as a false `no-unused-expressions` error on valid `.gts` files — see ember-tooling/ember-eslint-parser#230.

No fixture changes needed: `master`'s expected parse-error messages already match the content-tag 4.2 diagnostics that 0.14.2 resolves to. The `tests/lib/rules-preprocessor/` suite passes locally against 0.14.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)