### PR TITLE
template-no-extra-mut-helper-argument: applies to strict mode, and stop recommending (action)

### DIFF
--- a/docs/rules/template-no-extra-mut-helper-argument.md
+++ b/docs/rules/template-no-extra-mut-helper-argument.md
@@ -13,13 +13,13 @@ A common mistake when using the Ember handlebars template `mut(attr)` helper is 
 This rule **forbids** the following:
 
 ```hbs
-{{my-component click=(action (mut isClicked true))}}
+{{my-component click=(fn (mut isClicked true))}}
 ```
 
 This rule **allows** the following:
 
 ```hbs
-{{my-component click=(action (mut isClicked) true)}}
+{{my-component click=(fn (mut isClicked) true)}}
 ```
 
 ## Related Rules

--- a/docs/rules/template-no-extra-mut-helper-argument.md
+++ b/docs/rules/template-no-extra-mut-helper-argument.md
@@ -2,8 +2,6 @@
 
 💼 This rule is enabled in the 📋 `template-lint-migration` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 Disallows passing more than one argument to the `mut` helper.

--- a/lib/rules/template-no-extra-mut-helper-argument.js
+++ b/lib/rules/template-no-extra-mut-helper-argument.js
@@ -22,7 +22,7 @@ module.exports = {
 
   create(context) {
     const ERROR_MESSAGE =
-      'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.';
+      'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.';
 
     return {
       GlimmerSubExpression(node) {

--- a/lib/rules/template-no-extra-mut-helper-argument.js
+++ b/lib/rules/template-no-extra-mut-helper-argument.js
@@ -7,7 +7,7 @@ module.exports = {
       category: 'Possible Errors',
       recommended: false,
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-extra-mut-helper-argument.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     fixable: null,
     schema: [],

--- a/tests/lib/rules/template-no-extra-mut-helper-argument.js
+++ b/tests/lib/rules/template-no-extra-mut-helper-argument.js
@@ -8,20 +8,20 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('template-no-extra-mut-helper-argument', rule, {
   valid: [
-    '<template>{{my-component click=(action (mut isClicked))}}</template>',
-    '<template>{{my-component click=(action (mut isClicked) true)}}</template>',
+    '<template>{{my-component click=(fn (mut isClicked))}}</template>',
+    '<template>{{my-component click=(fn (mut isClicked) true)}}</template>',
     '<template>{{my-component isClickedMutable=(mut isClicked)}}</template>',
-    '<template><button {{action (mut isClicked)}}></button></template>',
-    '<template><button {{action (mut isClicked) true}}></button></template>',
+    '<template><button {{on "click" (fn (mut isClicked))}}></button></template>',
+    '<template><button {{on "click" (fn (mut isClicked) true)}}></button></template>',
   ],
   invalid: [
     {
-      code: '<template>{{my-component click=(action (mut isClicked true))}}</template>',
+      code: '<template>{{my-component click=(fn (mut isClicked true))}}</template>',
       output: null,
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
@@ -31,17 +31,17 @@ ruleTester.run('template-no-extra-mut-helper-argument', rule, {
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
     {
-      code: '<template><button {{action (mut isClicked true)}}></button></template>',
+      code: '<template><button {{on "click" (fn (mut isClicked true))}}></button></template>',
       output: null,
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
@@ -53,7 +53,7 @@ ruleTester.run('template-no-extra-mut-helper-argument', rule, {
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
@@ -70,20 +70,20 @@ const hbsRuleTester = new RuleTester({
 
 hbsRuleTester.run('template-no-extra-mut-helper-argument', rule, {
   valid: [
-    '{{my-component click=(action (mut isClicked))}}',
-    '{{my-component click=(action (mut isClicked) true)}}',
+    '{{my-component click=(fn (mut isClicked))}}',
+    '{{my-component click=(fn (mut isClicked) true)}}',
     '{{my-component isClickedMutable=(mut isClicked)}}',
-    '<button {{action (mut isClicked)}}></button>',
-    '<button {{action (mut isClicked) true}}></button>',
+    '<button {{on "click" (fn (mut isClicked))}}></button>',
+    '<button {{on "click" (fn (mut isClicked) true)}}></button>',
   ],
   invalid: [
     {
-      code: '{{my-component click=(action (mut isClicked true))}}',
+      code: '{{my-component click=(fn (mut isClicked true))}}',
       output: null,
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
@@ -93,17 +93,17 @@ hbsRuleTester.run('template-no-extra-mut-helper-argument', rule, {
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },
     {
-      code: '<button {{action (mut isClicked true)}}></button>',
+      code: '<button {{on "click" (fn (mut isClicked true))}}></button>',
       output: null,
       errors: [
         {
           message:
-            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(fn (mut attr) value)`.',
         },
       ],
     },

--- a/tests/lib/rules/template-no-extra-mut-helper-argument.js
+++ b/tests/lib/rules/template-no-extra-mut-helper-argument.js
@@ -45,6 +45,18 @@ ruleTester.run('template-no-extra-mut-helper-argument', rule, {
         },
       ],
     },
+    // `mut` is an ambient strict-mode keyword, so this reports in gjs/gts as well
+    {
+      filename: 'test.gjs',
+      code: '<template>{{yield (mut @a @b)}}</template>',
+      output: null,
+      errors: [
+        {
+          message:
+            'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.',
+        },
+      ],
+    },
   ],
 });
 


### PR DESCRIPTION
`templateMode: 'loose'` is wrong on this rule. `mut` is an ambient Glimmer keyword, so `(mut a b)` needs no import and is reachable in a gjs/gts template. The rule has no strict-mode guard and reports there today.

Verified by linting a `.gjs` file with only this rule on:

```gjs
const Foo = <template>{{yield (mut @a @b)}}</template>;
```
```
ember/template-no-extra-mut-helper-argument
```

Changes `templateMode` to `both`, which drops the "HBS Only" note from the docs, and adds a gjs test case so the behavior is pinned.

Found while implementing RFC #1217 in #2840: the RFC puts this rule in Appendix A (applies to strict mode) while the code claimed hbs-only. The RFC is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also: the message pointed at removed API

The report told people to write `(action (mut attr) value)`, and `{{action}}` is gone from ember-source. It now points at `(fn (mut attr) value)`. The docs examples and test fixtures move to `fn` and `{{on "click" ...}}` for the same reason.
