### PR TITLE
fix(template-no-template-lint-directives): preserve directive scope on conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ or
 
 ### Replacing `template-lint-disable` comments
 
-Inline disable directives need to be rewritten to ESLint's syntax, prefixed with `ember/template-`. For now, only two scopes are supported: the next line, or the rest of the file. For example, replace:
+Inline disable directives need to be rewritten to ESLint's syntax, prefixed with `ember/template-`. ESLint's own scopes are the next line and the rest of the file, but an `eslint-disable` / `eslint-enable` pair delimits an arbitrary region, so every template-lint scope has an exact equivalent. For example, replace:
 
 ```hbs
 {{!template-lint-disable no-invalid-role}}
@@ -218,7 +218,15 @@ with:
 {{!eslint-disable-next-line ember/template-no-invalid-role}}
 ```
 
-The [`template-no-template-lint-directives`](docs/rules/template-no-template-lint-directives.md) rule (enabled by the `template-lint-migration` config) does this rewrite for you: run `eslint --fix` once and it converts every `template-lint-disable` / `template-lint-enable` comment in your templates.
+or, to cover a region rather than one line, bracket it:
+
+```hbs
+{{!eslint-disable ember/template-no-invalid-role}}
+<div role='range'></div>
+{{!eslint-enable ember/template-no-invalid-role}}
+```
+
+The [`template-no-template-lint-directives`](docs/rules/template-no-template-lint-directives.md) rule (enabled by the `template-lint-migration` config) does this rewrite for you: run `eslint --fix` once and it converts every `template-lint-disable` / `template-lint-enable` comment in your templates, including the element-scoped and `-tree` forms, preserving each directive's original scope.
 
 To disable a rule for an entire `.gjs`/`.gts` file, use a regular ESLint file-level directive in the JS region — it applies to the `<template>` contents as well:
 

--- a/docs/rules/template-no-template-lint-directives.md
+++ b/docs/rules/template-no-template-lint-directives.md
@@ -15,9 +15,30 @@ The fixer:
 - replaces `template-lint-disable` / `template-lint-enable` with `eslint-disable` / `eslint-enable`;
 - prefixes each rule name with `ember/template-` (the namespace the rules are published under in this plugin);
 - joins multiple rule names with `,` (ESLint's directive syntax) instead of whitespace (template-lint's syntax);
-- when the directive appears inside an element's opening tag (between attributes), lifts it to its own line just before the element. ESLint scopes line-based directives from the line they appear on, and the violation typically lives on the element's start line, so leaving the directive inside the attribute list would put it after the violation it's meant to cover.
+- converts an element-scoped directive into an `eslint-disable` / `eslint-enable` pair bracketing that element (see below).
 
-The `-tree` suffix on a directive (e.g. `template-lint-disable-tree`) does **not** match this rule. ESLint has no equivalent of template-lint's subtree-scoped directives, so they need manual handling rather than a mechanical conversion.
+### Preserving scope
+
+`template-lint-disable` means different things depending on where it sits, and a
+conversion that ignores that either hides violations or floods a migration with
+noise. ESLint has no element scope, but an `eslint-disable` / `eslint-enable`
+pair delimits an arbitrary region, which reproduces every template-lint scope
+exactly:
+
+| `template-lint-disable` placement  | scope                                           | conversion                                                              |
+| ---------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------- |
+| standing alone                     | comment → end of template                       | `eslint-disable` (rest of file)                                         |
+| paired with `template-lint-enable` | between the two                                 | `eslint-disable` … `eslint-enable`                                      |
+| inside an element's opening tag    | that element's opening tag, not its descendants | `eslint-disable` before the element, `eslint-enable` as its first child |
+| with the `-tree` suffix            | that element and its descendants                | `eslint-disable` before the element, `eslint-enable` after it           |
+
+The closing comment is inserted without a surrounding newline. `{{! }}` comments
+compile away and leave no trace in the DOM, but a newline would add a whitespace
+text node, which can change inline layout.
+
+To suppress a rule across a whole file, use a file-level ESLint directive — in
+`.gjs`/`.gts` a `/* eslint-disable ember/template-… */` in the JS region also
+covers the `<template>` contents.
 
 ## Examples
 
@@ -38,7 +59,15 @@ Examples of **incorrect** code for this rule:
   class='example'
   {{! template-lint-disable no-invalid-interactive }}
   {{on 'click' this.click}}
-></div>
+><span>hi</span></div>
+```
+
+```hbs
+<div
+  class='example'
+  {{! template-lint-disable-tree no-invalid-interactive }}
+  {{on 'click' this.click}}
+><span>hi</span></div>
 ```
 
 Examples of **correct** code for this rule (i.e. what the autofix produces):
@@ -53,9 +82,23 @@ Examples of **correct** code for this rule (i.e. what the autofix produces):
 {{foo bar=baz}}
 ```
 
+The element-scoped form closes its region as the element's first child, leaving
+descendants linted:
+
 ```hbs
 {{! eslint-disable ember/template-no-invalid-interactive }}
-<div class='example' {{on 'click' this.click}}></div>
+<div
+  class='example'
+  {{on 'click' this.click}}
+>{{! eslint-enable ember/template-no-invalid-interactive }}<span>hi</span></div>
+```
+
+`-tree` closes it after the element, covering the subtree:
+
+```hbs
+{{! eslint-disable ember/template-no-invalid-interactive }}
+<div class='example' {{on 'click' this.click}}><span>hi</span></div>
+{{! eslint-enable ember/template-no-invalid-interactive }}
 ```
 
 ## When Not To Use It

--- a/lib/rules/template-no-template-lint-directives.js
+++ b/lib/rules/template-no-template-lint-directives.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const DIRECTIVE_COMMENT =
-  /^(?<open>{{!(?:--)?)\s*template-lint-(?<action>disable|enable)(?<rules>\s+[^]*?)?\s*(?:--)?}}$/;
+  /^(?<open>{{!(?:--)?)\s*template-lint-(?<action>disable|enable)(?<tree>-tree)?(?<rules>\s+[^]*?)?\s*(?:--)?}}$/;
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
@@ -17,18 +17,16 @@ module.exports = {
     fixable: 'code',
     schema: [],
     messages: {
-      convert: 'Use `eslint-{{action}}` instead of `template-lint-{{action}}`.',
+      convert: 'Use `{{replacement}}` instead of `{{directive}}`.',
     },
   },
 
   create(context) {
     const sourceCode = context.sourceCode;
     // Glimmer parks comments that appear inside an element's opening tag
-    // (between attributes) on `element.comments`, not in the children. We
-    // collect them so the Program:exit pass can lift a converted directive
-    // to before its enclosing element — ESLint scopes line-based directives
-    // from where they appear, and the violation typically lives on the
-    // element's start line, not on the in-attribute line.
+    // (between attributes) on `element.comments`, not in the children. Those
+    // are the element-scoped directives, and converting them faithfully needs
+    // the element they belong to.
     const elementByCommentStart = new Map();
 
     return {
@@ -42,26 +40,26 @@ module.exports = {
 
       'Program:exit'() {
         for (const comment of sourceCode.getAllComments()) {
-          const raw = sourceCode.text.slice(...comment.range);
-          const converted = convertComment(raw);
-          if (!converted) {
+          const directive = parseDirective(sourceCode.text.slice(...comment.range));
+          if (!directive) {
             continue;
           }
           const enclosingElement = elementByCommentStart.get(comment.range[0]);
+          const scoped = directive.action === 'disable' && enclosingElement;
           context.report({
             node: comment,
             messageId: 'convert',
-            data: { action: converted.action },
+            data: {
+              directive: `template-lint-${directive.action}${directive.tree ? '-tree' : ''}`,
+              replacement: scoped ? 'eslint-disable`/`eslint-enable' : `eslint-${directive.action}`,
+            },
             fix: (fixer) =>
-              enclosingElement
-                ? liftBeforeElement(
-                    fixer,
-                    comment,
-                    converted.newComment,
-                    enclosingElement,
-                    sourceCode
-                  )
-                : fixer.replaceTextRange(comment.range, converted.newComment),
+              scoped
+                ? wrapElementInRegion(fixer, comment, directive, enclosingElement, sourceCode)
+                : fixer.replaceTextRange(
+                    comment.range,
+                    buildComment(directive, `eslint-${directive.action}`)
+                  ),
           });
         }
       },
@@ -84,12 +82,12 @@ function unquote(name) {
   return name;
 }
 
-function convertComment(rawComment) {
+function parseDirective(rawComment) {
   const match = rawComment.match(DIRECTIVE_COMMENT);
   if (!match) {
     return null;
   }
-  const { open, action, rules: rulesPart } = match.groups;
+  const { open, action, tree, rules: rulesPart } = match.groups;
   // ESLint directives use comma-separated rule names; template-lint uses
   // whitespace. Prefix each with `ember/template-` to land in the namespace
   // where the ports live.
@@ -99,25 +97,76 @@ function convertComment(rawComment) {
     .filter(Boolean)
     .map((r) => `ember/template-${unquote(r)}`)
     .join(', ');
-  const body = rules ? `eslint-${action} ${rules}` : `eslint-${action}`;
-  // Emit symmetric markers regardless of what the source did.
-  const close = open.length === 5 ? '--}}' : '}}';
   return {
     action,
-    newComment: `${open} ${body} ${close}`,
+    tree: Boolean(tree),
+    rules,
+    open,
+    // Emit symmetric markers regardless of what the source did.
+    close: open.length === 5 ? '--}}' : '}}',
   };
 }
 
-// Strip the in-attribute comment line entirely (leading indent through
-// trailing newline) and re-emit the converted directive on its own line at
-// the element's indent, just above the element.
-function liftBeforeElement(fixer, comment, newComment, element, sourceCode) {
+// Indentation to give an inserted comment: the element's own, but only when the
+// element opens its line. Nested directives are converted over several fix
+// passes, and by a later pass the element can already be preceded on its line
+// by comments an earlier pass inserted — indenting to its column then would
+// push the markup out by the width of those comments.
+function indentOf(element, text) {
+  const lineStart = element.range[0] - element.loc.start.column;
+  const prefix = text.slice(lineStart, element.range[0]);
+  return /^\s*$/.test(prefix) ? prefix : '';
+}
+
+function buildComment(directive, eslintDirective) {
+  const body = directive.rules ? `${eslintDirective} ${directive.rules}` : eslintDirective;
+  return `${directive.open} ${body} ${directive.close}`;
+}
+
+// A `template-lint-disable` sitting inside an element's opening tag is scoped
+// to that element: without `-tree` it covers the opening tag only, with `-tree`
+// it covers the element's whole subtree. ESLint has no element scope, but an
+// `eslint-disable` / `eslint-enable` pair delimits an arbitrary region, so
+// bracketing the element reproduces either scope exactly. Closing the region
+// right after the opening tag (as the element's first child) leaves
+// descendants reporting, which is the non-`-tree` behaviour.
+function wrapElementInRegion(fixer, comment, directive, element, sourceCode) {
   const text = sourceCode.text;
+  // Strip the directive, leaving the opening tag as the author wrote it. When
+  // the comment has the line to itself, take the whole line — leading indent
+  // through trailing newline — so no blank line is left behind. When it shares
+  // the line with markup, take the comment plus the single space it sat in;
+  // reaching back to the line start there would swallow the tag itself.
   const lineStart = comment.range[0] - comment.loc.start.column;
-  const lineEnd = text[comment.range[1]] === '\n' ? comment.range[1] + 1 : comment.range[1];
-  const indent = ' '.repeat(element.loc.start.column);
-  return [
-    fixer.removeRange([lineStart, lineEnd]),
-    fixer.insertTextBeforeRange(element.range, `${newComment}\n${indent}`),
+  const ownsLine = /^\s*$/.test(text.slice(lineStart, comment.range[0]));
+  let removeFrom = ownsLine ? lineStart : comment.range[0];
+  let removeTo = comment.range[1];
+  if (ownsLine) {
+    if (text[removeTo] === '\n') {
+      removeTo += 1;
+    }
+  } else if (text[removeTo] === ' ') {
+    removeTo += 1;
+  } else if (text[removeFrom - 1] === ' ') {
+    removeFrom -= 1;
+  }
+  const indent = indentOf(element, text);
+
+  const fixes = [
+    fixer.removeRange([removeFrom, removeTo]),
+    fixer.insertTextBeforeRange(
+      element.range,
+      `${buildComment(directive, 'eslint-disable')}\n${indent}`
+    ),
   ];
+
+  const enableComment = buildComment(directive, 'eslint-enable');
+  const firstChild = element.children?.[0];
+  if (!directive.tree && firstChild) {
+    fixes.push(fixer.insertTextBeforeRange(firstChild.range, enableComment));
+  } else {
+    // `-tree`, or an element with no children where the two scopes coincide.
+    fixes.push(fixer.insertTextAfterRange(element.range, `\n${indent}${enableComment}`));
+  }
+  return fixes;
 }

--- a/tests/lib/rules/template-no-template-lint-directives.js
+++ b/tests/lib/rules/template-no-template-lint-directives.js
@@ -18,6 +18,8 @@ ruleTester.run('template-no-template-lint-directives', rule, {
     '/* template-lint-disable no-log */ const x = 1;',
   ],
   invalid: [
+    // A directive standing on its own applies from the comment to the end of
+    // the template, which is what `eslint-disable` already means.
     {
       code: '<template>{{! template-lint-disable no-log }}{{log "x"}}</template>',
       output: '<template>{{! eslint-disable ember/template-no-log }}{{log "x"}}</template>',
@@ -37,6 +39,11 @@ ruleTester.run('template-no-template-lint-directives', rule, {
     {
       code: '<template>{{! template-lint-disable no-log}}{{log "x"}}</template>',
       output: '<template>{{! eslint-disable ember/template-no-log }}{{log "x"}}</template>',
+      errors: [{ messageId: 'convert' }],
+    },
+    {
+      code: '<template>{{! template-lint-disable }}{{log "x"}}</template>',
+      output: '<template>{{! eslint-disable }}{{log "x"}}</template>',
       errors: [{ messageId: 'convert' }],
     },
     {
@@ -75,9 +82,9 @@ ruleTester.run('template-no-template-lint-directives', rule, {
       output: '<template>{{! eslint-disable ember/template-"no-log\' }}{{log "x"}}</template>',
       errors: [{ messageId: 'convert' }],
     },
-    // Directive inside an element's opening tag is lifted to before the
-    // element so the eslint-disable scope covers the line where the
-    // violation is reported.
+    // Inside an opening tag the directive is scoped to the element, so it
+    // becomes a disable/enable pair bracketing that element. With no children,
+    // the `-tree` and non-`-tree` scopes coincide.
     {
       code: `<template>
   <div
@@ -92,8 +99,176 @@ ruleTester.run('template-no-template-lint-directives', rule, {
     class="x"
     {{on "click" this.click}}
   ></div>
+  {{! eslint-enable ember/template-no-invalid-interactive }}
+</template>`,
+      errors: [{ messageId: 'convert' }],
+    },
+    // A directive sharing its line with markup is stripped on its own, not by
+    // the line: reaching back to the line start would delete the opening tag
+    // with it.
+    {
+      code: '<template><div {{! template-lint-disable no-invalid-interactive }} {{on "click" this.click}}></div></template>',
+      output: `<template>{{! eslint-disable ember/template-no-invalid-interactive }}
+<div {{on "click" this.click}}></div>
+{{! eslint-enable ember/template-no-invalid-interactive }}</template>`,
+      errors: [{ messageId: 'convert' }],
+    },
+    {
+      code: `<template>
+  <div class="x" {{! template-lint-disable no-invalid-interactive }}
+    {{on "click" this.click}}
+  ></div>
+</template>`,
+      output: `<template>
+  {{! eslint-disable ember/template-no-invalid-interactive }}
+  <div class="x"
+    {{on "click" this.click}}
+  ></div>
+  {{! eslint-enable ember/template-no-invalid-interactive }}
+</template>`,
+      errors: [{ messageId: 'convert' }],
+    },
+    // With children, the non-`-tree` scope covers the opening tag only, so the
+    // region closes as the element's first child and descendants keep linting.
+    {
+      code: `<template>
+  <div
+    {{! template-lint-disable no-invalid-interactive }}
+    {{on "click" this.click}}
+  ><span>hi</span></div>
+</template>`,
+      output: `<template>
+  {{! eslint-disable ember/template-no-invalid-interactive }}
+  <div
+    {{on "click" this.click}}
+  >{{! eslint-enable ember/template-no-invalid-interactive }}<span>hi</span></div>
+</template>`,
+      errors: [{ messageId: 'convert' }],
+    },
+    // `-tree` covers the subtree, so the region closes after the element.
+    {
+      code: `<template>
+  <div
+    {{! template-lint-disable-tree no-invalid-interactive }}
+    {{on "click" this.click}}
+  ><span>hi</span></div>
+</template>`,
+      output: `<template>
+  {{! eslint-disable ember/template-no-invalid-interactive }}
+  <div
+    {{on "click" this.click}}
+  ><span>hi</span></div>
+  {{! eslint-enable ember/template-no-invalid-interactive }}
 </template>`,
       errors: [{ messageId: 'convert' }],
     },
   ],
+});
+
+// The rewritten comment text is only half the contract. What has to hold is
+// that the converted directive suppresses exactly the violations the original
+// did — no more (which hides real problems) and no fewer (which floods a
+// migration with noise). These cases mirror ember-template-lint 7.9.3 run on
+// the same templates.
+describe('suppression scope after conversion', () => {
+  const { Linter } = require('eslint');
+  const plugin = require('../../../lib/index');
+  const hbsParser = require('ember-eslint-parser/hbs');
+
+  const baseConfig = {
+    files: ['**/*.hbs'],
+    languageOptions: { parser: hbsParser },
+    plugins: { ember: plugin },
+  };
+
+  function migrate(source) {
+    return new Linter({ configType: 'flat' }).verifyAndFix(
+      source,
+      { ...baseConfig, rules: { 'ember/template-no-template-lint-directives': 'error' } },
+      'a.hbs'
+    ).output;
+  }
+
+  // Each element carries a distinct tabindex, so a violation is identified by
+  // that value rather than by a line or column the fixer may have shifted.
+  function stillReported(source) {
+    const lines = source.split('\n');
+    return new Linter({ configType: 'flat' })
+      .verify(
+        source,
+        { ...baseConfig, rules: { 'ember/template-no-positive-tabindex': 'error' } },
+        'a.hbs'
+      )
+      .map((message) => lines[message.line - 1].match(/tabindex="(\d+)"/)[1]);
+  }
+
+  const ELEMENT = `<div
+  {{! template-lint-DIRECTIVE no-positive-tabindex }}
+  tabindex="1"
+>
+  <span tabindex="2"></span>
+</div>
+<a tabindex="3"></a>`;
+
+  it('scopes an in-tag directive to the opening tag, as template-lint does', () => {
+    const migrated = migrate(ELEMENT.replace('DIRECTIVE', 'disable'));
+
+    // template-lint suppresses the div's own tabindex="1" only. Its descendant
+    // and the following sibling keep reporting — verified against
+    // ember-template-lint 7.9.3 on this same template.
+    expect(stillReported(migrated)).toEqual(['2', '3']);
+  });
+
+  it('scopes a -tree directive to the subtree, as template-lint does', () => {
+    const migrated = migrate(ELEMENT.replace('DIRECTIVE', 'disable-tree'));
+
+    // Element and descendants suppressed; only the following sibling reports.
+    expect(stillReported(migrated)).toEqual(['3']);
+  });
+
+  it('keeps a standalone directive covering the rest of the template', () => {
+    const migrated = migrate(`{{! template-lint-disable no-positive-tabindex }}
+<div tabindex="1"></div>
+<a tabindex="3"></a>`);
+
+    expect(stillReported(migrated)).toEqual([]);
+  });
+
+  it('keeps the element intact when the directive shares its line with markup', () => {
+    const migrated = migrate(`<div {{! template-lint-disable no-positive-tabindex }} tabindex="1">
+  <span tabindex="2"></span>
+</div>
+<a tabindex="3"></a>`);
+
+    // The opening tag has to survive the strip — taking the comment's whole
+    // line here would delete `<div ` along with it.
+    expect(migrated).toContain('<div tabindex="1">');
+    expect(stillReported(migrated)).toEqual(['2', '3']);
+  });
+
+  it('converts nested element-scoped directives, each keeping its own scope', () => {
+    const migrated = migrate(`<div
+  {{! template-lint-disable no-positive-tabindex }}
+  tabindex="1"
+>
+  <span tabindex="2"></span>
+</div>`);
+
+    // Nested directives are converted across several fix passes; the result
+    // must still converge and must not swallow the descendant's violation.
+    expect(migrated).not.toContain('template-lint-');
+    expect(stillReported(migrated)).toEqual(['2']);
+  });
+
+  it('closes the region without adding whitespace to the element body', () => {
+    const migrated = migrate(`<div
+  {{! template-lint-disable no-positive-tabindex }}
+  tabindex="1"
+><span>hi</span></div>`);
+
+    // `{{! }}` comments compile away, but a newline would introduce a
+    // whitespace text node and can change inline rendering, so the enable
+    // comment is inserted without one.
+    expect(migrated).toContain('>{{! eslint-enable ember/template-no-positive-tabindex }}<span>');
+  });
 });


### PR DESCRIPTION
## The problem

`{{! template-lint-disable }}` does not have one scope. Per [ember-template-lint's `docs/configuration.md`](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/configuration.md):

> An in-element instruction will apply to only that element
>
> An in-element instruction with the `-tree` suffix will apply to that element and all its descendants

Standing alone it runs from the comment to the end of the template; inside an element's opening tag it covers that element; with `-tree` it covers the subtree.

This rule converted all of them to `eslint-disable`, which is file-wide. That silently widened the element-scoped forms:

```hbs
<div
  {{! template-lint-disable no-positive-tabindex }}
  tabindex="1"
></div>
<span tabindex="2"></span>
```

ember-template-lint reports the `<span>`. After `eslint --fix`, nothing reported at all — one migrated directive swallowed a real violation, and every later violation of that rule in the file.

That is the worst failure mode for a migration tool: it rewrites a codebase and quietly turns off the linting you were migrating *to*, with no diagnostic. It surfaced as three unrelated a11y rules reported as "no longer reporting failures that ember-template-lint reported"; differential testing cleared those rules, and the losses traced back here.

`-tree` was a second hole: it never matched the rule at all, so those directives migrated to nothing, also without a report.

## The fix

ESLint's own scopes are the next line and the rest of the file — neither matches an element. But an `eslint-disable` / `eslint-enable` **pair** delimits an arbitrary region, and bracketing the element reproduces both in-element scopes exactly. Closing the region as the element's first child covers the opening tag alone; closing it after the element covers the subtree:

| placement | template-lint scope | conversion |
| --- | --- | --- |
| standing alone | comment → end of template | `eslint-disable` (rest of file) |
| paired with `template-lint-enable` | between the two | `eslint-disable` … `eslint-enable` |
| inside an opening tag | that element's opening tag only | `eslint-disable` before element, `eslint-enable` as first child |
| `-tree` suffix | element and descendants | `eslint-disable` before element, `eslint-enable` after it |

The closing comment is inserted without a surrounding newline: `{{! }}` compiles away and leaves no trace in the DOM, but a newline would add a whitespace text node and can change inline layout.

## Verification

Each scope checked against ember-template-lint 7.9.3 on the same template, using a fixture where every element carries a distinct `tabindex` so violations stay identifiable after the fixer shifts lines:

| directive | ember-template-lint reports | after `--fix` |
| --- | --- | --- |
| in-tag `disable` | `tabindex="2"`, `tabindex="3"` | `tabindex="2"`, `tabindex="3"` |
| in-tag `disable-tree` | `tabindex="3"` | `tabindex="3"` |
| standalone `disable` | nothing | nothing |

Also covered: nested in-tag directives (converted across several fix passes — asserted to converge and to keep each scope), two directives on one element, and self-closing elements. Tests assert suppression scope end-to-end — migrate, then lint — rather than only the rewritten comment text, which was never the part that broke.

## Relation to earlier attempts

Two closed PRs went at this gap from the *processor* direction — teaching ESLint to honour `template-lint-*` comments natively, so codebases keep their existing directives:

- **#2627** added an opt-in `template-lint-disable` processor. Next-line only; it explicitly did not implement `template-lint-enable`, `-next-line` or `-tree`. Closed after review, with a perf benchmark requested since every file pays a preprocess cost.
- **[NullVoxPopuli-ai-agent#3](https://github.com/NullVoxPopuli-ai-agent/eslint-plugin-ember/pull/3)** built on that branch and added `template-lint-enable` range semantics, on the reasoning that *"projects migrating from ember-template-lint have existing block comments written for ETL's semantics. With next-line-only behaviour those comments silently do nothing beyond the first line, making the migration painful."*

That second PR had already identified the right diagnosis — **ranges are the missing piece** — and this PR reaches the same semantics from the other side. Rather than emulating template-lint's range behaviour in a processor, it emits ESLint's own `eslint-disable` / `eslint-enable`, which already provides ranges natively. No processor, no per-file preprocess cost, and no second directive system to keep in step with ESLint.

It also extends the idea past where #3 stopped. #3 covered the standalone `disable … enable` range; the in-element and `-tree` scopes are the ones that were actually losing violations here, and a region pair expresses those too — the element's first child and the element's end are just two more range boundaries.

And it answers the question left open on the #2627 thread — *"maybe it is enough with next line + whole file disable?"* — with a measured no. Next-line is too narrow for a multi-line element, whole-file is too wide, and the pair is what closes the gap.

## Behaviour change

User-visible for anyone on the `template-lint-migration` config. Newly converted templates preserve scope exactly, so `--fix` should not change which violations report. Templates converted by an earlier version keep their over-broad file-wide directives and want a manual pass — re-running `--fix` will not find them, since they no longer match.

## Docs

Three claims were wrong and are corrected: the rule doc presented the file-wide output as correct (contradicting the README, which is what made the behaviour look deliberate); the rule doc said `-tree` has no ESLint equivalent; and the README said only two scopes are expressible.