### PR TITLE
fix(template-no-template-lint-directives): unquote rule names when converting

### DIFF
--- a/lib/rules/template-no-template-lint-directives.js
+++ b/lib/rules/template-no-template-lint-directives.js
@@ -69,6 +69,21 @@ module.exports = {
   },
 };
 
+// ember-template-lint accepts quoted rule names in its directives and strips
+// the quotes before matching, so `{{! template-lint-disable "no-log" }}` is a
+// live directive. Mirror its `unquote` exactly: strip only when the first and
+// last character are the same quote character.
+function unquote(name) {
+  if (name.length < 3) {
+    return name;
+  }
+  const first = name[0];
+  if (first === name.at(-1) && (first === '"' || first === "'")) {
+    return name.slice(1, -1);
+  }
+  return name;
+}
+
 function convertComment(rawComment) {
   const match = rawComment.match(DIRECTIVE_COMMENT);
   if (!match) {
@@ -82,7 +97,7 @@ function convertComment(rawComment) {
     .trim()
     .split(/\s+/)
     .filter(Boolean)
-    .map((r) => `ember/template-${r}`)
+    .map((r) => `ember/template-${unquote(r)}`)
     .join(', ');
   const body = rules ? `eslint-${action} ${rules}` : `eslint-${action}`;
   // Emit symmetric markers regardless of what the source did.

--- a/tests/lib/rules/template-no-template-lint-directives.js
+++ b/tests/lib/rules/template-no-template-lint-directives.js
@@ -44,6 +44,37 @@ ruleTester.run('template-no-template-lint-directives', rule, {
       output: '<template>{{! eslint-enable ember/template-no-log }}{{log "x"}}</template>',
       errors: [{ messageId: 'convert' }],
     },
+    // ember-template-lint unquotes each rule name (single or double quotes),
+    // so quoted names are live directives in migrating codebases and must
+    // convert to bare eslint rule names.
+    {
+      code: '<template>{{! template-lint-disable "no-log" }}{{log "x"}}</template>',
+      output: '<template>{{! eslint-disable ember/template-no-log }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
+    {
+      code: '<template>{{! template-lint-disable \'no-log\' }}{{log "x"}}</template>',
+      output: '<template>{{! eslint-disable ember/template-no-log }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
+    {
+      code: '<template>{{! template-lint-disable "no-log" no-debugger }}{{log "x"}}</template>',
+      output:
+        '<template>{{! eslint-disable ember/template-no-log, ember/template-no-debugger }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
+    {
+      code: '<template>{{! template-lint-enable "no-log" }}{{log "x"}}</template>',
+      output: '<template>{{! eslint-enable ember/template-no-log }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
+    // Mismatched or lone quotes are not a quoted name — upstream's unquote
+    // only strips when the first and last character are the same quote.
+    {
+      code: '<template>{{! template-lint-disable "no-log\' }}{{log "x"}}</template>',
+      output: '<template>{{! eslint-disable ember/template-"no-log\' }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
     // Directive inside an element's opening tag is lifted to before the
     // element so the eslint-disable scope covers the line where the
     // violation is reported.


### PR DESCRIPTION
Reported during an ember-template-lint → eslint-plugin-ember migration.

## Quoted rule names are valid in *both* linters

- **ember-template-lint** maps its `unquote` helper over every name in a `template-lint-disable` / `template-lint-enable` list ([`_base.js`](https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/rules/_base.js)). Verified against 7.9.3: `{{! template-lint-disable "no-invalid-role" }}` suppresses `no-invalid-role`, while `{{! template-lint-disable "no-positive-tabindex" }}` does not — so quotes really are stripped before matching, and this isn't the "no arguments disables everything" path.
- **ESLint core** unquotes too: `/* eslint-disable "no-console" */` suppresses `no-console`, `/* eslint-disable "no-debugger" */` does not, and `/* eslint-disable "zzz-nope" */` reports ``Definition for rule 'zzz-nope' was not found`` — quotes already stripped in the message.

So this isn't an exotic ember-template-lint-ism being dragged into ESLint; both sides accept it.

It also occurs in the wild. A narrow GitHub code search for the quoted form in `.hbs` returns 16 files (a floor — code search only indexes public repos), including the official [`ember-learn/ember-website`](https://github.com/ember-learn/ember-website):

```hbs
{{!-- template-lint-disable "no-forbidden-elements" --}}   ember-learn/ember-website
{{! template-lint-disable "attribute-indentation" }}       mirego/accent
{{!template-lint-disable "no-negated-condition"}}          burningmantech/ranger-clubhouse-web
<label {{!template-lint-disable "no-nested-interactive"}}> NYCPlanning/labs-streets
```

## Problem

The conversion fixer passed the name through verbatim, so the `ember/template-` prefix landed *outside* the quotes:

```hbs
{{! template-lint-disable "no-log" }}   →   {{! eslint-disable ember/template-"no-log" }}
```

That name is quoted in the middle, so neither linter's unquoting applies. Verified — it does not suppress:

> Definition for rule `ember/template-"no-log"` was not found. | Unexpected log statement in template.

`eslint --fix` over a codebase using quoted names therefore silently converted working suppressions into dead ones, re-reporting violations the author had deliberately disabled. That is the exact failure this rule exists to prevent.

## Fix

Unquote each name before prefixing, mirroring upstream's `unquote` semantics: strip only when the first and last character are the same quote character (single or double), so `"no-log'` and other mismatched-quote inputs still pass through unchanged.

## Tests

Double-quoted, single-quoted, mixed quoted/unquoted lists, `template-lint-enable`, and the mismatched-quote pass-through case.