### PR TITLE
template-no-unnecessary-component-helper is not hbs-only

### DIFF
--- a/docs/rules/template-no-unnecessary-component-helper.md
+++ b/docs/rules/template-no-unnecessary-component-helper.md
@@ -4,8 +4,6 @@
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 The `component` template helper can be used to dynamically pick the component being rendered based on the provided property. But if the component name is passed as a string because it's already known, then the component should be invoked directly, instead of using the `component` helper.

--- a/lib/rules/template-no-unnecessary-component-helper.js
+++ b/lib/rules/template-no-unnecessary-component-helper.js
@@ -53,7 +53,7 @@ module.exports = {
       description: 'disallow unnecessary component helper',
       category: 'Best Practices',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-unnecessary-component-helper.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     fixable: 'code',
     schema: [],


### PR DESCRIPTION
`templateMode: 'loose'` contradicts the rule's own implementation. It has a strict-mode branch (`isStrictMode`) that picks the `noUnnecessaryComponentKebab` message and skips the autofix when the component name is not a valid JS identifier, and the test file already asserts reports for `test.gjs` and `test.gts`.

Verified by linting a `.gjs` file with only this rule on:

```gjs
<template>{{component "myComponent" foo=123}}</template>
```
```
ember/template-no-unnecessary-component-helper
```

Changes `templateMode` to `both`, which drops the "HBS Only" note. No behavior change; the note was just wrong.

Found while implementing RFC #1217 in #2840, which puts this rule in Appendix A. The RFC is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)