### PR TITLE
fix(template-no-unsupported-role-attributes): skip elements with a dynamic role

### DIFF
--- a/docs/rules/template-no-unsupported-role-attributes.md
+++ b/docs/rules/template-no-unsupported-role-attributes.md
@@ -32,6 +32,15 @@ This rule **allows** the following:
 </template>
 ```
 
+An element whose `role` is a dynamic expression is skipped: its role is not
+knowable at lint time, so no ARIA attribute on it can be judged against a role.
+
+```gjs
+<template>
+  <div role={{if @useCase "dialog"}} aria-modal={{if @useCase "true"}}></div>
+</template>
+```
+
 ## References
 
 - [Using ARIA, Roles, States, and Properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)

--- a/lib/rules/template-no-unsupported-role-attributes.js
+++ b/lib/rules/template-no-unsupported-role-attributes.js
@@ -97,12 +97,20 @@ function getImplicitRole(node) {
   return elementRoles.get(bestKey)[0];
 }
 
+const UNKNOWN_ROLE = Symbol('unknown role');
+
+// Returns the statically known role, `undefined` when the element carries no
+// `role` attribute (so the caller should fall back to the implicit role), or
+// UNKNOWN_ROLE when a `role` attribute is present but its value is dynamic.
 function getExplicitRole(node) {
   const roleAttr = node.attributes?.find((attr) => attr.name === 'role');
-  if (roleAttr && roleAttr.value?.type === 'GlimmerTextNode') {
-    return roleAttr.value.chars.trim();
+  if (!roleAttr) {
+    return undefined;
   }
-  return null;
+  if (roleAttr.value?.type !== 'GlimmerTextNode') {
+    return UNKNOWN_ROLE;
+  }
+  return roleAttr.value.chars.trim();
 }
 
 function removeRangeWithAdjacentWhitespace(sourceText, range) {
@@ -171,7 +179,15 @@ module.exports = {
         let role = getExplicitRole(node);
         let element;
 
-        if (!role) {
+        // A dynamic `role` leaves the element's role unknowable at lint time.
+        // Falling back to the implicit role would judge every aria-* attribute
+        // against a role the element may not have, and the fixer would then
+        // delete attributes that are valid for the role it resolves to.
+        if (role === UNKNOWN_ROLE) {
+          return;
+        }
+
+        if (role === undefined) {
           element = node.tag;
           role = getImplicitRole(node);
         }

--- a/tests/lib/rules/template-no-unsupported-role-attributes.js
+++ b/tests/lib/rules/template-no-unsupported-role-attributes.js
@@ -32,6 +32,15 @@ const validHbs = [
   '<input type="password" aria-checked="false" />',
   '<input type="password" aria-selected="true" />',
 
+  // A dynamic `role` makes the element's role unknowable at lint time, so no
+  // aria-* attribute can be judged against it. Falling back to the implicit
+  // role here would flag attributes that are valid for the role the expression
+  // actually resolves to.
+  '<div role={{this.role}} aria-modal="true"></div>',
+  '<div role="{{this.role}}" aria-modal="true"></div>',
+  '<div role={{if @useCase "dialog"}} aria-modal={{if @useCase "true"}}></div>',
+  '<span role={{@role}} aria-level="2"></span>',
+
   // <input type="text"> without a list attribute is a textbox — aria-required,
   // aria-readonly, aria-placeholder are all supported.
   '<input type="text" aria-required="true" />',


### PR DESCRIPTION
Reported during an ember-template-lint → eslint-plugin-ember migration.

## Problem

An element carrying a dynamic `role` was treated as if it had no `role` attribute at all. The rule fell back to the element's *implicit* role and judged every `aria-*` attribute against it — and the fixer then deleted them.

```hbs
<div role={{if @useCase "dialog"}} aria-modal={{if @useCase "true"}}></div>
```

reported:

> The attribute aria-modal is not supported by the element div with the implicit role of generic

and `--fix` rewrote it to `<div role={{if @useCase "dialog"}}></div>`, silently dropping `aria-modal`.

`ember-template-lint` reports nothing here: it branches on the *presence* of the `role` attribute before looking at its value, so a dynamic value leaves `role` undefined and the element is skipped — it never falls through to the implicit role. The port collapsed those two branches into one, losing the distinction between "no `role` attribute" and "`role` attribute present but not statically resolvable".

## Fix

`getExplicitRole` now distinguishes the three cases, and a dynamic role short-circuits the element instead of falling back to the implicit role.

## Verification

- New valid cases cover `role={{this.role}}`, `role="{{this.role}}"`, `role={{if ...}}` and `role={{@role}}`, in both `.gjs` and `.hbs` mode.
- Differentially fuzzed against `ember-template-lint` 7.9.3 over 41,280 generated `role`/`aria-*` combinations (every non-abstract `aria-query` role × 8 host elements × 10 attribute-value forms × 6 aria probes): **zero** cases where upstream reports and this plugin stays silent. The remaining differences are the pre-existing deliberate ones — this plugin also normalizes whitespace-padded and uppercase role values.