### PR TITLE
template-no-class-bindings applies to strict mode

### DIFF
--- a/docs/rules/template-no-class-bindings.md
+++ b/docs/rules/template-no-class-bindings.md
@@ -2,8 +2,6 @@
 
 💼 This rule is enabled in the 📋 `template-lint-migration` [config](https://github.com/ember-cli/eslint-plugin-ember#-configurations).
 
-> **HBS Only**: This rule applies to classic `.hbs` template files only (loose mode). It is not relevant for `gjs`/`gts` files (strict mode), where these patterns cannot occur.
-
 <!-- end auto-generated rule header -->
 
 Disallow passing `classBinding` or `classNameBindings` as arguments within templates. These are legacy Ember Classic patterns that should be replaced with modern approaches.

--- a/lib/rules/template-no-class-bindings.js
+++ b/lib/rules/template-no-class-bindings.js
@@ -6,7 +6,7 @@ module.exports = {
       description: 'disallow passing classBinding or classNameBindings as arguments in templates',
       category: 'Best Practices',
       url: 'https://github.com/ember-cli/eslint-plugin-ember/tree/master/docs/rules/template-no-class-bindings.md',
-      templateMode: 'loose',
+      templateMode: 'both',
     },
     fixable: null,
     schema: [],
@@ -23,11 +23,6 @@ module.exports = {
   },
 
   create(context) {
-    const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');
-    if (isStrictMode) {
-      return {};
-    }
-
     const FORBIDDEN_ATTR_NAMES = new Set([
       'classBinding',
       '@classBinding',

--- a/tests/lib/rules/template-no-class-bindings.js
+++ b/tests/lib/rules/template-no-class-bindings.js
@@ -13,15 +13,6 @@ ruleTester.run('template-no-class-bindings', rule, {
     '<template>{{true}}</template>',
     '<template>{{"hehe"}}</template>',
     '<template><div class="foo"></div></template>',
-    // Rule is HBS-only: @classBinding in GJS/GTS may be a legitimate component argument
-    {
-      filename: 'test.gjs',
-      code: '<template><SomeThing @classBinding="lol:wat" /></template>',
-    },
-    {
-      filename: 'test.gts',
-      code: '<template>{{some-thing classNameBindings="lol:foo:bar"}}</template>',
-    },
   ],
   invalid: [
     {
@@ -55,6 +46,30 @@ ruleTester.run('template-no-class-bindings', rule, {
       ],
     },
     {
+      code: '<template><SomeThing @classNameBindings="lol:foo:bar" /></template>',
+      output: null,
+      errors: [
+        {
+          messageId: 'noClassBindings',
+          data: { name: '@classNameBindings' },
+        },
+      ],
+    },
+    // `@ember/component` is still supported, so a classic component invoked from
+    // a strict-mode template still acts on these arguments.
+    {
+      filename: 'test.gjs',
+      code: '<template><SomeThing @classBinding="lol:wat" /></template>',
+      output: null,
+      errors: [
+        {
+          messageId: 'noClassBindings',
+          data: { name: '@classBinding' },
+        },
+      ],
+    },
+    {
+      filename: 'test.gts',
       code: '<template><SomeThing @classNameBindings="lol:foo:bar" /></template>',
       output: null,
       errors: [


### PR DESCRIPTION
Replaces #2843, which had this backwards.

The rule bailed out on gjs/gts:

```js
const isStrictMode = context.filename.endsWith('.gjs') || context.filename.endsWith('.gts');
if (isStrictMode) {
  return {};
}
```

`@ember/component` is still supported, so `<SomeThing @classNameBindings="a:b" />` in a gjs template still hits the classic path and still deserves the report. The guard and the hbs-only marker are both wrong.

After this, linting a `.gjs` and a `.gts` file both report:

```gjs
import Legacy from './legacy';
<template><Legacy @classNameBindings="a:b" /></template>
```
```
ember/template-no-class-bindings line 2
```

Two test cases move from valid to invalid, and `templateMode` becomes `both`, which drops the "HBS Only" doc note.

Worth knowing: a Glimmer component that happens to name an argument `@classBinding` now gets reported. That naming is unlikely and would be misleading anyway, but it is the one new false-positive surface.

This makes RFC #1217's Appendix A placement correct, so #2840 needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)