### PR TITLE
fix: warn on call expression defaults in avoid-leaking-state rule

### DIFF
--- a/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -37,7 +37,9 @@ function isAllowed(value) {
     ember.isFunctionExpression(value) ||
     types.isLiteral(value) ||
     types.isIdentifier(value) ||
-    types.isCallExpression(value) ||
+    // NOTE: CallExpression intentionally removed — myProp: A() or
+    // myProp: EmberObject.create() creates a shared instance across all
+    // object instances, leaking state. See issue #300.
     types.isBinaryExpression(value) ||
     types.isTemplateLiteral(value) ||
     types.isTaggedTemplateExpression(value) ||

--- a/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
+++ b/tests/lib/rules/avoid-leaking-state-in-ember-objects.js
@@ -273,5 +273,27 @@ eslintTester.run('avoid-leaking-state-in-ember-objects', rule, {
         },
       ],
     },
+    {
+      // myProp: A() creates a shared instance across all Ember object instances
+      code: 'export default Foo.extend({ someProp: A() });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
+    {
+      // EmberObject.create() as a default property leaks shared state
+      code: 'export default Foo.extend({ someProp: EmberObject.create() });',
+      output: null,
+      errors: [
+        {
+          message:
+            'Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Fixes #300 — `myProp: A()` and `myProp: EmberObject.create()` were not flagged by the `avoid-leaking-state-in-ember-objects` rule, even though they create a shared object instance across all instances of the Ember object, leaking state just like an inline array/object literal.

**Root cause:** `isAllowed()` had `types.isCallExpression(value)` in its allow-list.

**Fix:** Remove `CallExpression` from the allow-list. Users who intentionally call a factory that returns a primitive can add the property name to `ignoredProperties`.

## Test plan
- [ ] `npx eslint --rulesdir lib/rules .` — no regressions
- [x] Add test: `myProp: A()` → rule fires
- [x] Add test: `myProp: EmberObject.create()` → rule fires
- [ ] `myProp: () => {}` → rule does not fire (still allowed as FunctionExpression)