### PR TITLE
fix(no-array-prototype-extensions): handle Promise.withResolvers

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -720,6 +720,15 @@ module.exports = {
 
         const nodeInitializedTo = getNodeOrNodeFromVariable(node.callee.object, scopeManager);
         if (
+          node.callee.property.name === 'reject' &&
+          ['Promise.withResolvers()', 'window.Promise.withResolvers()'].includes(
+            getName(nodeInitializedTo, true)
+          )
+        ) {
+          return;
+        }
+
+        if (
           nodeInitializedTo.type === 'NewExpression' &&
           nodeInitializedTo.callee.type === 'Identifier' &&
           KNOWN_NON_ARRAY_CLASSES.has(nodeInitializedTo.callee.name)

--- a/tests/lib/rules/no-array-prototype-extensions.js
+++ b/tests/lib/rules/no-array-prototype-extensions.js
@@ -51,6 +51,8 @@ ruleTester.run('no-array-prototype-extensions', rule, {
     'Promise.reject("some reason");',
     'reject();',
     'this.reject();',
+    'const resolvers = Promise.withResolvers(); resolvers.reject();',
+    'const resolvers = window.Promise.withResolvers(); resolvers.reject();',
 
     // Promise.any()
     'Promise.any();',


### PR DESCRIPTION
Fixes #2360.

Recognizes values initialized by `Promise.withResolvers()` (including `window.Promise`) so `reject()` is not reported as an Ember Array extension. Includes regression cases for both forms.

Tests:
- `pnpm test:coverage`
- `pnpm lint`